### PR TITLE
Update Group Detail Mobile Breadcrumbs

### DIFF
--- a/app/components/breadcrumbs/index.tsx
+++ b/app/components/breadcrumbs/index.tsx
@@ -3,13 +3,9 @@ import Icon from "~/primitives/icon";
 
 interface BreadcrumbsProps {
   mode?: "light" | "dark";
-  hideHome?: boolean;
 }
 
-export default function Breadcrumbs({
-  mode = "dark",
-  hideHome = false,
-}: BreadcrumbsProps) {
+export default function Breadcrumbs({ mode = "dark" }: BreadcrumbsProps) {
   const location = useLocation();
   const pathSegments = location.pathname.split("/").filter(Boolean);
 
@@ -25,9 +21,7 @@ export default function Breadcrumbs({
     return (
       <div key={path} className={`flex items-center gap-4 ${textColor}`}>
         <Icon
-          className={`text-ocean min-w-[20px] ${
-            hideHome && index === 0 ? "hidden sm:block" : "block"
-          }`}
+          className="text-ocean min-w-[20px] block"
           size={20}
           name="caretRight"
         />
@@ -42,7 +36,7 @@ export default function Breadcrumbs({
 
   return (
     <div className={`flex items-center gap-4 ${textColor}`}>
-      <Link className={hideHome ? "hidden sm:block" : "block"} to="/">
+      <Link to="/">
         <span className="hover:underline text-sm">Home</span>
       </Link>
       {breadcrumbs}

--- a/app/routes/articles/article-single/partials/hero.partial.tsx
+++ b/app/routes/articles/article-single/partials/hero.partial.tsx
@@ -79,7 +79,7 @@ export const ArticleHero: React.FC<LoaderReturnType> = ({
         <div className="hidden md:block max-w-screen-content mx-auto">
           <hr className="border-neutral-lighter" />
           <div className="flex flex-col md:flex-row justify-between items-center py-10">
-            <Breadcrumbs mode="light" />
+            <Breadcrumbs mode="dark" />
             <IconButton
               className="hover:!text-ocean"
               to="/messages/series"

--- a/app/routes/group-finder/finder/components/hit-component.component.tsx
+++ b/app/routes/group-finder/finder/components/hit-component.component.tsx
@@ -3,6 +3,9 @@ import { GroupHit } from "../../types";
 import { useState } from "react";
 import { Button } from "~/primitives/button/button.primitive";
 
+export const defaultLeaderPhoto =
+  "https://cloudfront.christfellowship.church/GetAvatar.ashx?PhotoId=&AgeClassification=Adult&Gender=Unknown&RecordTypeId=1&Text=JC&Size=180&Style=icon&BackgroundColor=E4E4E7&ForegroundColor=A1A1AA";
+
 export function HitComponent({ hit }: { hit: GroupHit }) {
   const [isExpanded, setIsExpanded] = useState(false);
   const coverImage = hit.coverImage?.sources?.[0]?.uri || "";
@@ -32,7 +35,7 @@ export function HitComponent({ hit }: { hit: GroupHit }) {
                   boxShadow:
                     "0px 5.114px 10.228px -2.557px rgba(0, 0, 0, 0.10), 0px 2.557px 5.114px -2.557px rgba(0, 0, 0, 0.06)",
                 }}
-                src={leader.photo.uri}
+                src={leader.photo.uri || defaultLeaderPhoto}
                 key={i}
                 alt={leader.firstName}
               />

--- a/app/routes/group-finder/group-single/components/sidebar.component.tsx
+++ b/app/routes/group-finder/group-single/components/sidebar.component.tsx
@@ -2,6 +2,7 @@ import Icon from "~/primitives/icon";
 import { Button } from "~/primitives/button/button.primitive";
 import type { LoaderReturnType } from "../loader";
 import { icons } from "~/lib/icons";
+import { defaultLeaderPhoto } from "../../finder/components/hit-component.component";
 
 const Divider = () => (
   <div className="w-full h-[1px] bg-[#6E6E6E] opacity-10" role="separator" />
@@ -40,7 +41,7 @@ const LeaderGallery = ({ leaders }: LeaderGalleryProps) => (
       {leaders?.map((leader, i) => (
         <img
           key={leader.firstName}
-          src={leader.photo.uri}
+          src={leader.photo.uri || defaultLeaderPhoto}
           alt={`Group leader ${leader.firstName} ${leader.lastName}`}
           className="w-24 h-24 rounded-xl object-cover"
           loading="lazy"
@@ -48,7 +49,7 @@ const LeaderGallery = ({ leaders }: LeaderGalleryProps) => (
       ))}
     </div>
     <h2 className="text-sm font-semibold text-[#666666]">Hosted by</h2>
-    <div className="font-bold">
+    <div className="lg:text-lg font-bold">
       {leaders
         ?.map((leader) => `${leader.firstName} ${leader.lastName}`)
         .join(" & ")}
@@ -143,7 +144,7 @@ export function GroupSingleSidebar({
             icon="calendarAlt"
             style={{ display: `${meetingDay ? "flex" : "none"}` }}
           >
-            <span className="text-lg font-semibold">{meetingDay}</span>
+            <span className="lg:text-lg font-semibold">{meetingDay}</span>
           </InfoItem>
 
           <Divider />
@@ -151,7 +152,7 @@ export function GroupSingleSidebar({
             icon="alarm"
             style={{ display: `${meetingTime ? "flex" : "none"}` }}
           >
-            <span className="text-lg font-semibold">
+            <span className="lg:text-lg font-semibold">
               {formattedMeetingTime}
             </span>
           </InfoItem>
@@ -159,7 +160,7 @@ export function GroupSingleSidebar({
           <Divider />
           <InfoItem icon="map">
             <span className="text-sm text-[#666666]">{meetingType}</span>
-            <span className="text-lg font-semibold">{campusName}</span>
+            <span className="lg:text-lg font-semibold">{campusName}</span>
           </InfoItem>
         </div>
       </div>

--- a/app/routes/group-finder/group-single/group-single-page.tsx
+++ b/app/routes/group-finder/group-single/group-single-page.tsx
@@ -49,14 +49,19 @@ export const GroupSingleContent = ({ hit }: { hit: GroupHit }) => {
       <GroupsSingleHero imagePath={coverImage} />
       <div className="content-padding w-full flex flex-col items-center">
         <div className="flex flex-col gap-12 pt-10 lg:pt-16 w-full max-w-screen-content">
-          <div className="flex gap-6 lg:gap-10 items-center">
+          <div className="flex gap-6 items-center">
             <Link
-              className="cursor-pointer text-text-secondary hover:text-ocean"
+              className="cursor-pointer text-text-secondary hover:text-ocean flex items-center gap-2"
               to="/group-finder"
             >
               <Icon name="arrowBack" className="size-6" />
+              <span className="hover:underline text-sm line-clamp-2 md:hidden">
+                Back to Finder
+              </span>
             </Link>
-            <Breadcrumbs hideHome />
+            <div className="hidden md:block">
+              <Breadcrumbs />
+            </div>
           </div>
           <div className="w-full flex flex-col items-center lg:flex-row lg:items-start lg:gap-20">
             <GroupSingleBasicContent

--- a/app/routes/group-finder/group-single/loader.tsx
+++ b/app/routes/group-finder/group-single/loader.tsx
@@ -5,16 +5,6 @@ export type LoaderReturnType = {
   ALGOLIA_APP_ID: string;
   ALGOLIA_SEARCH_API_KEY: string;
   groupName: string;
-  coverImage: string;
-  tags: string[];
-  leaders: Array<{
-    id: string;
-    firstName: string;
-    lastName: string;
-    photo: {
-      uri: string;
-    };
-  }>;
 };
 
 export async function loader({ params }: LoaderFunctionArgs) {


### PR DESCRIPTION
## Summary
This PR cleans up the breadcrumbs displayed on mobile for Group Details page and removes unnecessary logic for Breadcrumbs component.

## Screenshots
<img width="530" alt="image" src="https://github.com/user-attachments/assets/32fb0249-3bc4-40ce-ba43-49116f2409f2" />

## Testing
- Check Group Details page in mobile and make sure the breadcrumbs working as expected
- Check anywhere else the breadcrumb component is being used.

## Tickets
[CFDP-3372](https://christfellowshipchurch.atlassian.net/browse/CFDP-3372)

[CFDP-3372]: https://christfellowshipchurch.atlassian.net/browse/CFDP-3372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ