### PR TITLE
Modal Clean Up

### DIFF
--- a/app/components/modals/connect-card/connect-card-flow.component.tsx
+++ b/app/components/modals/connect-card/connect-card-flow.component.tsx
@@ -34,7 +34,7 @@ const ConnectCardFlow = ({
   };
 
   return (
-    <div className="text-center text-text_primary p-8 overflow-auto w-[80vw] max-h-[85vh] md:max-h-[90vh] md:w-[85vw] 2xl:w-[60vw]">
+    <div className="text-center text-text_primary p-6 w-screen max-w-sm md:max-w-xl lg:max-w-3xl overflow-y-scroll max-h-[85vh] md:max-h-[90vh]">
       {renderStep()}
     </div>
   );

--- a/app/components/modals/connect-card/connect-card-flow.component.tsx
+++ b/app/components/modals/connect-card/connect-card-flow.component.tsx
@@ -34,7 +34,7 @@ const ConnectCardFlow = ({
   };
 
   return (
-    <div className="text-center text-text_primary p-6 w-screen max-w-sm md:max-w-xl lg:max-w-3xl overflow-y-scroll max-h-[85vh] md:max-h-[90vh]">
+    <div className="pt-10 text-center text-text_primary p-6 w-[90vw] max-w-sm md:max-w-xl lg:max-w-3xl overflow-y-scroll max-h-[85vh] md:max-h-[90vh]">
       {renderStep()}
     </div>
   );

--- a/app/components/modals/group-filters/group-filters-modal.tsx
+++ b/app/components/modals/group-filters/group-filters-modal.tsx
@@ -31,7 +31,7 @@ export function GroupFiltersModal({
         <ModalButton onClick={() => setOpenModal(true)}>Filters</ModalButton>
       </Modal.Button>
       <Modal.Content>
-        <div className="flex flex-col gap-2 p-8 w-[80vw] max-h-[85vh] md:max-h-[90vh] md:w-[85vw]">
+        <div className="flex flex-col gap-2 sm:p-6 mx-6 max-h-[85vh] md:max-h-[90vh] md:w-[85vw] overflow-y-scroll max-w-md">
           <h2 className="heading-h5 text-navy">Filter Your Results</h2>
           <p className="text-sm text-gray-500 mb-4">
             Adjust the filters to find the groups that best fit your needs.

--- a/app/components/modals/group-filters/group-filters-modal.tsx
+++ b/app/components/modals/group-filters/group-filters-modal.tsx
@@ -3,6 +3,7 @@ import Modal from "~/primitives/Modal";
 import { Button, ButtonProps } from "~/primitives/button/button.primitive";
 import { GroupFilters } from "./group-filters";
 import Icon from "~/primitives/icon";
+import { cn } from "~/lib/utils";
 
 interface GroupFiltersModalProps {
   ModalButton?: React.ComponentType<ButtonProps>;
@@ -31,7 +32,17 @@ export function GroupFiltersModal({
         <ModalButton onClick={() => setOpenModal(true)}>Filters</ModalButton>
       </Modal.Button>
       <Modal.Content>
-        <div className="flex flex-col gap-2 sm:p-6 mx-6 max-h-[85vh] md:max-h-[90vh] md:w-[85vw] overflow-y-scroll max-w-md">
+        <div
+          className={cn(
+            "flex flex-col gap-2",
+            "sm:p-6 mx-6",
+            "max-h-[85vh] md:max-h-[90vh]",
+            "md:w-[85vw]",
+            "overflow-y-scroll",
+            "max-w-md",
+            "pt-10"
+          )}
+        >
           <h2 className="heading-h5 text-navy">Filter Your Results</h2>
           <p className="text-sm text-gray-500 mb-4">
             Adjust the filters to find the groups that best fit your needs.

--- a/app/components/modals/leaders/index.tsx
+++ b/app/components/modals/leaders/index.tsx
@@ -1,5 +1,6 @@
 import * as Avatar from "@radix-ui/react-avatar";
 import { ShareLinks } from "~/components/share-links";
+import { cn } from "~/lib/utils";
 import { CircleLoader } from "~/primitives/loading-states/circle-loader.primitive";
 import { AuthorArticleProps } from "~/routes/author/components/author-content";
 import AuthorTabs from "~/routes/author/components/author-tabs";
@@ -41,7 +42,18 @@ export const LeadersModal = ({ author }: { author: Author | null }) => {
   }
 
   return (
-    <div className="overflow-auto max-w-screen-content max-h-[85vh] md:max-h-[90vh]">
+    <div
+      className={cn(
+        "overflow-auto",
+        "max-w-screen-content",
+        "max-h-[85vh]",
+        "xl:w-6xl",
+        "lg:w-4xl",
+        "md:w-2xl",
+        "sm:w-lg",
+        "w-[350px]"
+      )}
+    >
       <div className="size-full flex flex-col lg:flex-row w-full rounded-xl overflow-hidden">
         {/* Left/Top Side */}
         <div className="w-full lg:w-2/5 p-4 md:p-16 md:pt-8">

--- a/app/components/modals/set-a-reminder/reminder-flow.component.tsx
+++ b/app/components/modals/set-a-reminder/reminder-flow.component.tsx
@@ -42,7 +42,7 @@ const ReminderFlow: React.FC<ReminderFlowProps> = ({ setOpenModal }) => {
   };
 
   return (
-    <div className="text-center text-text_primary p-8 overflow-auto max-w-screen-content max-h-[85vh] md:max-h-[90vh]">
+    <div className="text-center text-text_primary p-6 pb-12 md:pb-16 w-screen max-w-sm md:max-w-xl lg:max-w-3xl overflow-y-scroll max-h-[85vh] md:max-h-[90vh]">
       {renderStep()}
     </div>
   );

--- a/app/components/modals/set-a-reminder/reminder-flow.component.tsx
+++ b/app/components/modals/set-a-reminder/reminder-flow.component.tsx
@@ -42,7 +42,7 @@ const ReminderFlow: React.FC<ReminderFlowProps> = ({ setOpenModal }) => {
   };
 
   return (
-    <div className="text-center text-text_primary p-6 pb-12 md:pb-16 w-screen max-w-sm md:max-w-xl lg:max-w-3xl overflow-y-scroll max-h-[85vh] md:max-h-[90vh]">
+    <div className="pt-10 text-center text-text_primary p-6 w-[90vw] max-w-sm md:max-w-xl lg:max-w-3xl overflow-y-scroll max-h-[85vh] md:max-h-[90vh]">
       {renderStep()}
     </div>
   );

--- a/app/primitives/Modal/modal.primitive.tsx
+++ b/app/primitives/Modal/modal.primitive.tsx
@@ -36,7 +36,7 @@ function ModalContent({
       <Dialog.Overlay className="fixed inset-0 bg-black/50 data-[state=closed]:animate-dialogOverlayHide data-[state=open]:animate-dialogOverlayShow z-499" />
       <Dialog.Content
         className={cn(
-          "fixed sm:h-auto max-h-[90vh] left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 data-[state=closed]:animate-dialogContentHide data-[state=open]:animate-dialogContentShow z-500 w-screen content-padding"
+          "fixed sm:h-auto max-h-[90vh] left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 data-[state=closed]:animate-dialogContentHide data-[state=open]:animate-dialogContentShow z-500 content-padding"
         )}
       >
         <div

--- a/app/primitives/Modal/modal.primitive.tsx
+++ b/app/primitives/Modal/modal.primitive.tsx
@@ -41,7 +41,7 @@ function ModalContent({
       >
         <div
           className={cn(
-            "rounded-xl md:rounded-2xl text-text-primary shadow relative flex justify-center items-center pt-8",
+            "rounded-xl md:rounded-2xl text-text-primary shadow relative flex justify-center items-center",
             background || "bg-white"
           )}
         >


### PR DESCRIPTION
## Summary
This PR updates the modal component layouts across several modal-related components to improve consistency, responsiveness, and visual alignment. The changes primarily adjust padding, width, and overflow handling to ensure modals look and behave better across different screen sizes. 

### 🐛Bug Issue Resolution
The bug we were seeing on mobile for the Connect Card Modal seem to only happen on the Chrome desktop inspect tool when in a phone layout. When testing with an actual phone the modal seems to appear fine with out the background being altered.

## Screenshots
![image](https://github.com/user-attachments/assets/350e8e08-3a88-4995-9199-c47623e3da4a)

## Testing
- Verified modal appearance and behavior on various screen sizes (mobile, tablet, desktop).
- Opened each modal (`ConnectCardFlow`, `GroupFiltersModal`, `LeadersModal`, `ReminderFlow`) to confirm:
  - Proper padding and spacing
  - Correct width and max-width constraints
  - Scroll behavior for content overflow
  - No visual regressions or layout issues
- Checked that the `Modal.Content` primitive renders with the updated styles and that all modals using it inherit the new layout.

## Tickets
[CFDP-3442](https://christfellowshipchurch.atlassian.net/browse/CFDP-3442)

[CFDP-3442]: https://christfellowshipchurch.atlassian.net/browse/CFDP-3442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ