### PR TITLE
Locations Finder Bug Fixes + Clean Up

### DIFF
--- a/app/lib/__tests__/utils.test.ts
+++ b/app/lib/__tests__/utils.test.ts
@@ -363,6 +363,24 @@ describe("formattedServiceTimes", () => {
     const result = formattedServiceTimes("Sunday^10:00 AM");
     expect(result).toEqual([{ day: "Sunday", hour: ["10:00 AM"] }]);
   });
+
+  it("drops OnDemand segments (e.g. online campus trailing OnDemand^)", () => {
+    const result = formattedServiceTimes(
+      "Sunday^8:15AM|Sunday^9:45AM|Sunday^11:30AM|OnDemand^",
+    );
+    expect(result).toEqual([
+      { day: "Sunday", hour: ["8:15AM", "9:45AM", "11:30AM"] },
+    ]);
+  });
+
+  it("drops OnDemand case-insensitively", () => {
+    expect(
+      formattedServiceTimes("Sunday^9:00 AM|ONDEMAND^|Saturday^5:00 PM"),
+    ).toEqual([
+      { day: "Sunday", hour: ["9:00 AM"] },
+      { day: "Saturday", hour: ["5:00 PM"] },
+    ]);
+  });
 });
 
 describe("ensureArray", () => {

--- a/app/lib/dev-web-vitals.ts
+++ b/app/lib/dev-web-vitals.ts
@@ -6,8 +6,13 @@
  * dispatched entry (no firstHiddenTime filter) so you can see whether the browser
  * emits LCP at all — `onLCP` can stay silent if supportedEntryTypes omits LCP or
  * if web-vitals filters every entry.
+ *
+ * Master switch: `DEV_WEB_VITALS_ENABLED` below — set false to disable all logging.
  */
 import { onFCP, onLCP } from "web-vitals";
+
+/** Set to `true` to turn dev / `?debugWebVitals=1` logging back on. */
+const DEV_WEB_VITALS_ENABLED = false;
 
 /**
  * User-Agent Client Hints (`navigator.userAgentData`). Optional on DOM typings;
@@ -191,6 +196,10 @@ function registerRawLcpObserver(): void {
 }
 
 export function setupDevWebVitalsLogging(): void {
+  if (!DEV_WEB_VITALS_ENABLED) {
+    return;
+  }
+
   if (typeof window === "undefined") {
     return;
   }

--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -286,13 +286,19 @@ export type dayTimes = {
 
 export const formattedServiceTimes = (serviceTimes: string) =>
   serviceTimes.split("|").reduce((acc: dayTimes[], time: string) => {
-    const [day, hour] = time.split("^");
-    const existingDay = acc.find((item) => item.day === day.trim());
+    const trimmed = time.trim();
+    if (!trimmed) return acc;
+
+    const [day, hour] = trimmed.split("^");
+    const dayTrimmed = day?.trim() ?? "";
+    if (dayTrimmed.toLowerCase() === "ondemand") return acc;
+
+    const existingDay = acc.find((item) => item.day === dayTrimmed);
 
     if (existingDay) {
       existingDay.hour.push(hour);
     } else {
-      acc.push({ day, hour: [hour] });
+      acc.push({ day: dayTrimmed, hour: [hour] });
     }
 
     return acc;

--- a/app/routes/home/components/location-search/location-hit.tsx
+++ b/app/routes/home/components/location-search/location-hit.tsx
@@ -63,12 +63,16 @@ const HitContent = ({ hit }: { hit: Hit<CampusHitType> | CampusHitType }) => {
       />
       <div className="flex flex-col">
         <h3 className="text-xs text-black font-bold">{hit.campusName}</h3>
-        {hit?.campusLocation && (
+        {isOnline ? (
+          <p className="text-xs font-medium text-text-secondary">
+            On Demand on
+          </p>
+        ) : hit?.campusLocation ? (
           <p className="text-xs font-medium text-text-secondary">
             {street1}
             {street2 && ` ${street2}`}, {city}
           </p>
-        )}
+        ) : null}
         <p className="text-xs text-black font-semibold">
           {serviceTimes.map((service, index) => (
             <span key={index}>

--- a/app/routes/home/components/location-search/location-search-inner.component.tsx
+++ b/app/routes/home/components/location-search/location-search-inner.component.tsx
@@ -4,7 +4,7 @@ import { Configure, InstantSearch } from "react-instantsearch";
 import { useFetcher, useLoaderData } from "react-router-dom";
 import { getCurrentPositionFromUserGesture } from "~/lib/browser-geolocation";
 import { SearchPopup } from "./search-popup";
-import { cn } from "~/lib/utils";
+import { cn, isValidZip } from "~/lib/utils";
 import { emptySearchClient } from "~/routes/search/route";
 import { globalSearchClient } from "~/routes/search/route";
 import { SearchBar } from "./search-bar";
@@ -20,6 +20,8 @@ export function LocationSearchInner({
   const { ALGOLIA_APP_ID, ALGOLIA_SEARCH_API_KEY } =
     useLoaderData<typeof loader>();
   const geocodeFetcher = useFetcher();
+  const geocodeFetcherRef = useRef(geocodeFetcher);
+  geocodeFetcherRef.current = geocodeFetcher;
 
   const locationSearchBarRef = useRef<HTMLDivElement>(null);
   const [internalIsSearching, setInternalIsSearching] = useState(false);
@@ -57,20 +59,20 @@ export function LocationSearchInner({
     return () => {
       document.removeEventListener("mousedown", handleClickOutside);
     };
-  }, []);
+  }, [setIsSearching]);
 
-  const handleSearch = (query: string | null) => {
-    if (!query) {
+  const handleSearch = useCallback((query: string | null) => {
+    if (!query || query.length !== 5 || !isValidZip(query)) {
       setCoordinates(null);
       return;
     }
     const formData = new FormData();
     formData.append("address", query);
-    geocodeFetcher.submit(formData, {
+    geocodeFetcherRef.current.submit(formData, {
       method: "post",
       action: "/google-geocode",
     });
-  };
+  }, []);
 
   const handlePreciseLocationRequest = useCallback(() => {
     getCurrentPositionFromUserGesture(
@@ -86,12 +88,18 @@ export function LocationSearchInner({
     );
   }, []);
 
+  const geocodeLat =
+    geocodeFetcher.data?.results?.[0]?.geometry?.location?.lat ?? null;
+  const geocodeLng =
+    geocodeFetcher.data?.results?.[0]?.geometry?.location?.lng ?? null;
+
   useEffect(() => {
-    if (geocodeFetcher.data?.results?.[0]?.geometry?.location) {
-      const { lat, lng } = geocodeFetcher.data.results[0].geometry.location;
-      setCoordinates({ lat, lng });
-    }
-  }, [geocodeFetcher.data]);
+    if (geocodeLat == null || geocodeLng == null) return;
+    setCoordinates((prev) => {
+      if (prev?.lat === geocodeLat && prev?.lng === geocodeLng) return prev;
+      return { lat: geocodeLat, lng: geocodeLng };
+    });
+  }, [geocodeLat, geocodeLng]);
 
   return (
     <div className={cn(isSearching && "mt-32")} ref={locationSearchBarRef}>

--- a/app/routes/home/components/location-search/search-bar.tsx
+++ b/app/routes/home/components/location-search/search-bar.tsx
@@ -1,45 +1,72 @@
-import { SearchBox } from "react-instantsearch";
-
-import { useEffect, useState } from "react";
+import {
+  useEffect,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type FormEvent,
+} from "react";
 import { useSearchBox } from "react-instantsearch";
+
 import { cn, isValidZip } from "~/lib/utils";
 import Icon from "~/primitives/icon";
 
 export const SearchBar = ({
   onSearchStateChange,
   onSearchSubmit,
+  "data-gtm": dataGtm,
 }: {
   onSearchStateChange: (isSearching: boolean) => void;
   onSearchSubmit: (query: string | null) => void;
+  "data-gtm"?: string;
 }) => {
-  const { query, refine } = useSearchBox();
-  const [zipCode, setZipCode] = useState<string | null>(null);
+  const { refine } = useSearchBox();
+  const [inputValue, setInputValue] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
-    if (query.length === 5 && isValidZip(query)) {
+    refine("");
+  }, [refine]);
+
+  const syncFromInput = (raw: string) => {
+    setInputValue(raw);
+    refine("");
+
+    const trimmed = raw.trim();
+    if (trimmed.length === 5 && isValidZip(trimmed)) {
       onSearchStateChange(true);
-      setZipCode(query);
-    } else if (zipCode) {
-      onSearchStateChange(true);
+      onSearchSubmit(trimmed);
     } else {
-      onSearchStateChange(!!query);
+      onSearchSubmit(null);
+      onSearchStateChange(!!raw.trim());
     }
-  }, [query, onSearchStateChange]);
+  };
 
-  // When the zip code is set, search for it and clear the query so the query doesn't interfere with the geo search
-  useEffect(() => {
-    if (zipCode) {
-      onSearchSubmit(zipCode);
-      refine("");
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    syncFromInput(e.target.value);
+  };
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    const trimmed = inputValue.trim();
+    refine("");
+    if (trimmed.length === 5 && isValidZip(trimmed)) {
+      onSearchStateChange(true);
+      onSearchSubmit(trimmed);
+    } else {
+      onSearchSubmit(null);
+      onSearchStateChange(!!trimmed);
     }
-  }, [zipCode]);
+    inputRef.current?.blur();
+  };
 
   return (
-    <div
+    <form
       className={cn(
         "flex w-full items-center gap-4 rounded-full p-1",
-        query ? "bg-gray" : "bg-white",
+        inputValue ? "bg-gray" : "bg-white",
       )}
+      data-gtm={dataGtm}
+      onSubmit={handleSubmit}
     >
       <button
         type="submit"
@@ -53,18 +80,17 @@ export const SearchBar = ({
         />
       </button>
 
-      <SearchBox
+      <input
+        ref={inputRef}
+        type="text"
+        inputMode="numeric"
+        autoComplete="postal-code"
+        value={inputValue}
+        onChange={handleChange}
         placeholder="Search by zip code"
-        classNames={{
-          root: "flex-grow w-full",
-          form: "flex",
-          input: `w-full justify-center text-black px-3 outline-none appearance-none`,
-          reset: "hidden",
-          loadingIndicator: "hidden",
-          resetIcon: "hidden",
-          submit: "hidden",
-        }}
+        className="w-full grow justify-center text-black px-3 outline-none appearance-none bg-transparent"
+        aria-label="Zip code"
       />
-    </div>
+    </form>
   );
 };

--- a/app/routes/locations/location-search/location-search-page.tsx
+++ b/app/routes/locations/location-search/location-search-page.tsx
@@ -101,7 +101,8 @@ export function LocationSearchPage() {
   );
 
   const geocodeFetcher = useFetcher();
-  const googleFetcher = useFetcher();
+  const geocodeFetcherRef = useRef(geocodeFetcher);
+  geocodeFetcherRef.current = geocodeFetcher;
 
   const handleSearch = useCallback(
     (query: string | null) => {
@@ -111,12 +112,12 @@ export function LocationSearchPage() {
       }
       const formData = new FormData();
       formData.append("address", query);
-      geocodeFetcher.submit(formData, {
+      geocodeFetcherRef.current.submit(formData, {
         method: "post",
         action: "/google-geocode",
       });
     },
-    [setSearchCoordinates, geocodeFetcher],
+    [setSearchCoordinates],
   );
 
   useEffect(() => {
@@ -169,13 +170,19 @@ export function LocationSearchPage() {
     });
   }, []);
 
+  const geocodeLat =
+    geocodeFetcher.data?.results?.[0]?.geometry?.location?.lat ?? null;
+  const geocodeLng =
+    geocodeFetcher.data?.results?.[0]?.geometry?.location?.lng ?? null;
+
   useEffect(() => {
-    if (geocodeFetcher.data?.results?.[0]?.geometry?.location) {
-      campusScrollUsesNavbarOffsetRef.current = true;
-      const { lat, lng } = geocodeFetcher.data.results[0].geometry.location;
-      setCoordinates({ lat, lng });
-    }
-  }, [geocodeFetcher.data]);
+    if (geocodeLat == null || geocodeLng == null) return;
+    campusScrollUsesNavbarOffsetRef.current = true;
+    setCoordinates((prev) => {
+      if (prev?.lat === geocodeLat && prev?.lng === geocodeLng) return prev;
+      return { lat: geocodeLat, lng: geocodeLng };
+    });
+  }, [geocodeLat, geocodeLng]);
 
   useEffect(() => {
     if (
@@ -259,7 +266,7 @@ export function LocationSearchPage() {
             coordinates={coordinates}
             setSearchCoordinates={setSearchCoordinates}
             handleSearch={handleSearch}
-            geocodeLoading={googleFetcher.state === "loading"}
+            geocodeLoading={geocodeFetcher.state === "loading"}
           />
         </InstantSearch>
       )}


### PR DESCRIPTION
## Summary
This branch fixes unstable geocode + React state behavior on the locations finder and tightens the home hero location search so Algolia is not filtered by arbitrary text.

**Locations finder (`location-search-page.tsx`):** Stops a “Maximum update depth exceeded” loop caused by `useEffect` depending on `geocodeFetcher.data` (new object references) and `setCoordinates` always receiving a new object. Geocode results are applied using stable `lat`/`lng` primitives, functional `setCoordinates` to skip no-op updates, and a ref for `geocodeFetcher.submit` so `handleSearch` stays stable. Loading state now correctly uses `geocodeFetcher` instead of an unused `googleFetcher`.

**Home location search:** Replaces InstantSearch `SearchBox` with a controlled zip input that always `refine("")` so the index query never filters by typed text. Geocoding / geo ranking runs only for a valid **5-digit** zip (`isValidZip`). Any other input clears coordinates and leaves default campus ordering. The inner component uses the same safe geocode application pattern and a stable `handleSearch` callback.

## Screenshots

## Testing

- [x] `pnpm run check` — passes, no new errors
- [x] **Locations** (`/locations` search): load page, search by zip, confirm no console “Maximum update depth” error and results update
- [x] **Home** hero search: type non-zip text — hits stay default order; type valid 5-digit zip — geocode + distance ordering; clear input — geo cleared
- [ ] **Home** “Use my precise location” still applies geo when chosen from the popup

## Tickets
[CFDP-3920](https://christfellowshipchurch.atlassian.net/browse/CFDP-3920)

## Changes Made

### New Components Added

- None

### New Utilities

- None

### New Assets

- None

### Dependencies

- None

### Route Implementation

- `app/routes/locations/location-search/location-search-page.tsx` — geocode fetcher ref, primitive-backed geocode effect, functional coordinate updates, correct loading fetcher
- `app/routes/home/components/location-search/location-search-inner.component.tsx` — zip-only geocode guard, stable `handleSearch`, safe geocode `useEffect`, click-outside effect deps
- `app/routes/home/components/location-search/search-bar.tsx` — controlled input + form; no `SearchBox` text query; optional `data-gtm` on form

### Key Features

- Eliminates infinite re-render risk from geocode fetcher data on the locations finder
- Home hero search: location filtering **only** for valid 5-digit zip; otherwise full campus list in normal index order (no text search on partial or non-zip input)
- Geocode loading indicator on locations page aligned with the fetcher that actually runs geocode

[CFDP-3920]: https://christfellowshipchurch.atlassian.net/browse/CFDP-3920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ