### PR TITLE
Volunteer Page | Stats Section

### DIFF
--- a/app/routes/volunteer-form/partials/welcome-screen.partial.tsx
+++ b/app/routes/volunteer-form/partials/welcome-screen.partial.tsx
@@ -10,33 +10,35 @@ export const VolunteerFormWelcome: React.FC = () => {
   }, []);
 
   return (
-    <section className="flex flex-col items-center justify-center py-10 bg-white rounded-xl shadow-md max-w-md gap-6 mb-24">
-      <h1 className="heading-h3">Help Me Find a Place</h1>
-      <p className="text-center text-text-secondary mb-10">
-        Thank you for your interest in volunteering with us. We're excited to
-        have you join our team.
-      </p>
-      <div className="grid grid-cols-3 items-center gap-2">
-        <div />
-        <Button
-          ref={buttonRef}
-          intent="primary"
-          href="/volunteer-form/about-you"
-          className="font-normal"
-          aria-label="Start Volunteer Form"
-          prefetch="viewport"
-        >
-          Get Started
-        </Button>
+    <section className="content-padding w-full">
+      <div className="px-4 flex flex-col items-center justify-center bg-white rounded-xl py-10 shadow-md max-w-md md:max-w-xl mx-auto gap-6 mb-24">
+        <h1 className="heading-h3 text-center">Help Me Find a Place</h1>
+        <p className="text-center text-text-secondary mb-10 max-w-md">
+          Thank you for your interest in volunteering with us. We're excited to
+          have you join our team.
+        </p>
+        <div className="grid grid-cols-3 items-center gap-2">
+          <div />
+          <Button
+            ref={buttonRef}
+            intent="primary"
+            href="/volunteer-form/about-you"
+            className="font-normal"
+            aria-label="Start Volunteer Form"
+            prefetch="viewport"
+          >
+            Get Started
+          </Button>
+          <span className="flex items-center gap-1 text-sm text-secondary">
+            Press <b>Enter</b>{" "}
+            <Icon name="arrowTopRight" className="size-5 text-ocean" />
+          </span>
+        </div>
         <span className="flex items-center gap-1 text-sm text-secondary">
-          Press <b>Enter</b>{" "}
-          <Icon name="arrowTopRight" className="size-5 text-ocean" />
+          <Icon name="timeFive" className="size-5 text-ocean" />
+          Takes 1 minute
         </span>
       </div>
-      <span className="flex items-center gap-1 text-sm text-secondary">
-        <Icon name="timeFive" className="size-5 text-ocean" />
-        Takes 1 minute
-      </span>
     </section>
   );
 };

--- a/app/routes/volunteer/components/animated-stat-value.component.tsx
+++ b/app/routes/volunteer/components/animated-stat-value.component.tsx
@@ -1,0 +1,217 @@
+import { useEffect, useRef, useState } from "react";
+
+import { cn } from "~/lib/utils";
+
+/**
+ * Webflow-style defaults (`baseDuration`, `cascadeStep`, `+1s` per counter),
+ * scaled ~15% faster (0.85×) so the first digit lands sooner and the cascade follows.
+ */
+export const DEFAULT_BASE_DURATION_MS = 3400;
+export const DEFAULT_CASCADE_STEP_MS = 340;
+export const DEFAULT_EXTRA_DURATION_PER_COUNTER_MS = 850;
+export const DEFAULT_EM_PER_ROW = 1.2;
+export const DEFAULT_INTERSECTION_THRESHOLD = 0.3;
+
+const DIGIT_ROUNDS = 3;
+
+function isStaticChar(digit: string, i: number, target: string): boolean {
+  const isFirstDollar = i === 0 && digit === "$";
+  const isLastSpecial =
+    i === target.length - 1 &&
+    (digit === "k" || digit === "+" || digit === "K");
+  const isSeparator = digit === "," || digit === ".";
+  return isFirstDollar || isLastSpecial || isSeparator;
+}
+
+function usePrefersReducedMotion(): boolean {
+  const [reduced, setReduced] = useState(false);
+
+  useEffect(() => {
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    setReduced(mq.matches);
+    const onChange = () => setReduced(mq.matches);
+    mq.addEventListener("change", onChange);
+    return () => mq.removeEventListener("change", onChange);
+  }, []);
+
+  return reduced;
+}
+
+function Digit({
+  digit,
+  durationMs,
+  emPerRow,
+}: {
+  digit: string;
+  durationMs: number;
+  emPerRow: number;
+}) {
+  const [collapsed, setCollapsed] = useState(false);
+  const [run, setRun] = useState(false);
+
+  useEffect(() => {
+    if (collapsed) return;
+    let raf2 = 0;
+    const raf1 = requestAnimationFrame(() => {
+      raf2 = requestAnimationFrame(() => setRun(true));
+    });
+    return () => {
+      cancelAnimationFrame(raf1);
+      cancelAnimationFrame(raf2);
+    };
+  }, [collapsed]);
+
+  const finalIndex = DIGIT_ROUNDS * 10;
+  const translateEm = finalIndex * emPerRow;
+
+  if (collapsed) {
+    return (
+      <span className="inline-flex h-[1.2em] min-w-[1ch] shrink-0 items-center justify-center font-black tabular-nums leading-none text-white">
+        {digit}
+      </span>
+    );
+  }
+
+  return (
+    <span className="inline-flex h-[1.2em] min-w-[1ch] shrink-0 overflow-hidden align-middle font-black tabular-nums leading-none text-white">
+      <span
+        className="flex flex-col will-change-transform"
+        style={{
+          transform: run ? `translateY(-${translateEm}em)` : "translateY(0)",
+          transition: run ? `transform ${durationMs}ms ease-out` : undefined,
+        }}
+        onTransitionEnd={(e) => {
+          if (e.propertyName !== "transform") return;
+          setCollapsed(true);
+        }}
+      >
+        {Array.from({ length: DIGIT_ROUNDS * 10 }, (_, idx) => (
+          <span
+            key={`d-${idx}`}
+            className="flex h-[1.2em] shrink-0 items-center justify-center leading-none"
+          >
+            {idx % 10}
+          </span>
+        ))}
+        <span className="flex h-[1.2em] shrink-0 items-center justify-center leading-none">
+          {digit}
+        </span>
+      </span>
+    </span>
+  );
+}
+
+export type AnimatedStatValueProps = {
+  value: string;
+  /** Adds length to the roll (same as Webflow’s `counterIndex * 1000`). */
+  statCounterIndex?: number;
+  className?: string;
+  baseDurationMs?: number;
+  cascadeStepMs?: number;
+  extraDurationPerCounterMs?: number;
+  emPerRow?: number;
+  /** IntersectionObserver threshold (Webflow used `0.3`). */
+  intersectionThreshold?: number;
+};
+
+/**
+ * Port of the Webflow “number counter”: in-view once, each digit is a vertical
+ * stack (0–9 × 3 + final), all rolls start together with staggered **durations**
+ * so columns land in sequence; `,` `.` and trailing `k`/`+` stay static.
+ */
+export function AnimatedStatValue({
+  value,
+  className,
+  statCounterIndex = 0,
+  baseDurationMs = DEFAULT_BASE_DURATION_MS,
+  cascadeStepMs = DEFAULT_CASCADE_STEP_MS,
+  extraDurationPerCounterMs = DEFAULT_EXTRA_DURATION_PER_COUNTER_MS,
+  emPerRow = DEFAULT_EM_PER_ROW,
+  intersectionThreshold = DEFAULT_INTERSECTION_THRESHOLD,
+}: AnimatedStatValueProps) {
+  const reducedMotion = usePrefersReducedMotion();
+  const containerRef = useRef<HTMLSpanElement>(null);
+  const [active, setActive] = useState(false);
+
+  useEffect(() => {
+    if (reducedMotion) {
+      setActive(true);
+      return;
+    }
+    const el = containerRef.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry?.isIntersecting) {
+          setActive(true);
+          observer.disconnect();
+        }
+      },
+      { threshold: intersectionThreshold },
+    );
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [reducedMotion, intersectionThreshold]);
+
+  const target = value.trim();
+  const extraDuration = statCounterIndex * extraDurationPerCounterMs;
+
+  if (reducedMotion || !active) {
+    return (
+      <span
+        ref={containerRef}
+        className={cn(
+          "inline-flex flex-wrap items-center font-black text-white",
+          className,
+        )}
+        aria-label={target}
+      >
+        {target}
+      </span>
+    );
+  }
+
+  return (
+    <span
+      ref={containerRef}
+      className={cn(
+        "inline-flex flex-wrap items-center font-black text-white",
+        className,
+      )}
+      aria-label={target}
+    >
+      <span className="inline-flex items-center" aria-hidden>
+        {[...target].map((ch, i) => {
+          if (isStaticChar(ch, i, target)) {
+            return (
+              <span
+                key={`${i}-${ch}`}
+                className="inline-flex h-[1.2em] shrink-0 items-center justify-center px-0.5 leading-none"
+              >
+                {ch}
+              </span>
+            );
+          }
+
+          const durationMs = Math.max(
+            510,
+            baseDurationMs +
+              extraDuration -
+              cascadeStepMs * (target.length - 1 - i),
+          );
+
+          return (
+            <Digit
+              key={`${i}-${ch}`}
+              digit={ch}
+              durationMs={durationMs}
+              emPerRow={emPerRow}
+            />
+          );
+        })}
+      </span>
+    </span>
+  );
+}

--- a/app/routes/volunteer/components/animated-stat-value.component.tsx
+++ b/app/routes/volunteer/components/animated-stat-value.component.tsx
@@ -2,9 +2,9 @@ import { useEffect, useRef, useState } from "react";
 
 import { cn } from "~/lib/utils";
 
-export const DEFAULT_BASE_DURATION_MS = 3400;
-export const DEFAULT_CASCADE_STEP_MS = 340;
-export const DEFAULT_EXTRA_DURATION_PER_COUNTER_MS = 850;
+export const DEFAULT_BASE_DURATION_MS = 1600;
+export const DEFAULT_CASCADE_STEP_MS = 150;
+export const DEFAULT_EXTRA_DURATION_PER_COUNTER_MS = 350;
 export const DEFAULT_EM_PER_ROW = 1.2;
 export const DEFAULT_INTERSECTION_THRESHOLD = 0.15;
 

--- a/app/routes/volunteer/components/animated-stat-value.component.tsx
+++ b/app/routes/volunteer/components/animated-stat-value.component.tsx
@@ -2,15 +2,11 @@ import { useEffect, useRef, useState } from "react";
 
 import { cn } from "~/lib/utils";
 
-/**
- * Webflow-style defaults (`baseDuration`, `cascadeStep`, `+1s` per counter),
- * scaled ~15% faster (0.85×) so the first digit lands sooner and the cascade follows.
- */
 export const DEFAULT_BASE_DURATION_MS = 3400;
 export const DEFAULT_CASCADE_STEP_MS = 340;
 export const DEFAULT_EXTRA_DURATION_PER_COUNTER_MS = 850;
 export const DEFAULT_EM_PER_ROW = 1.2;
-export const DEFAULT_INTERSECTION_THRESHOLD = 0.3;
+export const DEFAULT_INTERSECTION_THRESHOLD = 0.15;
 
 const DIGIT_ROUNDS = 3;
 
@@ -103,22 +99,16 @@ function Digit({
 
 export type AnimatedStatValueProps = {
   value: string;
-  /** Adds length to the roll (same as Webflow’s `counterIndex * 1000`). */
   statCounterIndex?: number;
   className?: string;
   baseDurationMs?: number;
   cascadeStepMs?: number;
   extraDurationPerCounterMs?: number;
   emPerRow?: number;
-  /** IntersectionObserver threshold (Webflow used `0.3`). */
+  /** IntersectionObserver threshold — fraction of the element that must be visible for animation to start (default `0.15`). */
   intersectionThreshold?: number;
 };
 
-/**
- * Port of the Webflow “number counter”: in-view once, each digit is a vertical
- * stack (0–9 × 3 + final), all rolls start together with staggered **durations**
- * so columns land in sequence; `,` `.` and trailing `k`/`+` stay static.
- */
 export function AnimatedStatValue({
   value,
   className,

--- a/app/routes/volunteer/partials/volunteer-church.partial.tsx
+++ b/app/routes/volunteer/partials/volunteer-church.partial.tsx
@@ -1,6 +1,5 @@
 import Icon from "~/primitives/icon";
 import { VolunteerAtChurchCarousel } from "../components/volunteer-at-church-carousel.component";
-import { Button } from "~/primitives/button/button.primitive";
 
 export function VolunteerAtChurch() {
   return (
@@ -21,27 +20,24 @@ export function VolunteerAtChurch() {
               <h2 className="text-[40px] font-extrabold leading-tight md:text-[52px]">
                 Volunteer <br className="md:hidden" /> At Church
               </h2>
-              <Button
-                href="/volunteer-form/welcome"
-                intent="primary"
-                size="lg"
-                className="min-w-[125px] w-full shrink-0 text-start bg-ocean-web text-white transition-all duration-300 text-sm text-bold hover:bg-navy md:w-fit flex md:hidden gap-2 rounded-[36px]"
-              >
-                <p>
-                  Help Me <br />
-                  <span className="text-dark-navy">Find My Fit</span>
-                </p>
-              </Button>
             </div>
           </div>
-
-          <a
-            href="/volunteer-form/welcome"
-            className="hidden w-full shrink-0 text-white transition-all duration-300 hover:translate-x-1 md:w-fit md:flex gap-2"
-          >
-            <p className="text-lg font-bold">Help Me Find My Fit</p>
-            <Icon name="arrowRight" className="text-white" size={24} />
-          </a>
+          <p className="flex min-w-0 flex-nowrap items-center gap-2 text-white md:text-lg font-bold">
+            <span className="shrink-0">Don&apos;t know?</span>
+            <a
+              href="/volunteer-form/welcome"
+              className="inline-flex shrink-0 items-center gap-2 transition-all duration-300 hover:translate-x-1"
+            >
+              <span className="underline md:no-underline">
+                Help Me Find My Fit
+              </span>
+              <Icon
+                name="arrowRight"
+                className="shrink-0 text-white"
+                size={24}
+              />
+            </a>
+          </p>
         </div>
 
         <VolunteerAtChurchCarousel />

--- a/app/routes/volunteer/partials/volunteer-stats.partial.tsx
+++ b/app/routes/volunteer/partials/volunteer-stats.partial.tsx
@@ -1,98 +1,107 @@
 import { cn } from "~/lib/utils";
 
-interface Stat {
-  year?: string;
-  label: string;
+type ImpactStat = {
   value: string;
-}
-
-interface Avatar {
-  src: string;
-  alt: string;
-}
-
-interface VolunteerStatsProps {
-  stats: Stat[];
-  avatars: Avatar[];
-  avatarCount: number;
-}
-
-const defaultStats: VolunteerStatsProps = {
-  stats: [
-    { year: "2024", label: "Volunteers served", value: "14,378" },
-    {
-      year: "2024",
-      label: "People impacted through missions outreach",
-      value: "108k",
-    },
-    { year: "2024", label: "International Missions Trips", value: "15" },
-  ],
-  avatars: [
-    { src: "https://picsum.photos/id/1011/70/70", alt: "Avatar 1" },
-    { src: "https://picsum.photos/id/1012/70/70", alt: "Avatar 2" },
-    { src: "https://picsum.photos/id/1015/70/70", alt: "Avatar 3" },
-    { src: "https://picsum.photos/id/1016/70/70", alt: "Avatar 4" },
-  ],
-  avatarCount: 3456,
+  label: string;
 };
 
-export function VolunteerStats(props: Partial<VolunteerStatsProps> = {}) {
-  const {
-    stats = defaultStats.stats,
-    avatars = defaultStats.avatars,
-    avatarCount = defaultStats.avatarCount,
-  } = props ?? {};
+const IMPACT_STATS_ROW1: ImpactStat[] = [
+  {
+    value: "695k+",
+    label: "People impacted through our mission efforts.",
+  },
+  { value: "13k+", label: "Volunteers served" },
+  {
+    value: "8,010",
+    label: "People said “yes” to Jesus.",
+  },
+  {
+    value: "639k+",
+    label: "Kids received hot meals in 39 different countries.",
+  },
+];
 
+const IMPACT_STATS_ROW2: ImpactStat[] = [
+  {
+    value: "42k+",
+    label: "People served by the food truck in our community.",
+  },
+  {
+    value: "41",
+    label: "Disasters responded to locally & globally",
+  },
+  {
+    value: "427k",
+    label: "Food distributed to the Missions Center.",
+  },
+  {
+    value: "2,794",
+    label: "People were baptized, declaring their faith.",
+  },
+];
+
+function StatCell({ value, label }: ImpactStat) {
   return (
-    <section id="stats" className="w-full bg-white py-20 content-padding">
-      <div className="max-w-screen-content mx-auto flex flex-col md:flex-row items-start justify-between gap-8">
-        <div className="grid grid-cols-1 md:grid-cols-2 xl:flex w-full gap-6 justify-between items-end">
-          {stats.map((stat, _idx) => (
-            <div
-              className="flex flex-col-reverse lg:flex-col items-start justify-between h-full xl:min-w-[278px]"
-              key={stat.label}
-            >
-              <div
-                className={cn(
-                  "w-full border-b-2 border-neutral-lighter",
-                  "text-neutral-default font-bold",
-                  "mb-1 pt-1",
-                  "grid grid-cols-3 gap-2",
-                  "md:flex md:justify-between md:items-end"
-                )}
-              >
-                <span className="col-span-1">
-                  {stat.year && `${stat.year}`}
-                </span>
-                <span className="col-span-2 text-right text-pretty pl-8">
-                  {stat.label}
-                </span>
-              </div>
-              <div className="text-ocean text-[52px] lg:text-7xl font-extrabold">
-                {stat.value}
-              </div>
-            </div>
-          ))}
-          <div className="flex flex-col-reverse lg:flex-col items-start min-w-[288px]">
-            <div className="w-full border-b-2 border-neutral-lighter text-neutral-default font-bold mb-1 pt-1">
-              More than, 3.4k Dream Team
-            </div>
-            <div className="flex items-center mb-6 lg:mb-0 mt-2">
-              <div className="flex -space-x-4">
-                {avatars.map((avatar, i) => (
-                  <img
-                    key={i}
-                    src={avatar.src}
-                    alt={avatar.alt}
-                    className="w-[64px] h-[64px] rounded-full shadow-md"
-                  />
-                ))}
-                <div className="w-[64px] h-[64px] rounded-full bg-ocean text-white flex items-center justify-center  shadow-md">
-                  {avatarCount.toLocaleString()}
-                </div>
-              </div>
-            </div>
+    <div className="flex min-w-0 flex-col gap-3">
+      <p className="text-[40px] font-black leading-none tracking-tight text-white md:text-[52px] lg:text-[72px]">
+        {value}
+      </p>
+      <p className="text-pretty font-medium leading-snug text-ocean-web lg:text-lg">
+        {label}
+      </p>
+    </div>
+  );
+}
+
+function StatRow({
+  items,
+  className,
+}: {
+  items: ImpactStat[];
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "grid grid-cols-2 gap-10 sm:grid-cols-2 sm:gap-x-8 sm:gap-y-12 md:grid-cols-4 lg:gap-x-8",
+        className,
+      )}
+    >
+      {items.map((stat) => (
+        <StatCell key={stat.label} {...stat} />
+      ))}
+    </div>
+  );
+}
+
+export function VolunteerStats() {
+  return (
+    <section
+      id="stats"
+      className="w-full bg-dark-navy text-white content-padding"
+    >
+      <div className="mx-auto flex w-full max-w-[1280px] flex-col py-16 md:py-24 lg:py-28">
+        <header className="flex flex-col gap-4">
+          <div className="flex items-center gap-4">
+            <div className="h-1 w-8 shrink-0 bg-ocean-web" aria-hidden />
+            <h3 className="text-xl font-extrabold leading-none text-ocean-web">
+              Impact 2025
+            </h3>
           </div>
+          <h2 className="text-pretty text-[32px] font-extrabold leading-tight text-white md:text-[40px] lg:text-[52px]">
+            Real Change Through Collective Action
+          </h2>
+        </header>
+
+        <div
+          className="my-10 h-px w-full bg-white/25 md:my-12 lg:my-14"
+          role="presentation"
+        />
+
+        <div className="flex flex-col gap-10 pr-5 md:pr-12 lg:pr-0 md:gap-12 lg:gap-14">
+          <StatRow items={IMPACT_STATS_ROW1} />
+          <div className="h-px w-full bg-white/25" role="presentation" />
+          <StatRow items={IMPACT_STATS_ROW2} />
         </div>
       </div>
     </section>

--- a/app/routes/volunteer/partials/volunteer-stats.partial.tsx
+++ b/app/routes/volunteer/partials/volunteer-stats.partial.tsx
@@ -1,5 +1,7 @@
 import { cn } from "~/lib/utils";
 
+import { AnimatedStatValue } from "../components/animated-stat-value.component";
+
 type ImpactStat = {
   value: string;
   label: string;
@@ -40,14 +42,20 @@ const IMPACT_STATS_ROW2: ImpactStat[] = [
   },
 ];
 
-function StatCell({ value, label }: ImpactStat) {
+function StatCell({
+  stat,
+  statCounterIndex,
+}: {
+  stat: ImpactStat;
+  statCounterIndex: number;
+}) {
   return (
     <div className="flex min-w-0 flex-col gap-3">
       <p className="text-[40px] font-black leading-none tracking-tight text-white md:text-[52px] lg:text-[72px]">
-        {value}
+        <AnimatedStatValue value={stat.value} statCounterIndex={statCounterIndex} />
       </p>
       <p className="text-pretty font-medium leading-snug text-ocean-web lg:text-lg">
-        {label}
+        {stat.label}
       </p>
     </div>
   );
@@ -56,9 +64,11 @@ function StatCell({ value, label }: ImpactStat) {
 function StatRow({
   items,
   className,
+  counterIndexStart,
 }: {
   items: ImpactStat[];
   className?: string;
+  counterIndexStart: number;
 }) {
   return (
     <div
@@ -67,8 +77,12 @@ function StatRow({
         className,
       )}
     >
-      {items.map((stat) => (
-        <StatCell key={stat.label} {...stat} />
+      {items.map((stat, idx) => (
+        <StatCell
+          key={stat.label}
+          stat={stat}
+          statCounterIndex={counterIndexStart + idx}
+        />
       ))}
     </div>
   );
@@ -99,9 +113,12 @@ export function VolunteerStats() {
         />
 
         <div className="flex flex-col gap-10 pr-5 md:pr-12 lg:pr-0 md:gap-12 lg:gap-14">
-          <StatRow items={IMPACT_STATS_ROW1} />
+          <StatRow items={IMPACT_STATS_ROW1} counterIndexStart={0} />
           <div className="h-px w-full bg-white/25" role="presentation" />
-          <StatRow items={IMPACT_STATS_ROW2} />
+          <StatRow
+            items={IMPACT_STATS_ROW2}
+            counterIndexStart={IMPACT_STATS_ROW1.length}
+          />
         </div>
       </div>
     </section>

--- a/app/routes/volunteer/partials/volunteer-stats.partial.tsx
+++ b/app/routes/volunteer/partials/volunteer-stats.partial.tsx
@@ -52,7 +52,10 @@ function StatCell({
   return (
     <div className="flex min-w-0 flex-col gap-3">
       <p className="text-[40px] font-black leading-none tracking-tight text-white md:text-[52px] lg:text-[72px]">
-        <AnimatedStatValue value={stat.value} statCounterIndex={statCounterIndex} />
+        <AnimatedStatValue
+          value={stat.value}
+          statCounterIndex={statCounterIndex}
+        />
       </p>
       <p className="text-pretty font-medium leading-snug text-ocean-web lg:text-lg">
         {stat.label}
@@ -103,7 +106,8 @@ export function VolunteerStats() {
             </h3>
           </div>
           <h2 className="text-pretty text-[32px] font-extrabold leading-tight text-white md:text-[40px] lg:text-[52px]">
-            Real Change Through Collective Action
+            Real Change{" "}
+            <span className="hidden md:inline">Through Collective Action</span>
           </h2>
         </header>
 


### PR DESCRIPTION
## Summary
Refactors the Volunteer **Impact / stats** block to the new **Impact 2025** copy and grid, and replaces the old stats + avatar layout with a **Webflow-style vertical number counter** implemented in React. Each stat value scrolls through stacked digits once the block is in view, with staggered settle timing per column; commas, periods, and trailing `k`/`+` render as static characters. Removes the previous placeholder avatars / Picsum data and simplifies the section to static content + `AnimatedStatValue`.

This PR also updates the mobile title for the Community Volunteer section.

## Screenshots
<img width="1460" height="848" alt="Screenshot 2026-04-21 at 10 19 46 AM" src="https://github.com/user-attachments/assets/4473a390-e9c0-4aee-bc66-0cb56fdc1c88" />

## Testing
- [ ] Open `/volunteer`, scroll to the stats section: numbers show as plain text until the block crosses the observer threshold (~15% visible), then each cell animates once.
- [ ] Confirm copy and layout for both rows (four columns on `md+`, two on smaller breakpoints).
- [ ] Verify `prefers-reduced-motion: reduce`: values show immediately without the roll animation.
- [ ] Run `pnpm run check` no new issues expected for touched files.

## Tickets
[CFDP-3896](https://christfellowshipchurch.atlassian.net/browse/CFDP-3896)

## Changes Made

### New Components Added
- **`app/routes/volunteer/components/animated-stat-value.component.tsx`** — `AnimatedStatValue` with internal `IntersectionObserver` (default threshold `0.3`), per-digit vertical stacks (`0–9` × 3 + final digit), `ease-out` transform duration formula aligned with Webflow (`baseDuration`, `cascadeStep`, extra per `statCounterIndex`), `transitionend` collapse to a single digit span, and configurable defaults (`DEFAULT_BASE_DURATION_MS`, `DEFAULT_CASCADE_STEP_MS`, etc.). Includes `Digit` sub-component and static-character rules for `$`, separators, and trailing `k`/`K`/`+`.

### New Utilities
- None (logic is colocated in the component above).

### New Assets
- None.

### Dependencies
- None — `package.json` unchanged vs `main` for this diff.

### Route Implementation
- **`app/routes/volunteer/partials/volunteer-stats.partial.tsx`** — Replaces legacy props-driven stats + avatars with fixed **Impact 2025** data (`IMPACT_STATS_ROW1` / `IMPACT_STATS_ROW2`), `StatCell` / `StatRow` helpers, and `AnimatedStatValue` with `statCounterIndex` (0–7) for per-cell timing. Section structure, headings, and dividers preserved for the new content.

### Key Features
- **Scroll-triggered, run-once** counter animation per stat string (observer disconnects after first trigger).
- **Accessible**: `aria-label` on the value; reduced-motion path skips animation.
- **Performance / cleanup**: `will-change-transform` during roll; stacks collapse to minimal DOM after each digit’s `transform` transition ends.

[CFDP-3896]: https://christfellowshipchurch.atlassian.net/browse/CFDP-3896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ