### PR TITLE
Article Hub Update

### DIFF
--- a/app/routes/articles/all-articles/all-articles-page.tsx
+++ b/app/routes/articles/all-articles/all-articles-page.tsx
@@ -29,14 +29,13 @@ export function AllArticlesPage() {
           <div className="flex flex-col gap-8">
             <div className="flex overflow-x-auto pb-1 w-full max-w-screen content-padding">
               {mockCategories.map((category, i) => (
-                <Link
-                  to={`/articles/category/${category.title}`}
-                  prefetch="intent"
+                // TODO: This might change to Algolia soon? - changes the results to that category (facet)
+                <div
                   key={i}
                   className="min-w-[170px] flex justify-between group px-2 border-b border-neutral-lighter "
                 >
                   <h3 className="font-semibold">{category.title}</h3>
-                </Link>
+                </div>
               ))}
             </div>
             <Articles />

--- a/app/routes/articles/all-articles/all-articles-page.tsx
+++ b/app/routes/articles/all-articles/all-articles-page.tsx
@@ -1,6 +1,11 @@
 import { DynamicHero } from "~/components";
-import { LatestArticles } from "./partials/latest.partial";
+import {
+  DesktopLatestArticles,
+  MobileLatestArticles,
+  mockCategories,
+} from "./partials/latest.partial";
 import { Articles } from "./partials/articles.partial";
+import { Link } from "react-router";
 
 export function AllArticlesPage() {
   return (
@@ -9,10 +14,33 @@ export function AllArticlesPage() {
         imagePath="/assets/images/articles-hero-bg.jpg"
         ctas={[{ href: "#testing", title: "Call to Action" }]}
       />
-      <div className="content-padding py-16 lg:pt-32 lg:pb-24">
-        <div className="flex-col flex md:flex-row justify-between gap-8 max-w-screen-content">
+      <div className="content-padding py-8 lg:pt-28 lg:pb-24">
+        {/* Desktop Layout */}
+        <div className="hidden md:flex flex-col md:flex-row justify-between gap-8 2xl:gap-16 max-w-screen-content">
           <Articles />
-          <LatestArticles />
+          <DesktopLatestArticles />
+        </div>
+
+        {/* Mobile Layout */}
+        <div className="flex flex-col gap-8 md:hidden">
+          <MobileLatestArticles />
+
+          {/* TODO: This might change to Algolia soon?*/}
+          <div className="flex flex-col gap-8">
+            <div className="flex overflow-x-auto pb-1 w-full max-w-screen content-padding">
+              {mockCategories.map((category, i) => (
+                <Link
+                  to={`/articles/category/${category.title}`}
+                  prefetch="intent"
+                  key={i}
+                  className="min-w-[170px] flex justify-between group px-2 border-b border-neutral-lighter "
+                >
+                  <h3 className="font-semibold">{category.title}</h3>
+                </Link>
+              ))}
+            </div>
+            <Articles />
+          </div>
         </div>
       </div>
     </div>

--- a/app/routes/articles/all-articles/loader.ts
+++ b/app/routes/articles/all-articles/loader.ts
@@ -1,6 +1,8 @@
 import { formatDate } from "date-fns";
 import { fetchRockData } from "~/lib/.server/fetch-rock-data";
 import { createImageUrlFromGuid } from "~/lib/utils";
+import { getAuthorDetails } from "../article-single/loader";
+import { AuthorProps } from "../article-single/partials/hero.partial";
 
 export type ArticlesReturnType = {
   recentArticles: Article[];
@@ -12,7 +14,11 @@ export type Article = {
   startDate: string;
   startDateTime: string;
   image: string;
+  content: string;
+  author: AuthorProps;
+  readTime: number;
   attributeValues: {
+    author: { value: string };
     summary: { value: string };
     image: { value: string };
     url: { value: string };
@@ -30,20 +36,29 @@ const getRecentArticles = async () => {
     },
   });
 
-  recentArticles.forEach((article: Article) => {
+  // Process each article to add author details and format data
+  for (const article of recentArticles) {
     if (article && article.attributeValues.image.value) {
       article.image = createImageUrlFromGuid(
         article.attributeValues.image.value
       );
     }
-  });
 
-  recentArticles.forEach((article: Article) => {
     article.startDate = formatDate(
       new Date(article.startDateTime),
       "MMMM d, yyyy"
     );
-  });
+
+    // Add author details
+    if (article.attributeValues.author?.value) {
+      article.author = await getAuthorDetails(
+        article.attributeValues.author.value
+      );
+    }
+
+    // Calculate read time
+    article.readTime = Math.round(article.content.split(" ").length / 200);
+  }
 
   return recentArticles;
 };
@@ -59,20 +74,29 @@ const getUpcomingArticles = async () => {
     },
   });
 
-  upcomingArticles.forEach((article: Article) => {
+  // Process each article to add author details and format data
+  for (const article of upcomingArticles) {
     if (article && article.attributeValues.image.value) {
       article.image = createImageUrlFromGuid(
         article.attributeValues.image.value
       );
     }
-  });
 
-  upcomingArticles.forEach((article: Article) => {
     article.startDate = formatDate(
       new Date(article.startDateTime),
       "MMMM d, yyyy"
     );
-  });
+
+    // Add author details
+    if (article.attributeValues.author?.value) {
+      article.author = await getAuthorDetails(
+        article.attributeValues.author.value
+      );
+    }
+
+    // Calculate read time
+    article.readTime = Math.round(article.content.split(" ").length / 200);
+  }
 
   return upcomingArticles;
 };

--- a/app/routes/articles/all-articles/partials/articles.partial.tsx
+++ b/app/routes/articles/all-articles/partials/articles.partial.tsx
@@ -1,51 +1,85 @@
 import { Link, useLoaderData } from "react-router-dom";
 import { Article, ArticlesReturnType } from "../loader";
-import Icon from "~/primitives/icon";
-import { Divider } from "./latest.partial";
 
 export const Articles = () => {
   const { upcomingArticles: articles } = useLoaderData<ArticlesReturnType>();
 
+  // TODO: This Articles might turn into hits from Algolai
   return (
-    <div className="flex flex-col gap-14">
+    <div className="content-padding md:px-0 grid grid-cols-1 gap-y-4">
       {articles.map((article, i) => (
-        <ArticlePanel article={article} key={i} />
+        <ArticleCard article={article} key={i} />
       ))}
     </div>
   );
 };
 
-const ArticlePanel = ({ article }: { article: Article }) => {
+const ArticleCard = ({ article }: { article: Article }) => {
+  const author = article.author || {
+    fullName: "Christ Fellowship Church",
+    photo: {
+      uri: "/logo.png",
+    },
+  };
+
   return (
     <Link
       to={`/articles/${article.attributeValues.url.value}`}
       prefetch="intent"
-      className="flex flex-col gap-5 w-full"
+      className="flex flex-col rounded-lg overflow-hidden max-w-[462px] w-full border border-neutral-lighter"
     >
-      <div className="flex flex-col gap-2">
-        <div className="w-full">
-          <img
-            src={article.image}
-            className="w-full h-auto object-cover"
-            alt={article.title}
-          />
+      {/* Article Image */}
+      <div className="relative">
+        <img
+          src={article.image}
+          className="w-full h-auto object-cover"
+          alt={article.title}
+        />
+
+        <div className="absolute top-3 left-3 bg-neutral-lightest p-2 rounded-[4px]">
+          <p className="font-semibold text-sm">
+            {/* TODO: Update to the Category */}
+            {article.startDate.toUpperCase()}
+          </p>
         </div>
-        <div className="flex flex-col">
-          <div className="flex items-center gap-2">
-            <Icon name="calendarAlt" size={16} />
-            <p className="font-medium text-text-secondary break-words">
-              {article.startDate.toUpperCase()}
-            </p>
+      </div>
+
+      {/* Article Content */}
+      <div className="p-6 flex flex-col gap-4">
+        {/* Article Title + Summary */}
+        <div className="flex flex-col gap-2">
+          <h3 className="font-extrabold text-lg break-words">
+            {article.title}
+          </h3>
+          <p className="break-words">{article.attributeValues.summary.value}</p>
+        </div>
+
+        {/* Article Author */}
+        <div className="flex gap-4 items-center">
+          {/* Author Image */}
+          <img
+            src={author?.photo?.uri}
+            alt="Article icon"
+            className="size-12 rounded-full object-cover"
+          />
+
+          {/* Author Name + Publish Date */}
+          <div className="flex flex-col gap-1">
+            <h4 className="font-semibold text-[17px] break-words">
+              {author?.fullName}
+            </h4>
+
+            <div className="flex">
+              {article.startDate && (
+                <p>
+                  {article.startDate}
+                  <span className="mx-2">•</span>
+                </p>
+              )}
+              {article.readTime && <p>{article.readTime} min read</p>}
+            </div>
           </div>
         </div>
-        <Divider />
-      </div>
-      <div className="w-full">
-        <h3 className="font-extrabold text-[36px] break-words">
-          {article.title}
-        </h3>
-        <p className="break-words">{article.attributeValues.summary.value}</p>
-        {/* TODO: Add CTA part */}
       </div>
     </Link>
   );

--- a/app/routes/articles/all-articles/partials/latest.partial.tsx
+++ b/app/routes/articles/all-articles/partials/latest.partial.tsx
@@ -20,7 +20,7 @@ export type Category = {
   articles: Article[];
 };
 
-const mockCategories: Category[] = [
+export const mockCategories: Category[] = [
   { amount: 12, title: "Study The Bible", articles: [] },
   { amount: 7, title: "Spiritual Growth", articles: [] },
   { amount: 4, title: "Personal Growth", articles: [] },
@@ -28,7 +28,7 @@ const mockCategories: Category[] = [
   { amount: 10, title: "Prayers", articles: [] },
 ];
 
-export const LatestArticles = () => {
+export const DesktopLatestArticles = () => {
   const { recentArticles: articles } = useLoaderData<ArticlesReturnType>();
 
   return (
@@ -44,7 +44,10 @@ export const LatestArticles = () => {
               prefetch="intent"
               className="flex items-center gap-5 cursor-pointer"
             >
-              <img src={article.image} className="size-18 object-cover" />
+              <img
+                src={article.image}
+                className="size-18 object-cover rounded-[4px] overflow-hidden"
+              />
               <div className="flex flex-col max-w-[220px]">
                 <p className="text-sm text-[#444]">{article.startDate}</p>
                 <h3 className="font-semibold text-lg leading-snug">
@@ -55,18 +58,79 @@ export const LatestArticles = () => {
             <Divider />
           </div>
         ))}
+
       <div className="flex flex-col gap-8">
         <h2 className="font-extrabold text-2xl">Article Category</h2>
         <div className="flex flex-col gap-4">
           {mockCategories.map((category, i) => (
-            <div key={i} className="flex justify-between">
-              <h3 className="font-bold text-lg">{category.title}</h3>
+            <Link
+              to={`/articles/category/${category.title}`}
+              prefetch="intent"
+              key={i}
+              className="flex justify-between group"
+            >
+              <h3 className="font-bold text-lg group-hover:text-text-secondary">
+                {category.title}
+              </h3>
               <p className="font-medium text-text-secondary">
                 ({category.amount})
               </p>
-            </div>
+            </Link>
           ))}
         </div>
+      </div>
+    </div>
+  );
+};
+
+export const MobileLatestArticles = () => {
+  const { recentArticles: articles } = useLoaderData<ArticlesReturnType>();
+
+  return (
+    <div className="flex flex-col gap-3 w-full max-w-screen content-padding">
+      <h2 className="font-extrabold text-2xl">Latest Posts</h2>
+
+      <div className="flex pb-1 gap-3 w-full overflow-x-auto">
+        {articles &&
+          articles.length > 0 &&
+          // Group articles into vertical pairs
+          Array.from(
+            { length: Math.ceil(articles.length / 2) },
+            (_, groupIndex) => {
+              const startIndex = groupIndex * 2;
+              const groupArticles = articles.slice(startIndex, startIndex + 2);
+
+              return (
+                <div
+                  key={groupIndex}
+                  className="flex flex-col gap-6 max-w-[90vw] min-w-[300px]"
+                >
+                  {groupArticles.map((article, i) => (
+                    <div key={startIndex + i}>
+                      <Link
+                        to={`/articles/${article.attributeValues.url.value}`}
+                        prefetch="intent"
+                        className="flex items-center gap-5 cursor-pointer"
+                      >
+                        <img
+                          src={article.image}
+                          className="size-16 object-cover rounded-[4px] overflow-hidden"
+                        />
+                        <div className="flex flex-col max-w-[220px]">
+                          <p className="text-sm text-[#444]">
+                            {article.startDate}
+                          </p>
+                          <h3 className="font-semibold text-lg leading-snug">
+                            {article.title}
+                          </h3>
+                        </div>
+                      </Link>
+                    </div>
+                  ))}
+                </div>
+              );
+            }
+          )}
       </div>
     </div>
   );

--- a/app/routes/articles/article-single/components/article-author.component.tsx
+++ b/app/routes/articles/article-single/components/article-author.component.tsx
@@ -38,7 +38,7 @@ export default function ArticleAuthor({
             prefetch="intent"
             className="underline hover:text-text-secondary"
           >
-            {author?.fullName || "Full Name"}
+            {author?.fullName || "Christ Fellowship Church"}
           </Link>
         </h2>
         <div className="flex text-neutral-500 font-normal">

--- a/app/routes/articles/article-single/loader.ts
+++ b/app/routes/articles/article-single/loader.ts
@@ -1,4 +1,4 @@
-import { data, type LoaderFunction } from "react-router-dom";
+import { type LoaderFunction } from "react-router-dom";
 import { fetchRockData, getImages } from "~/lib/.server/fetch-rock-data";
 import { AuthorProps } from "./partials/hero.partial";
 import { format } from "date-fns";


### PR DESCRIPTION
## Summary
This PR updates the Article Hub's page UI.

Some mobile changes are pending Algolia changes, since we will most likely change the page to use Algolia search because of the new Article Categories.
## Screenshots
<img width="1440" height="780" alt="Screenshot 2025-08-26 at 9 16 03 AM" src="https://github.com/user-attachments/assets/2b224d81-8a99-4902-8d47-0605507b3e83" />

## Testing
1. Ensure UI looks as designed for all views.

## Tickets
[CFDP-3598](https://christfellowshipchurch.atlassian.net/browse/CFDP-3598)