### PR TITLE
Locations Tabs Update

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -48,7 +48,7 @@ export default function App() {
     <GTMProvider gtmId="GTM-PFW26V4V">
       <AuthProvider>
         <CookieConsentProvider>
-          <div className="min-h-screen flex flex-col">
+          <div className="min-h-screen flex flex-col text-pretty">
             <Navbar />
             <main
               className={cn(

--- a/app/routes/locations/location-single/components/tabs-component/about-us/campus-pastors-quote.tsx
+++ b/app/routes/locations/location-single/components/tabs-component/about-us/campus-pastors-quote.tsx
@@ -13,7 +13,7 @@ export const CampusPastorsQuote = ({
   };
 }) => {
   return (
-    <div className="w-full rounded-t-[24px] md:rounded-none bg-gray pt-41 pb-28 content-padding flex justify-center">
+    <div className="w-full rounded-t-[24px] md:rounded-none bg-gray pt-40 pb-28 content-padding flex justify-center">
       <div className="w-full flex flex-col gap-20 max-w-screen-content mx-auto">
         <div className="flex flex-col items-center text-center gap-4">
           <h2 className="font-extrabold text-[40px] lg:text-[52px] max-w-[780px] leading-tight">

--- a/app/routes/locations/location-single/components/tabs-component/campus-tabs.component.tsx
+++ b/app/routes/locations/location-single/components/tabs-component/campus-tabs.component.tsx
@@ -1,24 +1,26 @@
 import * as Tabs from "@radix-ui/react-tabs";
-import * as Select from "@radix-ui/react-select";
 import { ComponentType, useState } from "react";
-import { Icon } from "~/primitives/icon/icon";
 import { cn } from "~/lib/utils";
 
 const tabData = [
   {
     label: "Sunday Details",
+    mobileLabel: "Sunday",
     value: "sunday-details",
   },
   {
     label: "About Us",
+    mobileLabel: "About",
     value: "about-us",
   },
   {
     label: "For Families",
+    mobileLabel: "Families",
     value: "for-families",
   },
   {
     label: "Upcoming Events",
+    mobileLabel: "Events",
     value: "upcoming-events",
   },
 ];
@@ -83,7 +85,6 @@ const CustomTabs = ({
       {/* iPad/Desktop Tabs */}
       <Tabs.List
         className={cn(
-          "hidden md:flex gap-4 w-full border border-neutral-lighter p-4",
           isOnline ? "max-w-[520px]" : "max-w-[668px]",
           tasListStyle
         )}
@@ -96,15 +97,14 @@ const CustomTabs = ({
           >
             {tab.label}
           </Tabs.Trigger>
+              value={tab.value}
+              className="md:hidden px-4 md:px-6 py-2 font-bold data-[state=active]:bg-navy-subdued rounded-[12px] transition-all duration-300 hover:bg-neutral-lightest cursor-pointer"
+            >
+              {tab.mobileLabel}
+            </Tabs.Trigger>
+          </>
         ))}
       </Tabs.List>
-
-      {/* Mobile Tabs - Radix UI Select */}
-      <MobileTabsDropdown
-        data={data}
-        activeTab={activeTab}
-        setActiveTab={setActiveTab}
-      />
 
       <div className="w-full flex flex-col justify-center items-center">
         {data.map((tab, index) => {
@@ -126,50 +126,5 @@ const CustomTabs = ({
         })}
       </div>
     </Tabs.Root>
-  );
-};
-
-const MobileTabsDropdown = ({
-  activeTab,
-  setActiveTab,
-  data,
-}: {
-  activeTab: string;
-  setActiveTab: (value: string) => void;
-  data: any[];
-}) => {
-  return (
-    <div className={`w-3/4 md:hidden ${tasListStyle}`}>
-      <Select.Root value={activeTab} onValueChange={setActiveTab}>
-        <Select.Trigger
-          className="w-full p-4 font-semibold border border-neutral-lighter rounded-[12px] bg-white flex items-center justify-between text-text-secondary focus:ring-2 focus:ring-ocean"
-          aria-label="Select Tab"
-        >
-          <Select.Value />
-          <Select.Icon asChild>
-            <Icon name="chevronDown" size={24} className="text-ocean" />
-          </Select.Icon>
-        </Select.Trigger>
-        <Select.Portal>
-          <Select.Content
-            className="z-50 mt-2 rounded-[12px] bg-white shadow-lg border border-neutral-lighter focus:outline-none"
-            position="popper"
-            sideOffset={4}
-          >
-            <Select.Viewport className="p-2">
-              {data.map((tab) => (
-                <Select.Item
-                  key={tab.value}
-                  value={tab.value}
-                  className="px-4 py-2 rounded-md cursor-pointer text-text-secondary data-[state=checked]:bg-ocean data-[state=checked]:text-white font-semibold focus:bg-ocean focus:text-white outline-none"
-                >
-                  <Select.ItemText>{tab.label}</Select.ItemText>
-                </Select.Item>
-              ))}
-            </Select.Viewport>
-          </Select.Content>
-        </Select.Portal>
-      </Select.Root>
-    </div>
   );
 };

--- a/app/routes/locations/location-single/components/tabs-component/campus-tabs.component.tsx
+++ b/app/routes/locations/location-single/components/tabs-component/campus-tabs.component.tsx
@@ -85,18 +85,25 @@ const CustomTabs = ({
       {/* iPad/Desktop Tabs */}
       <Tabs.List
         className={cn(
+          "flex gap-1 md:w-full md:gap-4 md:border border-neutral-lighter p-4 relative mt-15 md:mt-0",
           isOnline ? "max-w-[520px]" : "max-w-[668px]",
           tasListStyle
         )}
       >
         {data.map((tab, index) => (
-          <Tabs.Trigger
-            key={index}
-            value={tab.value}
-            className="px-6 py-2 text-text-secondary font-bold data-[state=active]:bg-ocean data-[state=active]:text-white rounded-[12px] transition-all duration-300 hover:bg-neutral-lightest cursor-pointer"
-          >
-            {tab.label}
-          </Tabs.Trigger>
+          <>
+            {/* Desktop Tabs */}
+            <Tabs.Trigger
+              key={index}
+              value={tab.value}
+              className="hidden md:flex px-6 py-2 text-text-secondary font-bold data-[state=active]:bg-ocean data-[state=active]:text-white rounded-[12px] transition-all duration-300 hover:bg-neutral-lightest cursor-pointer"
+            >
+              {tab.label}
+            </Tabs.Trigger>
+
+            {/* Mobile Tabs */}
+            <Tabs.Trigger
+              key={index}
               value={tab.value}
               className="md:hidden px-4 md:px-6 py-2 font-bold data-[state=active]:bg-navy-subdued rounded-[12px] transition-all duration-300 hover:bg-neutral-lightest cursor-pointer"
             >

--- a/app/routes/locations/location-single/components/tabs-component/sunday-details/what-to-expect.tsx
+++ b/app/routes/locations/location-single/components/tabs-component/sunday-details/what-to-expect.tsx
@@ -11,7 +11,7 @@ export const WhatToExpect = ({
   isOnline?: boolean;
 }) => {
   return (
-    <div className="w-full rounded-t-[24px] md:rounded-none bg-gray pt-24 lg:pt-41 pb-20 lg:pb-28 content-padding flex justify-center">
+    <div className="w-full rounded-t-[24px] md:rounded-none bg-gray pt-40 pb-20 lg:pb-28 content-padding flex justify-center">
       <div className="w-ful flex flex-col lg:flex-row gap-12 xl:gap-20 items-center justify-center max-w-screen-content mx-auto">
         {/* Left Side */}
         {!isOnline && (

--- a/app/routes/locations/location-single/partials/campus-info.partial.tsx
+++ b/app/routes/locations/location-single/partials/campus-info.partial.tsx
@@ -74,7 +74,7 @@ export const CampusInfo = ({
   }
   return (
     <div className="w-full content-padding">
-      <div className="w-full mx-auto max-w-screen-content flex flex-col lg:flex-row gap-8 lg:justify-between pt-16 pb-32">
+      <div className="w-full mx-auto max-w-screen-content flex flex-col lg:flex-row gap-8 lg:justify-between pt-16 pb-20 lg:pb-32">
         {/* Location Info */}
         <div className="flex-1 flex flex-col gap-8 lg:pb-16 max-w-[646px]">
           {/* Campus Name Section*/}
@@ -145,7 +145,7 @@ const OnlineCampusInfo = ({
 }: CampusInfoProps) => {
   return (
     <div className="w-full content-padding">
-      <div className="w-full mx-auto max-w-screen-content flex flex-col lg:flex-row gap-8 lg:justify-between pt-16 pb-32">
+      <div className="w-full mx-auto max-w-screen-content flex flex-col lg:flex-row gap-8 lg:justify-between pt-16 pb-20 lg:pb-32">
         {/* Location Info */}
         <div className="flex-1 flex flex-col gap-8 lg:pb-16 max-w-[646px]">
           {/* Campus Name Section*/}

--- a/app/routes/locations/location-single/partials/tabs/families.tsx
+++ b/app/routes/locations/location-single/partials/tabs/families.tsx
@@ -3,7 +3,7 @@ import { familiesMappedChildren } from "./tabs.data";
 
 export const ForFamilies = () => {
   return (
-    <div className="flex flex-col w-full rounded-t-[24px] md:rounded-none bg-gray pt-8 md:pt-24">
+    <div className="flex flex-col w-full rounded-t-[24px] md:rounded-none bg-gray pt-20 md:pt-24">
       {familiesMappedChildren.map((section) => renderSection(section))}
     </div>
   );

--- a/app/routes/locations/location-single/partials/tabs/upcoming-events.tsx
+++ b/app/routes/locations/location-single/partials/tabs/upcoming-events.tsx
@@ -5,7 +5,7 @@ import { upcomingEventsData } from "./tabs.data";
 export const UpcomingEvents = () => {
   return (
     <div className="flex flex-col w-full">
-      <div className="w-full rounded-t-[24px] md:rounded-none bg-gray">
+      <div className="w-full rounded-t-[24px] md:rounded-none bg-gray pt-20 md:pt-8">
         <ResourceCarouselSection
           key={upcomingEventsData.id}
           title={upcomingEventsData.name}


### PR DESCRIPTION
## Summary
This PR updates the mobile Tabs Section of the location page.

_**Pending:** Online campus is not currently in Algolia, and since some of the tabs in that location are different we need to test those too._ 

## Screenshots
<img width="321" alt="Screenshot 2025-06-17 at 10 24 22 AM" src="https://github.com/user-attachments/assets/e9203198-0366-476d-ac59-dc5d44ac3ce9" />

## Testing
Ensure UI for the tabs looks good on all screen views and in each tab, since the content is different padding could be inconsistent, in physical campuses as well as the Online campus.

## Tickets
[CFDP-3524](https://christfellowshipchurch.atlassian.net/browse/CFDP-3524)

[CFDP-3524]: https://christfellowshipchurch.atlassian.net/browse/CFDP-3524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ