### PR TITLE
Updated Leader Components Backend - Home/About

### DIFF
--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -1,5 +1,4 @@
-import type { LoaderFunction, MetaFunction } from "react-router";
-import { getUserFromRequest } from "~/lib/.server/authentication/get-user-from-request";
+import type { MetaFunction } from "react-router";
 import { HistorySection } from "./about/partials/history.partial";
 import { BeliefsSection } from "./about/partials/beliefs.partial";
 import { LeadershipSection } from "./about/partials/leadership.partial";
@@ -12,23 +11,13 @@ import {
   MobileHeroSection,
   BottomBar,
 } from "./home/partials/hero.partial";
+export { loader } from "./about/loader"; // Using the about loader for the home page to grab author data for the leaders grid and scroll components
 
 export const meta: MetaFunction = () => {
   return [
     { title: "Christ Fellowship Web App v3" },
     { name: "description", content: "Welcome to the CFDP!" },
   ];
-};
-
-/** Example of how to return current user via sever-side */
-export const loader: LoaderFunction = async ({ request }) => {
-  const userData = await getUserFromRequest(request);
-
-  if (!userData) {
-    return null; // here you can redirect to a login page etc.
-  }
-
-  return userData;
 };
 
 export default function Index() {

--- a/app/routes/about/components/leaders-data.ts
+++ b/app/routes/about/components/leaders-data.ts
@@ -1,33 +1,34 @@
-interface Leader {
+export interface Leader {
   name: string;
   role: string;
-  id: string;
+  pathname: string;
   imagePath: string;
 }
 
+// Local data for the LeadersGrid and LeaderScroll components
 export const leaders: Leader[] = [
   {
     name: "Todd & Julie",
     role: "Senior Pastors",
-    id: "496067",
+    pathname: "todd-julie-mullins",
     imagePath: "/assets/images/about/leaders/todd-julie.webp",
   },
   {
     name: "Tom Mullins",
     role: "Founding Pastor",
-    id: "224061",
+    pathname: "tom-mullins",
     imagePath: "/assets/images/about/leaders/tom-mullins.webp",
   },
   {
     name: "Ryan McDermott",
     role: "Executive Pastor",
-    id: "85081",
+    pathname: "ryan-mcdermott",
     imagePath: "/assets/images/about/leaders/ryan-mcdermott.webp",
   },
   {
     name: "John Maxwell",
     role: "Leadership Pastor",
-    id: "76186",
+    pathname: "john-maxwell",
     imagePath: "/assets/images/about/leaders/john-maxwell.webp",
   },
 ];

--- a/app/routes/about/components/leaders-grid.component.tsx
+++ b/app/routes/about/components/leaders-grid.component.tsx
@@ -1,48 +1,54 @@
-import { Icon } from "~/primitives/icon/icon";
-import { leaders } from "./leaders-data";
+import { useLoaderData } from "react-router";
+import { useState } from "react";
 import { cn } from "~/lib/utils";
-import Modal from "~/primitives/Modal";
-import { useEffect, useState } from "react";
-import { LeadersModal } from "~/components/modals/leaders";
+
+import { Leader, leaders } from "./leaders-data";
 import { Author } from "~/routes/author/loader";
-import { useFetcher } from "react-router";
+import { loader } from "~/routes/about/loader";
+import { LeadersModal } from "~/components/modals/leaders";
+
+import { Icon } from "~/primitives/icon/icon";
+import Modal from "~/primitives/Modal";
+
+export type LeaderModalItem = {
+  authorData: Author; // Rock API author data
+  leaderData: Leader; // Local leader data
+};
 
 export function LeaderGrid() {
+  const { authors } = useLoaderData<typeof loader>();
+
+  const leaderModalItems: LeaderModalItem[] = authors.map((author) => ({
+    authorData: author,
+    leaderData: leaders.find(
+      (leader) => leader.pathname === author.authorAttributes.pathname
+    ) as Leader,
+  }));
+
   return (
     <div className="flex items-start lg:items-end gap-3">
-      {leaders.map((leader, index) => (
-        <LeaderCard key={index} index={index} leader={leader} />
+      {leaderModalItems.map((leaderModalItem, index) => (
+        <LeaderCard key={index} index={index} leader={leaderModalItem} />
       ))}
     </div>
   );
 }
 
-const LeaderCard = ({ leader, index }: { leader: any; index: number }) => {
+const LeaderCard = ({
+  leader,
+  index,
+}: {
+  leader: LeaderModalItem;
+  index: number;
+}) => {
   const [openModal, setOpenModal] = useState(false);
-  const [author, setAuthor] = useState<Author | null>(null);
-  const fetcher = useFetcher();
-  const formData = new FormData();
-  formData.append("id", leader.id);
-
-  useEffect(() => {
-    try {
-      fetcher.submit(formData, {
-        method: "post",
-        action: "/home",
-      });
-    } catch (error) {
-      console.log("Fetching error: ", error);
-    }
-  }, []);
-
-  useEffect(() => {
-    if (fetcher.data) {
-      setAuthor(fetcher.data as Author);
-    }
-  }, [fetcher.data]);
 
   return (
-    <Modal open={openModal} onOpenChange={setOpenModal} key={leader.name}>
+    <Modal
+      open={openModal}
+      onOpenChange={setOpenModal}
+      key={leader.authorData.authorAttributes.pathname}
+    >
       <Modal.Button
         className={cn(
           "group w-full",
@@ -56,15 +62,15 @@ const LeaderCard = ({ leader, index }: { leader: any; index: number }) => {
         <div className="relative mb-6">
           <div className="relative overflow-hidden rounded-[8px]">
             <img
-              src={leader.imagePath}
-              alt={leader.name}
+              src={leader.leaderData.imagePath}
+              alt={leader.leaderData.name}
               className={cn(
                 "w-full aspect-[32/46] object-cover",
                 "transform transition-transform duration-300 group-hover:scale-105"
               )}
             />
             <div className="absolute size-[212px]">
-              {/* TOOD: Update logo to be the correct size */}
+              {/* TODO: Update logo to be the correct size */}
               <Icon
                 name="cfLogo"
                 className="opacity-75 absolute bototm-0 -left-16 object-contain size-full text-ocean group-hover:text-white transform transition-all duration-300 group-hover:-translate-y-36"
@@ -73,7 +79,7 @@ const LeaderCard = ({ leader, index }: { leader: any; index: number }) => {
           </div>
           <div
             className="absolute right-2 -bottom-4 w-10 h-10 bg-white group-hover:bg-ocean group-hover:text-white rounded-full flex items-center justify-center shadow-lg transition-all duration-300"
-            aria-label={`Learn more about ${leader.name}`}
+            aria-label={`Learn more about ${leader.leaderData.name}`}
           >
             <span className="text-2xl font-light">+</span>
           </div>
@@ -81,15 +87,15 @@ const LeaderCard = ({ leader, index }: { leader: any; index: number }) => {
 
         <div>
           <p className="text-gray-600 uppercase tracking-wider text-sm mb-1 text-start">
-            {leader.role}
+            {leader.leaderData.role}
           </p>
           <h4 className="text-2xl font-bold text-gray-900 text-start">
-            {leader.name}
+            {leader.leaderData.name}
           </h4>
         </div>
       </Modal.Button>
       <Modal.Content background="bg-gray">
-        <LeadersModal author={author} />
+        <LeadersModal author={leader.authorData} />
       </Modal.Content>
     </Modal>
   );

--- a/app/routes/about/loader.ts
+++ b/app/routes/about/loader.ts
@@ -1,0 +1,36 @@
+import { Leader, leaders } from "./components/leaders-data";
+import { fetchRockData } from "~/lib/.server/fetch-rock-data";
+import { Author, getAuthorDetails } from "../author/loader";
+
+const getAuthorIdsByPathname = async (person: Leader): Promise<string> => {
+  try {
+    const authorData = await fetchRockData({
+      endpoint: "People/GetByAttributeValue",
+      queryParams: {
+        attributeKey: "Pathname",
+        value: person.pathname,
+        $select: "Id",
+      },
+    });
+
+    return authorData.id;
+  } catch (error) {
+    console.error("Error fetching author:", error);
+    throw new Error(`Failed to fetch author ID for ${person.pathname}`);
+  }
+};
+
+// Grabs author data for the LeadersGrid and LeaderScroll components
+export const loader = async (): Promise<{ authors: Author[] }> => {
+  const authorIds = await Promise.all(leaders.map(getAuthorIdsByPathname));
+  const authorDetails = await Promise.all(authorIds.map(getAuthorDetails));
+
+  const authors: Author[] = authorDetails.map((data) => ({
+    hostUrl: process.env.HOST_URL || "host-url-not-found",
+    fullName: data.fullName,
+    profilePhoto: data.photo.uri ?? "",
+    authorAttributes: data.authorAttributes,
+  }));
+
+  return { authors };
+};

--- a/app/routes/about/route.tsx
+++ b/app/routes/about/route.tsx
@@ -5,6 +5,9 @@ import { HistorySection } from "./partials/history.partial";
 import { BeliefsSection } from "./partials/beliefs.partial";
 import { LeadershipSection } from "./partials/leadership.partial";
 import { ImpactSection } from "./partials/impact.partial";
+import { loader } from "./loader";
+
+export { loader };
 
 export const meta: MetaFunction = () => {
   return [

--- a/app/routes/author/loader.ts
+++ b/app/routes/author/loader.ts
@@ -19,6 +19,7 @@ export type Author = {
     jobTitle: string;
     socialLinks: SocialMedia[];
     publications: AuthorArticleProps[];
+    pathname: string;
   };
 };
 
@@ -135,6 +136,7 @@ export const getAuthorDetails = async (personId: string) => {
             }
           })
           .filter(Boolean),
+        pathname: authorData?.attributeValues?.pathname?.value || "",
       },
     };
   } catch (error) {


### PR DESCRIPTION
## Summary
We have been running into issues in our codebase with the way we are utilizing `useFetcher()` and need to be using our loader functions more correctly. This PR mainly cleans up the `LeaderGrid` and `LeaderScroll` components by removing the `useFetcher()` method and adding a **loader** function that loads all necessary data for the components from a single source. The same **loader** function is used for both `/home` and `/about`.

## Testing
- Make sure data loads correctly on both Home and About page for the Leader components.