### PR TITLE
Updated Group Finder Index

### DIFF
--- a/app/routes/group-finder/components/group-hit.component.tsx
+++ b/app/routes/group-finder/components/group-hit.component.tsx
@@ -7,21 +7,36 @@ export const defaultLeaderPhoto =
 
 export function GroupHit({ hit }: { hit: GroupHitType }) {
   const coverImage = hit.coverImage?.sources?.[0]?.uri || "";
-  const preference = hit.preferences[0];
+  const preference = hit.groupFor;
 
-  // Format the date time to show just time with AM/PM and timezone
-  const formatTime = (dateTimeString: string) => {
+  // Format the time string to show time with AM/PM and timezone
+  const formatTime = (timeString: string) => {
     try {
-      const date = new Date(dateTimeString);
-      const hours = date.getHours();
-      const minutes = date.getMinutes();
+      // If the time string already contains AM/PM, return it as is
+      if (
+        timeString.toLowerCase().includes("am") ||
+        timeString.toLowerCase().includes("pm")
+      ) {
+        return timeString;
+      }
+
+      // Parse time string (expecting format like "12:00" or "14:30")
+      const [hoursStr, minutesStr] = timeString.split(":");
+      const hours = parseInt(hoursStr, 10);
+      const minutes = parseInt(minutesStr || "0", 10);
+
+      if (isNaN(hours) || isNaN(minutes)) {
+        return timeString; // Return original if parsing fails
+      }
+
       const ampm = hours >= 12 ? "PM" : "AM";
       const displayHours = hours % 12 || 12;
       const displayMinutes = minutes.toString().padStart(2, "0");
 
-      // Get timezone abbreviation and shorten it
+      // Get current timezone abbreviation
+      const now = new Date();
       const timeZone =
-        date
+        now
           .toLocaleTimeString("en-US", {
             timeZoneName: "short",
           })
@@ -42,7 +57,7 @@ export function GroupHit({ hit }: { hit: GroupHitType }) {
       return `${displayHours}:${displayMinutes}${ampm} ${shortTimeZone}`;
     } catch (error) {
       // Fallback to original format if parsing fails
-      return dateTimeString;
+      return timeString;
     }
   };
 
@@ -56,11 +71,11 @@ export function GroupHit({ hit }: { hit: GroupHitType }) {
       "Saturday",
       "Sunday",
     ];
-    const isDayOfWeek = daysOfWeek.some((day) => hit.meetingDay.includes(day));
+    const isDayOfWeek = daysOfWeek.some((day) => hit.meetingDays.includes(day));
 
-    return isDayOfWeek ? hit.meetingDay.slice(0, 3) : hit.meetingDay;
+    return isDayOfWeek ? hit.meetingDays.slice(0, 3) : hit.meetingDays;
   })();
-  const formattedMeetingTime = formatTime(hit.dateTime);
+  const formattedMeetingTime = formatTime(hit.meetingTime);
 
   const meetingInfo = formattedMeetingDay + " " + formattedMeetingTime;
 
@@ -89,7 +104,9 @@ export function GroupHit({ hit }: { hit: GroupHitType }) {
                     boxShadow:
                       "0px 5.114px 10.228px -2.557px rgba(0, 0, 0, 0.10), 0px 2.557px 5.114px -2.557px rgba(0, 0, 0, 0.06)",
                   }}
-                  src={hit.leaders[0].photo.uri || defaultLeaderPhoto}
+                  src={
+                    hit.leaders[0].photo.sources[0].uri || defaultLeaderPhoto
+                  }
                   alt={hit.leaders[0].firstName}
                 />
               )}
@@ -101,12 +118,11 @@ export function GroupHit({ hit }: { hit: GroupHitType }) {
               <div className="flex flex-col gap-[10px]">
                 <div
                   className={`${
-                    // TODO: Update the preference to the actual preference once updated
-                    preference === "Sisterhood"
+                    preference === "Women"
                       ? "bg-peach/15 text-[#B33A1B]"
-                      : preference === "Crew"
+                      : preference === "Men"
                       ? "bg-cotton-candy/15 text-cotton-candy"
-                      : preference === "Everyone"
+                      : preference === "Anyone"
                       ? "bg-ocean/15 text-ocean"
                       : // Couples
                         "bg-lemon/35 text-[#937200]"
@@ -124,19 +140,17 @@ export function GroupHit({ hit }: { hit: GroupHitType }) {
               </div>
             </div>
 
-            {/* TOOD: Separate tags and map them into TagButton */}
+            {/* Display topics as tags */}
             <div className="flex px-6 gap-2 pb-4">
-              {hit.subPreferences.map((subPreference, index) => (
-                <TagButton key={index} label={subPreference} />
+              {hit.topics.map((topic, index) => (
+                <TagButton key={index} label={topic} />
               ))}
             </div>
           </div>
 
           <div className="w-full px-6 flex justify-center gap-2 py-3 bg-navy text-white">
             <Icon name="map" size={20} color="white" />
-            <p className="text-center text-sm font-semibold">
-              {hit.campusName}
-            </p>
+            <p className="text-center text-sm font-semibold">{hit.campus}</p>
           </div>
         </div>
       </div>

--- a/app/routes/group-finder/partials/group-search.partial.tsx
+++ b/app/routes/group-finder/partials/group-search.partial.tsx
@@ -73,7 +73,7 @@ export const GroupSearch = () => {
   return (
     <div className="flex flex-col gap-4 w-full pt-12" id="search">
       <InstantSearch
-        indexName="production_Groups"
+        indexName="dev_daniel_Groups"
         searchClient={searchClient}
         future={{
           preserveSharedStateOnUnmount: true,

--- a/app/routes/group-finder/partials/group-search.partial.tsx
+++ b/app/routes/group-finder/partials/group-search.partial.tsx
@@ -194,7 +194,7 @@ const ResponsiveConfigure = ({
   const hitsPerPage = (() => {
     switch (true) {
       case isXLarge || isLarge:
-        return 16;
+        return 12;
       case isMedium:
         return 9;
       case isSmall:

--- a/app/routes/group-finder/types.ts
+++ b/app/routes/group-finder/types.ts
@@ -1,70 +1,62 @@
-export interface GroupHitType {
-  rockItemId: number;
-  title: string;
-  summary: string;
-  dateTime: string;
-  leaders: {
-    firstName: string;
-    lastName: string;
-    photo: {
-      uri: string;
-    };
+// Image source structure
+export interface ImageSource {
+  sources: {
+    uri: string;
   }[];
-  priority: number;
-  action: string;
-  campusName: string;
-  meetingTime: string;
-  meetingDay: string;
-  meetingType: string;
-  preferences: string[];
-  subPreferences: string[];
-  coverImage: {
-    sources: {
-      uri: string;
-    }[];
-  };
-  _typename: string;
-  objectID: string;
-  _highlightResult: {
-    title: {
-      value: string;
-      matchLevel: string;
-      matchedWords: string[];
-    };
-    summary: {
-      value: string;
-      matchLevel: string;
-      matchedWords: string[];
-    };
-    author: {
-      firstName: {
-        value: string;
-        matchLevel: string;
-        matchedWords: string[];
-      };
-      lastName: {
-        value: string;
-        matchLevel: string;
-        matchedWords: string[];
-      };
-    };
-    routing: {
-      pathname: {
-        value: string;
-        matchLevel: string;
-        matchedWords: string[];
-      };
-    };
-    htmlContent: {
-      value: string;
-      matchLevel: string;
-      matchedWords: string[];
-    }[];
-  };
-  __position: number;
 }
 
-export type ContactFormType = {
-  PersonId: string;
-  GroupId: string;
-};
+// New Group Finder Type we want to use
+export interface GroupHitType {
+  id: string;
+  title: string;
+  summary: string;
+  coverImage: ImageSource;
+  campus: string; //pick a campus
+  meetingLocationType: "Home" | "Church" | "Public Place";
+  meetingLocation: string;
+  meetingDays:
+    | "Monday"
+    | "Tuesday"
+    | "Wednesday"
+    | "Thursday"
+    | "Friday"
+    | "Saturday"
+    | "Sunday";
+  meetingTime: string;
+  meetingType: "In Person" | "Online";
+  meetingFrequency: "Weekly" | "Bi-Weekly" | "Monthly";
+  adultOnly: boolean;
+  childCareDescription?: string; // 100 characters max
+  leaders: Array<{
+    id: string;
+    firstName: string;
+    lastName: string;
+    photo: ImageSource;
+  }>;
+  groupFor: "Men" | "Women" | "Anyone" | "Couples"; // required to select one
+  peopleWhoAre?:
+    | "Single"
+    | "Married"
+    | "Divorced"
+    | "Engaged"
+    | "New Believer"
+    | "Parent"
+    | "Professional"; // can select up to 2
+  minAge: number;
+  maxAge: number;
+  language: "English" | "Spanish";
+  topics: Array<
+    | "Bible Study"
+    | "Prayer"
+    | "Message Discussion"
+    | "Marriage"
+    | "Parenting"
+    | "Finances"
+    | "Friendship"
+    | "Sports"
+    | "Activty/Hobby"
+    | "Book Club"
+    | "Watch Party"
+    | "Podcast"
+  >; // must select one or more, can select up to 3
+}


### PR DESCRIPTION
## Summary
This PR updates the Group Finder functionality to implement a new data structure and improve the user experience. The changes include:
- Updated the Group Finder to use the new Algolia index
- Migrated from the old GroupHitType structure to a new GroupHitType interface from the new Algolia index
- Improved time formatting logic to handle both pre-formatted time strings and raw time values
- Updated field mappings to match the new data structure (e.g., `meetingDay` → `meetingDays`, `preferences` → `groupFor`)
- Fixed image source handling to use the new nested structure
- Updated preference/group type mappings for better UI consistency
- Updated pagination to show 12 items per page on large screens (down from 16)

### NOTE
_**This update is NOT complete**_ and only updates the Algolia index we are pointing to and the GroupCards to read the new data. We still need to do the following for the Groups:
- Update all filters to match Figma/new index
- Update GroupSingle UI to match Figma/new index

## Screenshots
<img width="1463" height="1086" alt="image" src="https://github.com/user-attachments/assets/7e9f90a4-874c-4b45-b579-6c4d60ea4af7" />

## Testing
Tested the Group Finder with the new Algolia index:
- Confirmed group type badges display correctly with new mapping (Women/Men/Anyone/Couples)
- Tested image loading with new nested photo structure
- Verified topic tags display properly with new topics array
- Tested responsive behavior across different screen sizes

## Tickets
[CFDP-3611](https://christfellowshipchurch.atlassian.net/browse/CFDP-3611)