### PR TITLE
All Articles Cleanup

### DIFF
--- a/app/routes/articles/all-articles/all-articles-page.tsx
+++ b/app/routes/articles/all-articles/all-articles-page.tsx
@@ -10,7 +10,6 @@ export function AllArticlesPage() {
           customTitle="Articles"
           fullOverlay
           imagePath={getImageUrl("3143898")}
-          ctas={[{ href: "/class-finder", title: "Take a Class" }]}
         />
       </div>
       <AllArticles />

--- a/app/routes/articles/all-articles/partials/all-articles.partial.tsx
+++ b/app/routes/articles/all-articles/partials/all-articles.partial.tsx
@@ -49,7 +49,7 @@ export function AllArticles() {
         pathnameRef,
         onUpdateCallbackRef,
       }),
-    []
+    [],
   );
 
   const stateMapping = useMemo(() => createAllArticlesStateMapping(), []);
@@ -62,7 +62,7 @@ export function AllArticles() {
   const searchClient = useMemo(
     () =>
       createSearchClient(ALGOLIA_APP_ID || "", ALGOLIA_SEARCH_API_KEY || ""),
-    [ALGOLIA_APP_ID, ALGOLIA_SEARCH_API_KEY]
+    [ALGOLIA_APP_ID, ALGOLIA_SEARCH_API_KEY],
   );
 
   const routing = useMemo(
@@ -70,7 +70,7 @@ export function AllArticles() {
       router,
       stateMapping,
     }),
-    [router, stateMapping]
+    [router, stateMapping],
   );
 
   const [allArticlesLoading, setAllArticlesLoading] = useState(true);
@@ -98,7 +98,7 @@ export function AllArticles() {
   })();
 
   return (
-    <section className="relative pb-28 pt-18 min-h-screen bg-white content-padding pagination-scroll-to">
+    <section className="relative pb-28 pt-8 md:pt-16 min-h-screen bg-white content-padding pagination-scroll-to">
       <div className="relative max-w-screen-content mx-auto">
         <InstantSearch
           indexName={INDEX_NAME}
@@ -115,7 +115,7 @@ export function AllArticles() {
           />
 
           {/* Filter Section */}
-          <div className="mt-10 mb-12">
+          <div className="mb-4">
             <HubsTagsRefinementList attribute="articlePrimaryCategories" />
           </div>
 


### PR DESCRIPTION
## Summary

This PR tightens the Articles listing layout and removes the hero “Take a Class” CTA from the all-articles page. Top padding on the main section is made responsive (`pt-8` on small screens, `pt-16` from `md` up) instead of a single large `pt-18` value. The filter block spacing is reduced by dropping the large top margin and using a smaller bottom margin so the filters sit closer to the content hierarchy the design expects. Trailing commas were added in several `useMemo` dependency arrays for consistency with the project formatter.

## Screenshots
[Paste your screenshots here]

## Testing
- [ ] Open `/articles` (or the all-articles route) and confirm the hero no longer shows the “Take a Class” CTA.
- [ ] Confirm filters and article list layout look correct on mobile and desktop (padding and spacing above filters).
- [ ] Smoke-test InstantSearch (filters, pagination) still behaves as before.
- [ ] Run `pnpm lint` — only formatting-style edits in dependency arrays; no new logic.

## Tickets
[insert Jira ticket reference here]

## Changes Made

### New Components Added
- None

### New Utilities
- None

### New Assets
- None

### Dependencies
- None

### Route Implementation
- **`app/routes/articles/all-articles/all-articles-page.tsx`** — Removed `ctas` prop from the page hero so the all-articles page no longer promotes the class finder CTA there.
- **`app/routes/articles/all-articles/partials/all-articles.partial.tsx`** — Adjusted main section classes (`pt-8 md:pt-16` vs `pt-18`), reduced filter wrapper spacing (`mb-4` vs `mt-10 mb-12`), trailing commas in `useMemo` dependency arrays.

### Key Features
- Cleaner articles-only hero without the class-finder CTA.
- More balanced vertical rhythm on the articles listing (responsive top padding, tighter filter block margin).