### PR TITLE
Migration to `react-router-dom`

### DIFF
--- a/app/components/additional-resources/index.tsx
+++ b/app/components/additional-resources/index.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router";
+import { Link } from "react-router-dom";
 import { cn } from "~/lib/utils";
 import { Button } from "~/primitives/button/button.primitive";
 

--- a/app/components/breadcrumbs/index.tsx
+++ b/app/components/breadcrumbs/index.tsx
@@ -1,4 +1,4 @@
-import { Link, useLocation } from "react-router";
+import { Link, useLocation } from "react-router-dom";
 import Icon from "~/primitives/icon";
 
 interface BreadcrumbsProps {

--- a/app/components/dynamic-hero/index.tsx
+++ b/app/components/dynamic-hero/index.tsx
@@ -1,4 +1,4 @@
-import { useLocation } from "react-router";
+import { useLocation } from "react-router-dom";
 import { Breadcrumbs } from "../breadcrumbs";
 import { IconButton } from "~/primitives/button/icon-button.primitive";
 import { Button, ButtonProps } from "~/primitives/button/button.primitive";

--- a/app/components/finders-location-search/location-search.component.tsx
+++ b/app/components/finders-location-search/location-search.component.tsx
@@ -6,7 +6,7 @@ import Icon from "~/primitives/icon";
 
 import { InstantSearch, Configure } from "react-instantsearch";
 import { algoliasearch, SearchClient } from "algoliasearch";
-import { useFetcher, useLoaderData } from "react-router";
+import { useFetcher, useLoaderData } from "react-router-dom";
 import { emptySearchClient } from "~/routes/search/route";
 import { globalSearchClient } from "~/routes/search/route";
 import { LoaderReturnType } from "~/routes/group-finder/loader";

--- a/app/components/modals/connect-card/confirmation.component.tsx
+++ b/app/components/modals/connect-card/confirmation.component.tsx
@@ -1,6 +1,6 @@
 import { Button } from "~/primitives/button/button.primitive";
 import Icon from "~/primitives/icon";
-import { useNavigate } from "react-router";
+import { useNavigate } from "react-router-dom";
 
 interface ConnectCardConfirmationProps {
   onSuccess?: () => void;

--- a/app/components/modals/connect-card/connect-form.component.tsx
+++ b/app/components/modals/connect-card/connect-form.component.tsx
@@ -2,7 +2,7 @@ import * as Form from "@radix-ui/react-form";
 import { useEffect, useState } from "react";
 import { Button } from "~/primitives/button/button.primitive";
 import { defaultTextInputStyles } from "~/primitives/inputs/text-field/text-field.primitive";
-import { useFetcher } from "react-router";
+import { useFetcher } from "react-router-dom";
 import { ConnectCardLoaderReturnType } from "~/routes/connect-card/types";
 
 interface ConnectCardProps {

--- a/app/components/modals/group-connect/group-connect-form.component.tsx
+++ b/app/components/modals/group-connect/group-connect-form.component.tsx
@@ -1,7 +1,7 @@
 import * as Form from "@radix-ui/react-form";
 import { useEffect, useState } from "react";
 import { Button } from "~/primitives/button/button.primitive";
-import { useFetcher } from "react-router";
+import { useFetcher } from "react-router-dom";
 import { defaultTextInputStyles } from "~/primitives/inputs/text-field/text-field.primitive";
 import RadioButtons from "~/primitives/inputs/radio-buttons";
 

--- a/app/components/modals/missions/missions-modal.tsx
+++ b/app/components/modals/missions/missions-modal.tsx
@@ -1,5 +1,5 @@
 import { useState, ReactNode } from "react";
-import { useLoaderData } from "react-router";
+import { useLoaderData } from "react-router-dom";
 import { cn } from "~/lib/utils";
 import Modal from "~/primitives/Modal";
 import { Button, ButtonProps } from "~/primitives/button/button.primitive";

--- a/app/components/modals/set-a-reminder/confirmation.component.tsx
+++ b/app/components/modals/set-a-reminder/confirmation.component.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { useFetcher } from "react-router";
+import { useFetcher } from "react-router-dom";
 import { icsLink, icsLinkEvents } from "~/lib/utils";
 import { Button } from "~/primitives/button/button.primitive";
 import Icon from "~/primitives/icon";

--- a/app/components/modals/set-a-reminder/reminder-flow.component.tsx
+++ b/app/components/modals/set-a-reminder/reminder-flow.component.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import ReminderConfirmation from "./confirmation.component";
 import ReminderForm from "./reminder-form.component";
-import { useLoaderData } from "react-router";
+import { useLoaderData } from "react-router-dom";
 import { LoaderReturnType } from "~/routes/locations/location-single/loader";
 
 interface ReminderFlowProps {

--- a/app/components/modals/set-a-reminder/reminder-form.component.tsx
+++ b/app/components/modals/set-a-reminder/reminder-form.component.tsx
@@ -2,7 +2,7 @@ import * as Form from "@radix-ui/react-form";
 import { useEffect, useState } from "react";
 import { Button } from "~/primitives/button/button.primitive";
 import { defaultTextInputStyles } from "~/primitives/inputs/text-field/text-field.primitive";
-import { useFetcher } from "react-router";
+import { useFetcher } from "react-router-dom";
 import { renderInputField } from "../connect-card/connect-form.component";
 import { LoaderReturnType } from "~/routes/set-a-reminder/loader";
 

--- a/app/components/modals/set-a-reminder/reminder-modal.component.tsx
+++ b/app/components/modals/set-a-reminder/reminder-modal.component.tsx
@@ -3,7 +3,7 @@ import Modal from "~/primitives/Modal";
 import ReminderFlow from "./reminder-flow.component";
 import { Button, ButtonProps } from "~/primitives/button/button.primitive";
 import { LoaderReturnType } from "~/routes/locations/location-single/loader";
-import { useLoaderData } from "react-router";
+import { useLoaderData } from "react-router-dom";
 import { cn } from "~/lib/utils";
 
 interface SetAReminderModalProps {

--- a/app/components/navbar/desktop/search/search.component.tsx
+++ b/app/components/navbar/desktop/search/search.component.tsx
@@ -7,7 +7,7 @@ import {
   SearchBox,
   useSearchBox,
 } from "react-instantsearch";
-import { useRouteLoaderData } from "react-router";
+import { useRouteLoaderData } from "react-router-dom";
 import Icon from "~/primitives/icon";
 import { SearchPopup } from "./search-popup.component";
 import { RootLoaderData } from "~/routes/navbar/loader";

--- a/app/components/navbar/mobile/search/mobile-search.component.tsx
+++ b/app/components/navbar/mobile/search/mobile-search.component.tsx
@@ -1,7 +1,7 @@
 import { algoliasearch, SearchClient } from "algoliasearch";
 import { useEffect, useState } from "react";
 import { Configure, InstantSearch, SearchBox } from "react-instantsearch";
-import { useRouteLoaderData } from "react-router";
+import { useRouteLoaderData } from "react-router-dom";
 import Icon from "~/primitives/icon";
 import { LoaderReturnType } from "~/routes/search/loader";
 import { SearchPopup } from "./search-popup.component";

--- a/app/components/navbar/navbar.component.tsx
+++ b/app/components/navbar/navbar.component.tsx
@@ -1,5 +1,5 @@
 import { useLocation, Outlet } from "react-router-dom";
-import { useRouteLoaderData } from "react-router";
+import { useRouteLoaderData } from "react-router-dom";
 import { useEffect, useState, useRef } from "react";
 import { useResponsive } from "~/hooks/use-responsive";
 import {

--- a/app/components/share-links/index.tsx
+++ b/app/components/share-links/index.tsx
@@ -1,4 +1,4 @@
-import { useLoaderData, useLocation } from "react-router";
+import { useLoaderData, useLocation } from "react-router-dom";
 import CopyLink from "./copy-link.component";
 import Icon from "~/primitives/icon";
 

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,5 +1,9 @@
 /** Root Error Boundary */
-import { isRouteErrorResponse, useRouteError, useLocation } from "react-router";
+import {
+  isRouteErrorResponse,
+  useRouteError,
+  useLocation,
+} from "react-router-dom";
 import { Navbar, Footer } from "./components";
 import { AuthProvider } from "./providers/auth-provider";
 import { CookieConsentProvider } from "./providers/cookie-consent-provider";

--- a/app/primitives/button/button.primitive.tsx
+++ b/app/primitives/button/button.primitive.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { cva, type VariantProps } from "class-variance-authority";
 import { twMerge } from "tailwind-merge";
-import { Link } from "react-router";
+import { Link } from "react-router-dom";
 
 export const button = cva(
   [

--- a/app/primitives/cards/resource-card.tsx
+++ b/app/primitives/cards/resource-card.tsx
@@ -1,5 +1,5 @@
 import { Icon } from "../icon/icon";
-import { Link } from "react-router";
+import { Link } from "react-router-dom";
 import { cn } from "~/lib/utils";
 import HtmlRenderer from "../html-renderer";
 import { CollectionItem } from "~/routes/page-builder/types";

--- a/app/providers/auth-provider/index.tsx
+++ b/app/providers/auth-provider/index.tsx
@@ -1,4 +1,4 @@
-import { redirect, useNavigate, useRevalidator } from "react-router";
+import { redirect, useNavigate, useRevalidator } from "react-router-dom";
 import React, { createContext, useContext, useEffect, useState } from "react";
 import { useHydrated } from "~/hooks/use-hydrated";
 

--- a/app/providers/gtm-provider/index.tsx
+++ b/app/providers/gtm-provider/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import TagManager from "react-gtm-module";
-import { useLocation } from "react-router";
+import { useLocation } from "react-router-dom";
 
 declare global {
   interface Window {

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -5,7 +5,7 @@ import {
   Scripts,
   ScrollRestoration,
   useLocation,
-} from "react-router";
+} from "react-router-dom";
 import { type ReactNode } from "react";
 
 import { Navbar, Footer } from "./components";

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -1,4 +1,4 @@
-import type { MetaFunction } from "react-router";
+import type { MetaFunction } from "react-router-dom";
 import { HistorySection } from "./about/partials/history.partial";
 import { BeliefsSection } from "./about/partials/beliefs.partial";
 import { LeadershipSection } from "./about/partials/leadership.partial";

--- a/app/routes/about/components/leaders-grid.component.tsx
+++ b/app/routes/about/components/leaders-grid.component.tsx
@@ -1,4 +1,4 @@
-import { useLoaderData } from "react-router";
+import { useLoaderData } from "react-router-dom";
 import { useState } from "react";
 import { cn } from "~/lib/utils";
 

--- a/app/routes/about/components/leaders-scroll.component.tsx
+++ b/app/routes/about/components/leaders-scroll.component.tsx
@@ -1,4 +1,4 @@
-import { useLoaderData } from "react-router";
+import { useLoaderData } from "react-router-dom";
 import { useState } from "react";
 import { cn } from "~/lib/utils";
 

--- a/app/routes/articles/all-articles/partials/articles.partial.tsx
+++ b/app/routes/articles/all-articles/partials/articles.partial.tsx
@@ -1,4 +1,4 @@
-import { Link, useLoaderData } from "react-router";
+import { Link, useLoaderData } from "react-router-dom";
 import { Article, ArticlesReturnType } from "../loader";
 import Icon from "~/primitives/icon";
 import { Divider } from "./latest.partial";

--- a/app/routes/articles/all-articles/partials/latest.partial.tsx
+++ b/app/routes/articles/all-articles/partials/latest.partial.tsx
@@ -1,4 +1,4 @@
-import { Link, useLoaderData } from "react-router";
+import { Link, useLoaderData } from "react-router-dom";
 import { Article, ArticlesReturnType } from "../loader";
 
 export const Divider = ({

--- a/app/routes/articles/article-single/action.ts
+++ b/app/routes/articles/article-single/action.ts
@@ -1,5 +1,5 @@
-import type { ActionFunctionArgs } from "react-router";
-import { data, redirect } from "react-router";
+import type { ActionFunctionArgs } from "react-router-dom";
+import { data, redirect } from "react-router-dom";
 
 export const action = async ({ request }: ActionFunctionArgs) => {
   const formData = await request.formData();

--- a/app/routes/articles/article-single/article-page.tsx
+++ b/app/routes/articles/article-single/article-page.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { LoaderReturnType } from "./loader";
-import { useLoaderData } from "react-router";
+import { useLoaderData } from "react-router-dom";
 
 import { ArticleHero } from "./partials/hero.partial";
 import { ArticleContent } from "./partials/content.partial";

--- a/app/routes/articles/article-single/components/article-author.component.tsx
+++ b/app/routes/articles/article-single/components/article-author.component.tsx
@@ -1,7 +1,7 @@
 import * as Avatar from "@radix-ui/react-avatar";
 import { CircleLoader } from "~/primitives/loading-states/circle-loader.primitive";
 import { AuthorProps } from "../partials/hero.partial";
-import { Link } from "react-router";
+import { Link } from "react-router-dom";
 
 export default function ArticleAuthor({
   author,

--- a/app/routes/articles/article-single/components/related-article-card.components.tsx
+++ b/app/routes/articles/article-single/components/related-article-card.components.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router";
+import { Link } from "react-router-dom";
 import { CardAuthor, CardProps } from "./card-author.component";
 
 export function RelatedArticleCard({

--- a/app/routes/articles/article-single/loader.ts
+++ b/app/routes/articles/article-single/loader.ts
@@ -1,4 +1,4 @@
-import { data, type LoaderFunction } from "react-router";
+import { data, type LoaderFunction } from "react-router-dom";
 import { fetchRockData, getImages } from "~/lib/.server/fetch-rock-data";
 import { AuthorProps } from "./partials/hero.partial";
 import { format } from "date-fns";

--- a/app/routes/articles/article-single/meta.ts
+++ b/app/routes/articles/article-single/meta.ts
@@ -1,4 +1,4 @@
-import type { MetaFunction } from "react-router";
+import type { MetaFunction } from "react-router-dom";
 
 interface ArticleData {
   title: string;

--- a/app/routes/articles/article-single/partials/related-articles.partial.tsx
+++ b/app/routes/articles/article-single/partials/related-articles.partial.tsx
@@ -1,6 +1,6 @@
 import { Button } from "~/primitives/button/button.primitive";
 import { RelatedArticleCard } from "../components/related-article-card.components";
-import { useLoaderData } from "react-router";
+import { useLoaderData } from "react-router-dom";
 import { LoaderReturnType } from "../loader";
 
 export const RelatedArticles = () => {

--- a/app/routes/auth/authenticate-sms.tsx
+++ b/app/routes/auth/authenticate-sms.tsx
@@ -1,5 +1,5 @@
-import { data } from "react-router";
-import { isRouteErrorResponse } from "react-router";
+import { data } from "react-router-dom";
+import { isRouteErrorResponse } from "react-router-dom";
 import { authenticateOrRegisterWithSms } from "~/lib/.server/authentication/authenticate-or-register-with-sms";
 
 type AuthenticateSmsData = {

--- a/app/routes/auth/authenticate.tsx
+++ b/app/routes/auth/authenticate.tsx
@@ -1,4 +1,4 @@
-import { data } from "react-router";
+import { data } from "react-router-dom";
 import { authenticateUser } from "~/lib/.server/authentication/authenticate-user";
 
 import {

--- a/app/routes/auth/current-user.tsx
+++ b/app/routes/auth/current-user.tsx
@@ -1,4 +1,4 @@
-import { data } from "react-router";
+import { data } from "react-router-dom";
 import { getCurrentPerson } from "~/lib/.server/authentication/rock-authentication";
 import { decrypt } from "~/lib/.server/decrypt";
 import { registerToken } from "~/lib/.server/token";

--- a/app/routes/auth/register-person.tsx
+++ b/app/routes/auth/register-person.tsx
@@ -1,4 +1,4 @@
-import { data } from "react-router";
+import { data } from "react-router-dom";
 import { registerPersonWithEmail } from "~/lib/.server/authentication/rock-authentication";
 import { RegistrationTypes, UserInputData } from "~/providers/auth-provider";
 import { authenticateOrRegisterWithSms } from "~/lib/.server/authentication/authenticate-or-register-with-sms";

--- a/app/routes/auth/request-sms-pin-login.tsx
+++ b/app/routes/auth/request-sms-pin-login.tsx
@@ -1,4 +1,4 @@
-import { data } from "react-router";
+import { data } from "react-router-dom";
 import { requestSmsLogin } from "~/lib/.server/authentication/sms-authentication";
 import {
   AuthenticationError,

--- a/app/routes/auth/route.tsx
+++ b/app/routes/auth/route.tsx
@@ -1,4 +1,4 @@
-import { ActionFunction, data } from "react-router";
+import { ActionFunction, data } from "react-router-dom";
 import { authenticate } from "./authenticate";
 import { requestSmsPinLogin } from "./request-sms-pin-login";
 import { authenticateSms } from "./authenticate-sms";

--- a/app/routes/auth/userExists.tsx
+++ b/app/routes/auth/userExists.tsx
@@ -1,4 +1,4 @@
-import { data } from "react-router";
+import { data } from "react-router-dom";
 import { fetchUserLogin } from "~/lib/.server/authentication/rock-authentication";
 
 export const checkUserExists = async (identity: string): Promise<boolean> => {

--- a/app/routes/author/action.ts
+++ b/app/routes/author/action.ts
@@ -1,5 +1,5 @@
-import type { ActionFunctionArgs } from "react-router";
-import { data, redirect } from "react-router";
+import type { ActionFunctionArgs } from "react-router-dom";
+import { data, redirect } from "react-router-dom";
 
 export const action = async ({ request }: ActionFunctionArgs) => {
   const formData = await request.formData();

--- a/app/routes/author/author-page.tsx
+++ b/app/routes/author/author-page.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Author } from "./loader";
-import { useLoaderData } from "react-router";
+import { useLoaderData } from "react-router-dom";
 import BackButton from "./components/back-button";
 import AuthorTabs from "./components/author-tabs";
 import { AuthorBioDesktop, AuthorBioMobile } from "./partials/author-bio";

--- a/app/routes/author/components/author-content.tsx
+++ b/app/routes/author/components/author-content.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router";
+import { Link } from "react-router-dom";
 
 export type AuthorArticleProps = {
   title: string;

--- a/app/routes/author/loader.ts
+++ b/app/routes/author/loader.ts
@@ -1,4 +1,4 @@
-import { LoaderFunction } from "react-router";
+import { LoaderFunction } from "react-router-dom";
 import { fetchRockData } from "~/lib/.server/fetch-rock-data";
 import { createImageUrlFromGuid } from "~/lib/utils";
 import { fetchAuthorData } from "../articles/article-single/loader";

--- a/app/routes/author/meta.ts
+++ b/app/routes/author/meta.ts
@@ -1,4 +1,4 @@
-import type { MetaFunction } from "react-router";
+import type { MetaFunction } from "react-router-dom";
 import { loader } from "./loader";
 
 export const meta: MetaFunction<typeof loader> = ({ data }) => {

--- a/app/routes/class-finder/class-single/action.tsx
+++ b/app/routes/class-finder/class-single/action.tsx
@@ -1,4 +1,4 @@
-import { ActionFunctionArgs } from "react-router";
+import { ActionFunctionArgs } from "react-router-dom";
 
 export async function action({ params }: ActionFunctionArgs) {
   const { path } = params;

--- a/app/routes/class-finder/class-single/class-single-page.tsx
+++ b/app/routes/class-finder/class-single/class-single-page.tsx
@@ -1,4 +1,4 @@
-import { Link, useLoaderData } from "react-router";
+import { Link, useLoaderData } from "react-router-dom";
 import { LoaderReturnType } from "./loader";
 import { Breadcrumbs } from "~/components";
 

--- a/app/routes/class-finder/class-single/loader.tsx
+++ b/app/routes/class-finder/class-single/loader.tsx
@@ -1,4 +1,4 @@
-import { LoaderFunctionArgs } from "react-router";
+import { LoaderFunctionArgs } from "react-router-dom";
 import { AuthenticationError } from "~/lib/.server/error-types";
 
 export type LoaderReturnType = {

--- a/app/routes/class-finder/class-single/meta.tsx
+++ b/app/routes/class-finder/class-single/meta.tsx
@@ -1,4 +1,4 @@
-import type { MetaFunction } from "react-router";
+import type { MetaFunction } from "react-router-dom";
 import { loader } from "./loader";
 
 interface ClassData {

--- a/app/routes/class-finder/class-single/partials/upcoming-sections.partial.tsx
+++ b/app/routes/class-finder/class-single/partials/upcoming-sections.partial.tsx
@@ -1,4 +1,4 @@
-import { useLoaderData } from "react-router";
+import { useLoaderData } from "react-router-dom";
 import { liteClient as algoliasearch } from "algoliasearch/lite";
 import { InstantSearch, Hits, Configure, Stats } from "react-instantsearch";
 import { useResponsive } from "~/hooks/use-responsive";

--- a/app/routes/class-finder/finder/components/hit-component.component.tsx
+++ b/app/routes/class-finder/finder/components/hit-component.component.tsx
@@ -3,7 +3,7 @@
  */
 
 import { GroupHit } from "../../types";
-import { Link } from "react-router";
+import { Link } from "react-router-dom";
 
 export const defaultLeaderPhoto =
   "https://cloudfront.christfellowship.church/GetAvatar.ashx?PhotoId=&AgeClassification=Adult&Gender=Unknown&RecordTypeId=1&Text=JC&Size=180&Style=icon&BackgroundColor=E4E4E7&ForegroundColor=A1A1AA";

--- a/app/routes/class-finder/finder/loader.tsx
+++ b/app/routes/class-finder/finder/loader.tsx
@@ -1,4 +1,4 @@
-import { LoaderFunction } from "react-router";
+import { LoaderFunction } from "react-router-dom";
 import { AuthenticationError } from "~/lib/.server/error-types";
 
 export type LoaderReturnType = {

--- a/app/routes/class-finder/finder/partials/class-search.partial.tsx
+++ b/app/routes/class-finder/finder/partials/class-search.partial.tsx
@@ -1,4 +1,4 @@
-import { useLoaderData } from "react-router";
+import { useLoaderData } from "react-router-dom";
 import { liteClient as algoliasearch } from "algoliasearch/lite";
 import {
   InstantSearch,

--- a/app/routes/class-finder/loader.tsx
+++ b/app/routes/class-finder/loader.tsx
@@ -1,4 +1,4 @@
-import { LoaderFunction } from "react-router";
+import { LoaderFunction } from "react-router-dom";
 import { AuthenticationError } from "~/lib/.server/error-types";
 
 export type LoaderReturnType = {

--- a/app/routes/connect-card/action.ts
+++ b/app/routes/connect-card/action.ts
@@ -1,4 +1,4 @@
-import { ActionFunction, data } from "react-router";
+import { ActionFunction, data } from "react-router-dom";
 import { ConnectFormType } from "./types";
 import { postRockData } from "~/lib/.server/fetch-rock-data";
 

--- a/app/routes/connect-card/loader.ts
+++ b/app/routes/connect-card/loader.ts
@@ -1,4 +1,4 @@
-import { LoaderFunction } from "react-router";
+import { LoaderFunction } from "react-router-dom";
 import { fetchRockData } from "~/lib/.server/fetch-rock-data";
 import { ConnectCardLoaderReturnType } from "./types";
 

--- a/app/routes/events/all-events/components/featured-card.component.tsx
+++ b/app/routes/events/all-events/components/featured-card.component.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router";
+import { Link } from "react-router-dom";
 import { Event } from "../loader";
 import { Button } from "~/primitives/button/button.primitive";
 import Icon from "~/primitives/icon";

--- a/app/routes/events/all-events/partials/events-for-you.partial.tsx
+++ b/app/routes/events/all-events/partials/events-for-you.partial.tsx
@@ -1,4 +1,4 @@
-import { useLoaderData } from "react-router";
+import { useLoaderData } from "react-router-dom";
 import { EventReturnType } from "../loader";
 import { SectionTitle } from "~/components";
 import {

--- a/app/routes/events/all-events/partials/featured-events.partial.tsx
+++ b/app/routes/events/all-events/partials/featured-events.partial.tsx
@@ -1,5 +1,5 @@
 import { FeaturedEventCard } from "../components/featured-card.component";
-import { useLoaderData } from "react-router";
+import { useLoaderData } from "react-router-dom";
 import { EventReturnType } from "../loader";
 import { ResourceCard } from "~/primitives/cards/resource-card";
 

--- a/app/routes/events/event-single/event-single-page.tsx
+++ b/app/routes/events/event-single/event-single-page.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useLoaderData } from "react-router";
+import { useLoaderData } from "react-router-dom";
 import { SectionTitle, AdditionalResources } from "~/components";
 
 import { LoaderReturnType } from "./loader";

--- a/app/routes/events/event-single/loader.ts
+++ b/app/routes/events/event-single/loader.ts
@@ -1,4 +1,4 @@
-import type { LoaderFunction } from "react-router";
+import type { LoaderFunction } from "react-router-dom";
 import { fetchRockData, getImages } from "~/lib/.server/fetch-rock-data";
 import { format } from "date-fns";
 

--- a/app/routes/events/event-single/meta.ts
+++ b/app/routes/events/event-single/meta.ts
@@ -1,4 +1,4 @@
-import type { MetaFunction } from "react-router";
+import type { MetaFunction } from "react-router-dom";
 import { loader } from "./loader";
 
 interface EventData {

--- a/app/routes/google-geocode/action.ts
+++ b/app/routes/google-geocode/action.ts
@@ -1,4 +1,4 @@
-import { ActionFunction } from "react-router";
+import { ActionFunction } from "react-router-dom";
 import {
   AuthenticationError,
   EncryptionError,

--- a/app/routes/group-finder/finder/action.tsx
+++ b/app/routes/group-finder/finder/action.tsx
@@ -1,4 +1,4 @@
-import { ActionFunction, data } from "react-router";
+import { ActionFunction, data } from "react-router-dom";
 import { fetchRockData, postRockData } from "~/lib/.server/fetch-rock-data";
 import { fetchUserLogin } from "~/lib/.server/authentication/rock-authentication";
 import { updatePerson } from "~/lib/.server/rock-person";

--- a/app/routes/group-finder/finder/components/hit-component.component.tsx
+++ b/app/routes/group-finder/finder/components/hit-component.component.tsx
@@ -1,6 +1,6 @@
 import Icon from "~/primitives/icon";
 import { GroupHit } from "../../types";
-import { Link } from "react-router";
+import { Link } from "react-router-dom";
 
 export const defaultLeaderPhoto =
   "https://cloudfront.christfellowship.church/GetAvatar.ashx?PhotoId=&AgeClassification=Adult&Gender=Unknown&RecordTypeId=1&Text=JC&Size=180&Style=icon&BackgroundColor=E4E4E7&ForegroundColor=A1A1AA";

--- a/app/routes/group-finder/finder/loader.tsx
+++ b/app/routes/group-finder/finder/loader.tsx
@@ -1,4 +1,4 @@
-import { LoaderFunction } from "react-router";
+import { LoaderFunction } from "react-router-dom";
 import { AuthenticationError } from "~/lib/.server/error-types";
 
 export type LoaderReturnType = {

--- a/app/routes/group-finder/finder/partials/group-search.partial.tsx
+++ b/app/routes/group-finder/finder/partials/group-search.partial.tsx
@@ -1,4 +1,4 @@
-import { useLoaderData } from "react-router";
+import { useLoaderData } from "react-router-dom";
 import { liteClient as algoliasearch } from "algoliasearch/lite";
 import {
   InstantSearch,

--- a/app/routes/group-finder/group-single/action.tsx
+++ b/app/routes/group-finder/group-single/action.tsx
@@ -1,4 +1,4 @@
-import { ActionFunctionArgs } from "react-router";
+import { ActionFunctionArgs } from "react-router-dom";
 
 export async function action({ params }: ActionFunctionArgs) {
   const { path } = params;

--- a/app/routes/group-finder/group-single/components/basic-content.component.tsx
+++ b/app/routes/group-finder/group-single/components/basic-content.component.tsx
@@ -1,4 +1,4 @@
-import { useLoaderData } from "react-router";
+import { useLoaderData } from "react-router-dom";
 import type { LoaderReturnType } from "../loader";
 import { GroupFAQ } from "./faq.component";
 

--- a/app/routes/group-finder/group-single/group-single-page.tsx
+++ b/app/routes/group-finder/group-single/group-single-page.tsx
@@ -1,4 +1,4 @@
-import { Link, useLoaderData } from "react-router";
+import { Link, useLoaderData } from "react-router-dom";
 import { LoaderReturnType } from "./loader";
 import { FinderSingleHero } from "./partials/finder-single-hero.partial";
 import { Breadcrumbs } from "~/components";

--- a/app/routes/group-finder/group-single/loader.tsx
+++ b/app/routes/group-finder/group-single/loader.tsx
@@ -1,4 +1,4 @@
-import { LoaderFunctionArgs } from "react-router";
+import { LoaderFunctionArgs } from "react-router-dom";
 import { AuthenticationError } from "~/lib/.server/error-types";
 
 export type LoaderReturnType = {

--- a/app/routes/group-finder/group-single/meta.tsx
+++ b/app/routes/group-finder/group-single/meta.tsx
@@ -1,4 +1,4 @@
-import type { MetaFunction } from "react-router";
+import type { MetaFunction } from "react-router-dom";
 import { loader } from "./loader";
 
 /**

--- a/app/routes/group-finder/group-single/partials/related-groups.partial.tsx
+++ b/app/routes/group-finder/group-single/partials/related-groups.partial.tsx
@@ -3,7 +3,7 @@ import { useHits } from "react-instantsearch";
 import { Button } from "~/primitives/button/button.primitive";
 import { useMemo } from "react";
 import { HitComponent } from "../../finder/components/hit-component.component";
-import { useLoaderData } from "react-router";
+import { useLoaderData } from "react-router-dom";
 import { LoaderReturnType } from "../loader";
 import { useResponsive } from "~/hooks/use-responsive";
 import { createSearchClient } from "~/routes/messages/all-messages/components/all-messages.component";

--- a/app/routes/group-finder/loader.tsx
+++ b/app/routes/group-finder/loader.tsx
@@ -1,4 +1,4 @@
-import { LoaderFunction } from "react-router";
+import { LoaderFunction } from "react-router-dom";
 import { AuthenticationError } from "~/lib/.server/error-types";
 
 export type LoaderReturnType = {

--- a/app/routes/home/components/location-search/location-search.component.tsx
+++ b/app/routes/home/components/location-search/location-search.component.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { algoliasearch, SearchClient } from "algoliasearch";
 import { useEffect, useRef } from "react";
 import { Configure, InstantSearch } from "react-instantsearch";
-import { useFetcher, useLoaderData } from "react-router";
+import { useFetcher, useLoaderData } from "react-router-dom";
 import { SearchPopup } from "./search-popup";
 import { cn } from "~/lib/utils";
 import { emptySearchClient } from "~/routes/search/route";

--- a/app/routes/home/components/location-search/search-popup.tsx
+++ b/app/routes/home/components/location-search/search-popup.tsx
@@ -1,7 +1,7 @@
 import { Hits } from "react-instantsearch";
 import { HitComponent, CampusHit } from "./location-hit";
 import { Hit } from "algoliasearch";
-import { Link } from "react-router";
+import { Link } from "react-router-dom";
 import { Icon } from "~/primitives/icon/icon";
 
 export const SearchPopup = ({

--- a/app/routes/home/partials/app.partial.tsx
+++ b/app/routes/home/partials/app.partial.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router";
+import { Link } from "react-router-dom";
 
 export function AppSection() {
   return (

--- a/app/routes/home/partials/hero.partial.tsx
+++ b/app/routes/home/partials/hero.partial.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router";
+import { Link } from "react-router-dom";
 import { LocationSearch } from "../components/location-search/location-search.component";
 import { IconName } from "~/primitives/button/types";
 import { Icon } from "~/primitives/icon/icon";

--- a/app/routes/link-tree/loader.ts
+++ b/app/routes/link-tree/loader.ts
@@ -1,4 +1,4 @@
-import { LoaderFunctionArgs } from "react-router";
+import { LoaderFunctionArgs } from "react-router-dom";
 import { fetchRockData } from "~/lib/.server/fetch-rock-data";
 import { parseRockKeyValueList } from "~/lib/utils";
 import { LinkTreeLoaderData, RockLinkTreeData } from "./types";

--- a/app/routes/locations/location-search/action.ts
+++ b/app/routes/locations/location-search/action.ts
@@ -1,4 +1,4 @@
-import { ActionFunction } from "react-router";
+import { ActionFunction } from "react-router-dom";
 import { fetchRockData } from "~/lib/.server/fetch-rock-data";
 import { Campus } from "./partials/location-card-list.partial";
 import { createImageUrlFromGuid, latLonDistance } from "~/lib/utils";

--- a/app/routes/locations/location-search/components/locations-search-card.component.tsx
+++ b/app/routes/locations/location-search/components/locations-search-card.component.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router";
+import { Link } from "react-router-dom";
 import heroBgImgStyles from "~/styles/hero-bg-image-styles";
 
 export type LocationCardProps = {

--- a/app/routes/locations/location-search/components/locations-search-skeleton.component.tsx
+++ b/app/routes/locations/location-search/components/locations-search-skeleton.component.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router";
+import { Link } from "react-router-dom";
 import "./locations-search-skeleton.css"; // todo : figure out how load in css SSR, to remove error on console
 
 const LocationSkeletonCard = () => {

--- a/app/routes/locations/location-search/loader.tsx
+++ b/app/routes/locations/location-search/loader.tsx
@@ -1,4 +1,4 @@
-import { LoaderFunctionArgs } from "react-router";
+import { LoaderFunctionArgs } from "react-router-dom";
 import { fetchRockData } from "~/lib/.server/fetch-rock-data";
 import { createImageUrlFromGuid } from "~/lib/utils";
 import { fetchWistiaData } from "~/lib/.server/fetch-wistia-data";

--- a/app/routes/locations/location-search/location-search.tsx
+++ b/app/routes/locations/location-search/location-search.tsx
@@ -4,7 +4,7 @@ import {
   Campus,
   LocationCardList,
 } from "./partials/location-card-list.partial";
-import { useFetcher, useLoaderData } from "react-router";
+import { useFetcher, useLoaderData } from "react-router-dom";
 import { CampusesReturnType } from "./loader";
 
 export type LocationSearchCoordinatesType = {

--- a/app/routes/locations/location-search/meta.tsx
+++ b/app/routes/locations/location-search/meta.tsx
@@ -1,4 +1,4 @@
-import type { MetaFunction } from "react-router";
+import type { MetaFunction } from "react-router-dom";
 
 export const meta: MetaFunction = () => {
   return [

--- a/app/routes/locations/location-search/partials/location-card-list.partial.tsx
+++ b/app/routes/locations/location-search/partials/location-card-list.partial.tsx
@@ -1,7 +1,7 @@
 import lodash from "lodash";
 import LocationCard from "../components/locations-search-card.component";
 import { LocationsLoader } from "../components/locations-search-skeleton.component";
-import { Link } from "react-router";
+import { Link } from "react-router-dom";
 
 export type Campus = {
   name: string;

--- a/app/routes/locations/location-search/partials/locations-search-hero.partial.tsx
+++ b/app/routes/locations/location-search/partials/locations-search-hero.partial.tsx
@@ -2,7 +2,7 @@ import { Button } from "~/primitives/button/button.primitive";
 import Icon from "~/primitives/icon";
 import { CampusesReturnType } from "../loader";
 import * as Form from "@radix-ui/react-form";
-import { useLoaderData } from "react-router";
+import { useLoaderData } from "react-router-dom";
 import { defaultTextInputStyles } from "~/primitives/inputs/text-field/text-field.primitive";
 import { useEffect, useState } from "react";
 import { Video } from "~/primitives/video/video.primitive";

--- a/app/routes/locations/location-single/components/ctas.component.tsx
+++ b/app/routes/locations/location-single/components/ctas.component.tsx
@@ -2,7 +2,7 @@ import { SetAReminderModal } from "~/components/modals/set-a-reminder/reminder-m
 import { icons } from "~/lib/icons";
 import { Icon } from "~/primitives/icon/icon";
 import { ButtonProps } from "~/primitives/button/button.primitive";
-import { Link } from "react-router";
+import { Link } from "react-router-dom";
 import React from "react";
 
 const CTAButtonContent = ({

--- a/app/routes/locations/location-single/components/during-the-week.component.tsx
+++ b/app/routes/locations/location-single/components/during-the-week.component.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router";
+import { Link } from "react-router-dom";
 import { Icon } from "~/primitives/icon/icon";
 
 export const DuringTheWeek = ({

--- a/app/routes/locations/location-single/components/tabs-component/about-us/connect-with-us.tsx
+++ b/app/routes/locations/location-single/components/tabs-component/about-us/connect-with-us.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router";
+import { Link } from "react-router-dom";
 import { SetAReminderModal } from "~/components";
 import { Button, ButtonProps } from "~/primitives/button/button.primitive";
 

--- a/app/routes/locations/location-single/components/tabs-component/upcoming-events/get-involved.tsx
+++ b/app/routes/locations/location-single/components/tabs-component/upcoming-events/get-involved.tsx
@@ -10,7 +10,7 @@ import {
   CarouselNext,
 } from "~/primitives/shadcn-primitives/carousel";
 import { Carousel } from "~/primitives/shadcn-primitives/carousel";
-import { Link } from "react-router";
+import { Link } from "react-router-dom";
 import Icon from "~/primitives/icon";
 
 const items = [

--- a/app/routes/locations/location-single/components/virtual-tour.component.tsx
+++ b/app/routes/locations/location-single/components/virtual-tour.component.tsx
@@ -1,5 +1,5 @@
 import * as Tabs from "@radix-ui/react-tabs";
-import { useLoaderData } from "react-router";
+import { useLoaderData } from "react-router-dom";
 import { Icon } from "~/primitives/icon/icon";
 import { Video } from "~/primitives/video/video.primitive";
 import { LoaderReturnType } from "../loader";

--- a/app/routes/locations/location-single/loader.ts
+++ b/app/routes/locations/location-single/loader.ts
@@ -1,4 +1,4 @@
-import { LoaderFunction } from "react-router";
+import { LoaderFunction } from "react-router-dom";
 
 export type LoaderReturnType = {
   ALGOLIA_APP_ID: string;

--- a/app/routes/locations/location-single/meta.tsx
+++ b/app/routes/locations/location-single/meta.tsx
@@ -1,4 +1,4 @@
-import type { MetaFunction } from "react-router";
+import type { MetaFunction } from "react-router-dom";
 import { loader } from "./loader";
 
 export const meta: MetaFunction<typeof loader> = ({ data }: any) => {

--- a/app/routes/locations/location-single/partials/faq.partial.tsx
+++ b/app/routes/locations/location-single/partials/faq.partial.tsx
@@ -1,7 +1,7 @@
 import { StyledAccordion } from "~/components";
 import { Button } from "~/primitives/button/button.primitive";
 import { faqData } from "~/lib/faq-data.data";
-import { useLoaderData } from "react-router";
+import { useLoaderData } from "react-router-dom";
 import { LoaderReturnType } from "../loader";
 
 export const LocationFAQ = ({ campusName }: { campusName: string }) => {

--- a/app/routes/messages/all-messages/components/all-messages.component.tsx
+++ b/app/routes/messages/all-messages/components/all-messages.component.tsx
@@ -1,4 +1,4 @@
-import { useLoaderData } from "react-router";
+import { useLoaderData } from "react-router-dom";
 import { liteClient as algoliasearch } from "algoliasearch/lite";
 import {
   InstantSearch,

--- a/app/routes/messages/all-messages/loader.tsx
+++ b/app/routes/messages/all-messages/loader.tsx
@@ -1,4 +1,4 @@
-import { LoaderFunction } from "react-router";
+import { LoaderFunction } from "react-router-dom";
 import { AuthenticationError } from "~/lib/.server/error-types";
 import { fetchRockData } from "~/lib/.server/fetch-rock-data";
 import { createImageUrlFromGuid } from "~/lib/utils";

--- a/app/routes/messages/message-single/loader.ts
+++ b/app/routes/messages/message-single/loader.ts
@@ -1,4 +1,4 @@
-import type { LoaderFunction } from "react-router";
+import type { LoaderFunction } from "react-router-dom";
 import { fetchRockData, getImages } from "~/lib/.server/fetch-rock-data";
 import { format } from "date-fns";
 import { mockInThisSeries } from "./components/mockData";

--- a/app/routes/messages/message-single/meta.ts
+++ b/app/routes/messages/message-single/meta.ts
@@ -1,4 +1,4 @@
-import type { MetaFunction } from "react-router";
+import type { MetaFunction } from "react-router-dom";
 import { loader } from "./loader";
 
 /**

--- a/app/routes/messages/message-single/partials/content.partial.tsx
+++ b/app/routes/messages/message-single/partials/content.partial.tsx
@@ -1,4 +1,4 @@
-import { useLoaderData } from "react-router";
+import { useLoaderData } from "react-router-dom";
 import { MessageReturnType } from "../loader";
 import HTMLRenderer from "~/primitives/html-renderer";
 

--- a/app/routes/messages/message-single/partials/hero-video.partial.tsx
+++ b/app/routes/messages/message-single/partials/hero-video.partial.tsx
@@ -1,6 +1,6 @@
 import { VideoHeader } from "~/components";
 import { MessageReturnType } from "../loader";
-import { useLoaderData } from "react-router";
+import { useLoaderData } from "react-router-dom";
 import kebabCase from "lodash/kebabCase";
 
 const VideoSkeleton = () => (

--- a/app/routes/messages/message-single/partials/related-messages.partial.tsx
+++ b/app/routes/messages/message-single/partials/related-messages.partial.tsx
@@ -1,5 +1,5 @@
 import { Button } from "~/primitives/button/button.primitive";
-import { useLoaderData } from "react-router";
+import { useLoaderData } from "react-router-dom";
 import { SectionTitle } from "~/components";
 
 import { MessageReturnType } from "../loader";

--- a/app/routes/messages/message-single/partials/series.partial.tsx
+++ b/app/routes/messages/message-single/partials/series.partial.tsx
@@ -1,4 +1,4 @@
-import { useLoaderData } from "react-router";
+import { useLoaderData } from "react-router-dom";
 import { MessageReturnType } from "../loader";
 import { SeriesCard } from "../components/this-series-card.component";
 import { mockInThisSeries } from "../components/mockData";

--- a/app/routes/ministries/loader.ts
+++ b/app/routes/ministries/loader.ts
@@ -1,4 +1,4 @@
-import { LoaderFunction } from "react-router";
+import { LoaderFunction } from "react-router-dom";
 import { fetchRockData } from "~/lib/.server/fetch-rock-data";
 import { createImageUrlFromGuid } from "~/lib/utils";
 

--- a/app/routes/ministries/route.tsx
+++ b/app/routes/ministries/route.tsx
@@ -1,6 +1,6 @@
 import { DynamicHero } from "~/components";
 import { AllMinistriesPartial } from "./all-ministries/partials/all-ministries.partial";
-import { useLoaderData } from "react-router";
+import { useLoaderData } from "react-router-dom";
 import type { Ministry } from "./loader";
 export { loader } from "./loader";
 

--- a/app/routes/navbar/loader.tsx
+++ b/app/routes/navbar/loader.tsx
@@ -1,6 +1,6 @@
 // This loader is used to fetch the feature cards for the navbar and is stored in the root loader to be used across the app
 
-import type { LoaderFunctionArgs } from "react-router";
+import type { LoaderFunctionArgs } from "react-router-dom";
 import { fetchRockData } from "~/lib/.server/fetch-rock-data";
 import type { FeatureCard } from "~/components/navbar/types";
 import { createImageUrlFromGuid } from "~/lib/utils";

--- a/app/routes/page-builder/loader.tsx
+++ b/app/routes/page-builder/loader.tsx
@@ -1,4 +1,4 @@
-import { LoaderFunction } from "react-router";
+import { LoaderFunction } from "react-router-dom";
 import { fetchRockData } from "~/lib/.server/fetch-rock-data";
 import { createImageUrlFromGuid, parseRockKeyValueList } from "~/lib/utils";
 import {

--- a/app/routes/page-builder/page-builder-page.tsx
+++ b/app/routes/page-builder/page-builder-page.tsx
@@ -1,4 +1,4 @@
-import { useLoaderData } from "react-router";
+import { useLoaderData } from "react-router-dom";
 import { PageBuilderLoader } from "./types";
 import { DynamicHero } from "~/components";
 import { ResourceCarouselSection } from "~/components/page-builder/resource-section.partial";

--- a/app/routes/podcasts/all-podcasts/loader.ts
+++ b/app/routes/podcasts/all-podcasts/loader.ts
@@ -1,4 +1,4 @@
-import type { LoaderFunctionArgs } from "react-router";
+import type { LoaderFunctionArgs } from "react-router-dom";
 import type { Podcast } from "../types";
 
 export type PodcastsHubLoaderData = {

--- a/app/routes/podcasts/podcasts-details/components/podcast-episode-card.tsx
+++ b/app/routes/podcasts/podcasts-details/components/podcast-episode-card.tsx
@@ -1,6 +1,6 @@
 import { Icon } from "~/primitives/icon/icon";
 import { PodcastEpisode } from "../../types";
-import { Link } from "react-router";
+import { Link } from "react-router-dom";
 import lodash from "lodash";
 
 export const PodcastEpisodeCard = ({

--- a/app/routes/podcasts/podcasts-details/loader.tsx
+++ b/app/routes/podcasts/podcasts-details/loader.tsx
@@ -1,4 +1,4 @@
-import { LoaderFunctionArgs } from "react-router";
+import { LoaderFunctionArgs } from "react-router-dom";
 import { PodcastEpisode, Podcast } from "../types";
 
 export type LoaderReturnType = {

--- a/app/routes/podcasts/podcasts-details/partials/all-seasons.partials.tsx
+++ b/app/routes/podcasts/podcasts-details/partials/all-seasons.partials.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useLoaderData } from "react-router";
+import { useLoaderData } from "react-router-dom";
 import { LoaderReturnType } from "../loader";
 import { PodcastEpisodeCard } from "../components/podcast-episode-card";
 

--- a/app/routes/podcasts/podcasts-details/podcasts-details-page.tsx
+++ b/app/routes/podcasts/podcasts-details/podcasts-details-page.tsx
@@ -1,4 +1,4 @@
-import { useLoaderData } from "react-router";
+import { useLoaderData } from "react-router-dom";
 import { LoaderReturnType } from "./loader";
 import { PodcastsHero } from "./partials/podcasts-hero.partial";
 import { LatestEpisodes } from "./partials/latests-episodes.partials";

--- a/app/routes/podcasts/podcasts-episode/loader.tsx
+++ b/app/routes/podcasts/podcasts-episode/loader.tsx
@@ -1,4 +1,4 @@
-import { LoaderFunctionArgs } from "react-router";
+import { LoaderFunctionArgs } from "react-router-dom";
 import { PodcastEpisode } from "../types";
 
 export type LoaderReturnType = {

--- a/app/routes/podcasts/podcasts-episode/podcast-episode.tsx
+++ b/app/routes/podcasts/podcasts-episode/podcast-episode.tsx
@@ -1,4 +1,4 @@
-import { useLoaderData } from "react-router";
+import { useLoaderData } from "react-router-dom";
 import { LoaderReturnType } from "./loader";
 import { SubscribeSection } from "../podcasts-details/partials/subscribe-section.partial";
 import { EpisodeNotes } from "./partials/episode-notes.partial";

--- a/app/routes/profile.tsx
+++ b/app/routes/profile.tsx
@@ -1,5 +1,5 @@
-import { LoaderFunction, redirect } from "react-router";
-import { useLoaderData } from "react-router";
+import { LoaderFunction, redirect } from "react-router-dom";
+import { useLoaderData } from "react-router-dom";
 import { AuthModal } from "~/components";
 import { Button } from "~/primitives/button/button.primitive";
 import { useAuth } from "~/providers/auth-provider";

--- a/app/routes/search/route.tsx
+++ b/app/routes/search/route.tsx
@@ -7,7 +7,7 @@ import {
   RefinementList,
 } from "react-instantsearch";
 import { ContentItemHit } from "./types";
-import { useLoaderData } from "react-router";
+import { useLoaderData } from "react-router-dom";
 import { LoaderReturnType } from "./loader";
 import { SearchClient } from "algoliasearch";
 

--- a/app/routes/set-a-reminder/action.ts
+++ b/app/routes/set-a-reminder/action.ts
@@ -1,4 +1,4 @@
-import { ActionFunction, data } from "react-router";
+import { ActionFunction, data } from "react-router-dom";
 import { SetAReminderType } from "./types";
 import { fetchRockData, postRockData } from "~/lib/.server/fetch-rock-data";
 

--- a/app/routes/set-a-reminder/loader.ts
+++ b/app/routes/set-a-reminder/loader.ts
@@ -1,4 +1,4 @@
-import { LoaderFunctionArgs } from "react-router";
+import { LoaderFunctionArgs } from "react-router-dom";
 import { getUserFromRequest } from "~/lib/.server/authentication/get-user-from-request";
 import { fetchRockData } from "~/lib/.server/fetch-rock-data";
 import { dayTimes, formattedServiceTimes } from "~/lib/utils";

--- a/app/routes/volunteer/components/cards/community-card.component.tsx
+++ b/app/routes/volunteer/components/cards/community-card.component.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router";
+import { Link } from "react-router-dom";
 import { Button } from "~/primitives/button/button.primitive";
 import { CommunityCard as CommunityCardType } from "../../types";
 

--- a/app/routes/volunteer/components/cards/region-card.component.tsx
+++ b/app/routes/volunteer/components/cards/region-card.component.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router";
+import { Link } from "react-router-dom";
 import { icons } from "~/lib/icons";
 import { Icon } from "~/primitives/icon/icon";
 import { useState } from "react";

--- a/app/routes/volunteer/components/cards/volunteer-at-church-card.component.tsx
+++ b/app/routes/volunteer/components/cards/volunteer-at-church-card.component.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Link } from "react-router";
+import { Link } from "react-router-dom";
 import { Icon } from "~/primitives/icon/icon";
 import { CollectionItem } from "~/routes/page-builder/types";
 

--- a/app/routes/volunteer/loader.ts
+++ b/app/routes/volunteer/loader.ts
@@ -1,4 +1,4 @@
-import { LoaderFunctionArgs } from "react-router";
+import { LoaderFunctionArgs } from "react-router-dom";
 import {
   CommunityCard,
   RegionCard,

--- a/app/routes/volunteer/partials/volunteer-community.partial.tsx
+++ b/app/routes/volunteer/partials/volunteer-community.partial.tsx
@@ -4,7 +4,7 @@ import {
   RegionCardWrapper,
 } from "../components/cards/region-card.component";
 import { CommunityCard } from "../components/cards/community-card.component";
-import { useLoaderData } from "react-router";
+import { useLoaderData } from "react-router-dom";
 import { LoaderReturnType } from "../loader";
 import { ResourceCarousel } from "~/components/page-builder/resource-section.partial";
 import { Icon } from "~/primitives/icon/icon";

--- a/app/routes/volunteer/partials/volunteer-feature-event.partial.tsx
+++ b/app/routes/volunteer/partials/volunteer-feature-event.partial.tsx
@@ -1,5 +1,5 @@
 import { IconButton } from "~/primitives/button/icon-button.primitive";
-import { useLoaderData } from "react-router";
+import { useLoaderData } from "react-router-dom";
 import type { LoaderReturnType } from "../loader";
 import { cn } from "~/lib/utils";
 

--- a/app/routes/volunteer/partials/volunteer-globe.partial.tsx
+++ b/app/routes/volunteer/partials/volunteer-globe.partial.tsx
@@ -1,6 +1,6 @@
 import { SectionTitle } from "~/components/section-title";
 import { GlobalMap } from "../components/global-map.component";
-import { useLoaderData } from "react-router";
+import { useLoaderData } from "react-router-dom";
 import { Trip } from "../types";
 import { MissionTripCard } from "../components/cards/mission-trip-card.component";
 


### PR DESCRIPTION
## Summary
For web applications, all React Router hooks and components (such as useLocation, useLoaderData, useFetcher, Link, etc.) should be imported from react-router-dom instead of react-router. This is because react-router-dom provides the web-specific context and features required for routing to work correctly in the browser. Importing from react-router can lead to context mismatches and runtime errors, as it is the platform-agnostic core and does not include the necessary DOM bindings. Using react-router-dom ensures that all routing logic, hooks, and components are fully compatible with the web environment, preventing subtle bugs and improving maintainability.

## Testing
- Ensure website runs locally
- Ensure all tests run successfully