### PR TITLE
Feature Section Update

### DIFF
--- a/app/routes/page-builder/components/content-block/cta-card-section.tsx
+++ b/app/routes/page-builder/components/content-block/cta-card-section.tsx
@@ -15,13 +15,13 @@ export const CtaCardSection: FC<{ data: ContentBlockData }> = ({ data }) => {
     <section className="content-padding py-28" aria-label={data.name}>
       <div
         className={cn(
-          "flex flex-col md:flex-row gap-10",
+          "max-w-screen-content mx-auto flex flex-col md:flex-row gap-10",
           "md:items-center justify-between",
           "border border-neutral-lighter rounded-2xl p-8 md:p-12",
           `bg-${lowerCase(data.backgroundColor)}`
         )}
       >
-        <div className="flex-1 lg:max-w-[50%]">
+        <div className="flex-1 lg:max-w-[70%]">
           <h2
             className={cn("heading-h3 mb-4", {
               "text-white": isDark,

--- a/app/routes/page-builder/components/content-block/feature-section.tsx
+++ b/app/routes/page-builder/components/content-block/feature-section.tsx
@@ -54,9 +54,17 @@ export const FeatureSection: FC<{
   }[];
 }> = ({ data, customCtas }) => {
   const ctas = parseRockKeyValueList(data.callsToAction ?? "");
+  const slicedCtas = ctas.slice(0, 2);
+  const grayBg = data.backgroundColor === "GRAY" || null;
 
   return (
-    <section className={cn("content-padding py-16")} aria-label={data.name}>
+    <section
+      className={cn(
+        "content-padding py-16",
+        grayBg ? "bg-gray" : "bg-transparent"
+      )}
+      aria-label={data.name}
+    >
       <div
         className={cn(
           "flex flex-col md:flex-row gap-12 xl:gap-20 items-center max-w-screen-content mx-auto",
@@ -83,11 +91,13 @@ export const FeatureSection: FC<{
             html={data.content}
           />
           <div className="flex items-center sm:items-start flex-col-reverse md:flex-row flex-wrap gap-4 mt-10">
-            {ctas.slice(0, 2).map((cta, idx) => (
+            {slicedCtas.map((cta, idx) => (
               <Button
                 linkClassName="w-full px-6 sm:w-auto sm:px-0"
                 className="font-normal w-full"
-                intent={idx === 0 ? "white" : "primary"}
+                intent={
+                  slicedCtas.length > 1 && idx === 0 ? "white" : "primary"
+                }
                 key={idx}
                 href={cta.url}
               >

--- a/app/routes/page-builder/types.ts
+++ b/app/routes/page-builder/types.ts
@@ -108,7 +108,12 @@ export type ContentBlockImageLayout = "LEFT" | "RIGHT";
 /**
  * Background color options
  */
-export type ContentBlockBackgroundColor = "WHITE" | "OCEAN" | "NAVY" | string;
+export type ContentBlockBackgroundColor =
+  | "WHITE"
+  | "OCEAN"
+  | "NAVY"
+  | "GRAY"
+  | string;
 
 /**
  * Represents a Content Block section in the page builder


### PR DESCRIPTION
## Summary
This PR updates Featured Section to add Gray background color when in Rock and it fixes the buttons from the CTA to be primary if only one CTA is present. It also adds max width to the CTA Card Component which was missing.

## Screenshots
<img width="2560" height="1230" alt="Screenshot 2025-10-02 at 10 11 41 AM" src="https://github.com/user-attachments/assets/68f99e71-2727-4404-aaa0-39807b81e531" />

## Testing
- Navigate to [/careers](https://deploy-preview-131--cf-web-v3.netlify.app/careers) in the testing link.
- Ensure the Gray background color is working on the intended sections (the top section of the page). Check that on mobile it is also correct.
- Ensure the buttons there are set to primary.
- Ensure that buttons in [/ministries/marriage](https://deploy-preview-131--cf-web-v3.netlify.app/ministries/marriage) are still showing as desired (white first, primary second).
- Ensure that CTA Cards have a max width (easier to test on very large screens). 

## Tickets
[CFDP-3639](https://christfellowshipchurch.atlassian.net/browse/CFDP-3639)

### Key Features
- Featured Sections can now have a Gray background color.
- Featured Sections only display buttons as primary when only one is present.
- CTA Card Component now has a max width.

[CFDP-3639]: https://christfellowshipchurch.atlassian.net/browse/CFDP-3639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ