### PR TITLE
Link Tree Pages

### DIFF
--- a/app/components/navbar/navbar-routes.ts
+++ b/app/components/navbar/navbar-routes.ts
@@ -15,6 +15,7 @@ export const darkModeRoutes: RoutePattern[] = [
   { path: "/messages/", isDynamic: true }, // This will match /messages/[slug]
   { path: "/articles" },
   { path: "/podcasts" },
+  { path: "/link-tree", isDynamic: true }, // This will match /link-tree/[slug]
   // Add more routes as needed
 ];
 

--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -218,3 +218,20 @@ export const getFirstParagraph = (html: string): string => {
   const firstParagraph = doc.querySelector("p");
   return firstParagraph?.textContent || "";
 };
+
+interface CallToAction {
+  title: string;
+  url: string;
+}
+
+export const parseRockKeyValueList = (input: string): CallToAction[] => {
+  if (!input) return [];
+
+  return input.split("|").map((item) => {
+    const [title, url] = item.split("^#");
+    return {
+      title: title.trim(),
+      url: url.trim(),
+    };
+  });
+};

--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -219,12 +219,12 @@ export const getFirstParagraph = (html: string): string => {
   return firstParagraph?.textContent || "";
 };
 
-interface CallToAction {
+export const parseRockKeyValueList = (
+  input: string
+): {
   title: string;
   url: string;
-}
-
-export const parseRockKeyValueList = (input: string): CallToAction[] => {
+}[] => {
   if (!input) return [];
 
   return input.split("|").map((item) => {

--- a/app/routes/link-tree/loader.ts
+++ b/app/routes/link-tree/loader.ts
@@ -20,7 +20,6 @@ const fetchLinkTreePage = async (pathname: string) => {
 const fetchCardCollections = async (id: string) => {
   const collections = await fetchRockData({
     endpoint: `ContentChannelItems/GetChildren/${id}`,
-    cache: false,
   });
 
   if (!collections || !Array.isArray(collections) || collections.length === 0) {
@@ -83,7 +82,7 @@ export const loader = async ({
 
   const primaryCallToAction = parseRockKeyValueList(calltoActionKeyValues)[0]; // only returning the first call to action
 
-  const cardCollections = await fetchCardCollections(id);
+  // const cardCollections = await fetchCardCollections(id);
 
   return {
     id,
@@ -92,6 +91,6 @@ export const loader = async ({
     summary,
     additionalResources,
     primaryCallToAction,
-    cardCollections,
+    cardCollections: [],
   };
 };

--- a/app/routes/link-tree/loader.ts
+++ b/app/routes/link-tree/loader.ts
@@ -1,0 +1,97 @@
+import { LoaderFunctionArgs } from "react-router";
+import { fetchRockData } from "~/lib/.server/fetch-rock-data";
+import { parseRockKeyValueList } from "~/lib/utils";
+import { LinkTreeLoaderData, RockLinkTreeData } from "./types";
+
+const fetchLinkTreePage = async (pathname: string) => {
+  const linkTreePage = await fetchRockData({
+    endpoint: "ContentChannelItems/GetByAttributeValue",
+    queryParams: {
+      attributeKey: "Pathname",
+      $filter: "ContentChannelId eq 166 and Status eq 'Approved'",
+      value: pathname,
+      loadAttributes: "simple",
+    },
+  });
+
+  return linkTreePage;
+};
+
+const fetchCardCollections = async (id: string) => {
+  const collections = await fetchRockData({
+    endpoint: `ContentChannelItems/GetChildren/${id}`,
+    cache: false,
+  });
+
+  if (!collections || !Array.isArray(collections) || collections.length === 0) {
+    console.log("No valid collections data found");
+    return [];
+  }
+
+  const cardCollections = await Promise.all(
+    collections.map(async (collection: any) => {
+      const items = await fetchRockData({
+        endpoint: `ContentChannelItems/GetChildren/${collection.Id}`,
+        cache: false,
+      });
+
+      return {
+        title: collection.Title || collection.title || "Untitled",
+        collectionType: collection.ContentChannelType?.Name || "Unknown",
+        items:
+          items?.map((item: any) => ({
+            title: item.Title || item.title || "Untitled",
+            url: item.attributeValues?.url?.value || "",
+            description: item.attributeValues?.description?.value,
+            imageUrl: item.attributeValues?.image?.value,
+          })) || [],
+      };
+    })
+  );
+
+  return cardCollections;
+};
+
+export const loader = async ({
+  request,
+}: LoaderFunctionArgs): Promise<LinkTreeLoaderData | []> => {
+  const pathname = request.url.split("/").pop();
+  if (!pathname) {
+    return [];
+  }
+
+  const linkTreePage = await fetchLinkTreePage(pathname);
+
+  if (!linkTreePage) {
+    return [];
+  }
+
+  const {
+    id,
+    title,
+    content,
+    attributeValues: {
+      summary: { value: summary },
+      additionalResources: { value: additionalResourcesKeyValues },
+      calltoAction: { value: calltoActionKeyValues },
+    },
+  } = linkTreePage as RockLinkTreeData;
+
+  const additionalResources = parseRockKeyValueList(
+    additionalResourcesKeyValues
+  );
+
+  const primaryCallToAction = parseRockKeyValueList(calltoActionKeyValues)[0]; // only returning the first call to action
+
+  const cardCollections = await fetchCardCollections(id);
+
+  return {
+    id,
+    title,
+    content,
+    summary,
+    additionalResources,
+    primaryCallToAction,
+    cardCollections,
+  };
+};

--- a/app/routes/link-tree/loader.ts
+++ b/app/routes/link-tree/loader.ts
@@ -82,6 +82,7 @@ export const loader = async ({
 
   const primaryCallToAction = parseRockKeyValueList(calltoActionKeyValues)[0]; // only returning the first call to action
 
+  // todo: Fix card collections for link tree(getChildren not working)
   // const cardCollections = await fetchCardCollections(id);
 
   return {

--- a/app/routes/link-tree/loader.ts
+++ b/app/routes/link-tree/loader.ts
@@ -14,6 +14,13 @@ const fetchLinkTreePage = async (pathname: string) => {
     },
   });
 
+  if (!linkTreePage || linkTreePage.length === 0) {
+    throw new Response("Link tree page not found at: /link-tree/" + pathname, {
+      status: 404,
+      statusText: "Not Found",
+    });
+  }
+
   return linkTreePage;
 };
 

--- a/app/routes/link-tree/page.tsx
+++ b/app/routes/link-tree/page.tsx
@@ -1,0 +1,60 @@
+import { useLoaderData } from "react-router-dom";
+import { LinkTreeLoaderData } from "./types";
+import { HTMLRenderer } from "~/primitives/html-renderer/html-renderer.component";
+import { cn } from "~/lib/utils";
+import { Button } from "~/primitives/button/button.primitive";
+
+export function ResourcePage() {
+  const {
+    title,
+    content,
+    summary,
+    additionalResources,
+    primaryCallToAction,
+    cardCollections,
+  } = useLoaderData<LinkTreeLoaderData>();
+
+  return (
+    <div className=" bg-navy py-30 content-padding text-white text-center">
+      <h1 className="heading-h1 my-16 ">{title}</h1>
+
+      <div
+        className={cn(
+          "flex",
+          "flex-col",
+          "gap-6",
+          "justify-center",
+          "items-center",
+          "max-w-[560px]",
+          "w-full",
+          "mx-auto",
+          "font-light"
+        )}
+      >
+        <h2 className="heading-h5 font-bold">{summary}</h2>
+        <HTMLRenderer html={content} />
+        <Button
+          href={primaryCallToAction?.url}
+          linkClassName="mt-10 w-full"
+          className="w-full"
+        >
+          {primaryCallToAction?.title}
+        </Button>
+        <h2 className="heading-h5 font-bold mt-4">Helpful Links</h2>
+        <div className="flex flex-col gap-4 w-full">
+          {additionalResources.map((resource) => (
+            <Button
+              href={resource.url}
+              linkClassName="w-full"
+              className="w-full"
+            >
+              {resource.title}
+            </Button>
+          ))}
+        </div>
+
+        {/* todo: build out card collections */}
+      </div>
+    </div>
+  );
+}

--- a/app/routes/link-tree/page.tsx
+++ b/app/routes/link-tree/page.tsx
@@ -4,14 +4,20 @@ import { HTMLRenderer } from "~/primitives/html-renderer/html-renderer.component
 import { cn } from "~/lib/utils";
 import { Button } from "~/primitives/button/button.primitive";
 
-export function ResourcePage() {
+const linkTreeButtonClass = cn(
+  "w-full",
+  "hover:enabled:bg-white",
+  "hover:enabled:text-navy"
+);
+
+export function LinkTreePage() {
   const {
     title,
     content,
     summary,
     additionalResources,
     primaryCallToAction,
-    cardCollections,
+    // cardCollections,
   } = useLoaderData<LinkTreeLoaderData>();
 
   return (
@@ -36,7 +42,7 @@ export function ResourcePage() {
         <Button
           href={primaryCallToAction?.url}
           linkClassName="mt-10 w-full"
-          className="w-full"
+          className={linkTreeButtonClass}
         >
           {primaryCallToAction?.title}
         </Button>
@@ -46,7 +52,7 @@ export function ResourcePage() {
             <Button
               href={resource.url}
               linkClassName="w-full"
-              className="w-full"
+              className={linkTreeButtonClass}
             >
               {resource.title}
             </Button>

--- a/app/routes/link-tree/route.tsx
+++ b/app/routes/link-tree/route.tsx
@@ -1,3 +1,0 @@
-export default function ResourcePage() {
-  return <div>Resource Page</div>;
-}

--- a/app/routes/link-tree/route.tsx
+++ b/app/routes/link-tree/route.tsx
@@ -1,0 +1,3 @@
+export default function ResourcePage() {
+  return <div>Resource Page</div>;
+}

--- a/app/routes/link-tree/types.ts
+++ b/app/routes/link-tree/types.ts
@@ -1,0 +1,29 @@
+export type RockLinkTreeData = {
+  id: string;
+  title: string;
+  content: string;
+  attributeValues: {
+    summary: { value: string };
+    additionalResources: { value: string };
+    calltoAction: { value: string };
+  };
+};
+
+export type LinkTreeLoaderData = {
+  id: string;
+  title: string;
+  content: string;
+  summary: string;
+  additionalResources: Array<{ title: string; url: string }>;
+  primaryCallToAction: { title: string; url: string } | undefined;
+  cardCollections: Array<{
+    title: string;
+    collectionType: string;
+    items: Array<{
+      title: string;
+      url: string;
+      description?: string;
+      imageUrl?: string;
+    }>;
+  }>;
+};

--- a/app/routes/link-tree_.$path.tsx
+++ b/app/routes/link-tree_.$path.tsx
@@ -1,3 +1,5 @@
-import { loader } from "./link-tree/loader";
+import { ResourcePage } from "./link-tree/page";
 
-export { loader };
+export { loader } from "./link-tree/loader";
+
+export default ResourcePage;

--- a/app/routes/link-tree_.$path.tsx
+++ b/app/routes/link-tree_.$path.tsx
@@ -1,0 +1,3 @@
+import { loader } from "./link-tree/loader";
+
+export { loader };

--- a/app/routes/link-tree_.$path.tsx
+++ b/app/routes/link-tree_.$path.tsx
@@ -1,5 +1,5 @@
-import { ResourcePage } from "./link-tree/page";
+import { LinkTreePage } from "./link-tree/page";
 
 export { loader } from "./link-tree/loader";
 
-export default ResourcePage;
+export default LinkTreePage;

--- a/app/routes/navbar/route.tsx
+++ b/app/routes/navbar/route.tsx
@@ -3,7 +3,7 @@ import { fetchRockData } from "~/lib/.server/fetch-rock-data";
 import type { FeatureCard } from "~/components/navbar/types";
 import { createImageUrlFromGuid } from "~/lib/utils";
 import { getUserFromRequest } from "~/lib/.server/authentication/get-user-from-request";
-
+import { Button } from "~/primitives/button/button.primitive";
 const fetchFeatureCards = async () => {
   try {
     const navCardDefinedValues = await fetchRockData({
@@ -84,7 +84,15 @@ export async function loader({ request }: LoaderFunctionArgs) {
   }
 }
 
-// This is a resource route - no UI needed
+// This is a resource route - so we'll throw a 404 if user navigates here
 export default function NavbarRoute() {
-  return null;
+  return (
+    <div className="p-6 mt-20 flex flex-col items-center justify-center gap-6">
+      <h1 className="text-4xl font-bold">⚠ 404 - Page Not Found</h1>
+      <p className="text-lg italic">
+        This page is not available. Please check the URL and try again.
+      </p>
+      <Button href="/">Go to Home</Button>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
This PR introduces the new Link Tree Pages. It connects to the new [Rock Content Channel](https://rock.christfellowship.church/admin/cms/content-channels/166). 

NOTE: Card Collections are currently NOT working, and am working with Rock team to see why we can't fetch Children. We also will create a new content channel called Resource Collections that the Link Tree Page items will take as children.

## Screenshots
![image](https://github.com/user-attachments/assets/cb4b31b8-a8aa-4369-a505-6f0096370082)

## Testing
- test any of the existing Link Tree pages from Rock(Eg. `/link-tree/kids-resources`)

## Tickets
[CFDP-3446](https://christfellowshipchurch.atlassian.net/browse/CFDP-3446)

[CFDP-3446]: https://christfellowshipchurch.atlassian.net/browse/CFDP-3446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ