### PR TITLE
Classes Finder + Single Pages UI Cleanup

### DIFF
--- a/app/components/finders/hero/__tests__/index.test.tsx
+++ b/app/components/finders/hero/__tests__/index.test.tsx
@@ -42,6 +42,31 @@ describe('FinderHero', () => {
     ).toHaveAttribute('href', '/class-finder');
   });
 
+  it('hides back link below md when backLinkMdUpOnly is true', () => {
+    renderFinderHero({
+      backLink: {
+        href: '/class-finder',
+        label: 'Back to All Classes',
+      },
+      backLinkMdUpOnly: true,
+    });
+
+    const link = screen.getByRole('link', { name: 'Back to All Classes' });
+    expect(link.className).toMatch(/hidden/);
+    expect(link.className).toMatch(/md:flex/);
+  });
+
+  it('hides hero image below md when heroImageMdUpOnly is true', () => {
+    renderFinderHero({
+      topic: 'Bible Study',
+      heroImageMdUpOnly: true,
+    });
+
+    const img = screen.getByRole('img', { name: 'Find Community' });
+    expect(img.className).toMatch(/hidden/);
+    expect(img.className).toMatch(/md:block/);
+  });
+
   it('renders custom CTAs in the class topic CTA placements', () => {
     renderFinderHero({
       topic: 'Bible Study',

--- a/app/components/finders/hero/index.tsx
+++ b/app/components/finders/hero/index.tsx
@@ -1,14 +1,14 @@
-import { Link } from "react-router-dom";
-import { Fragment, type MouseEvent, type ReactNode } from "react";
+import { Link } from 'react-router-dom';
+import { Fragment, type MouseEvent, type ReactNode } from 'react';
 
-import { SectionTitle } from "~/components";
-import { cn } from "~/lib/utils";
-import { Button } from "~/primitives/button/button.primitive";
-import { HTMLRenderer } from "~/primitives/html-renderer/html-renderer.component";
-import { Icon } from "~/primitives/icon/icon";
+import { SectionTitle } from '~/components';
+import { cn } from '~/lib/utils';
+import { Button } from '~/primitives/button/button.primitive';
+import { HTMLRenderer } from '~/primitives/html-renderer/html-renderer.component';
+import { Icon } from '~/primitives/icon/icon';
 
-export type FinderHeroBgColor = "ocean" | "navy" | "white";
-type FinderHeroCtaPlacement = "mobile" | "desktop";
+export type FinderHeroBgColor = 'ocean' | 'navy' | 'white';
+type FinderHeroCtaPlacement = 'mobile' | 'desktop';
 
 type FinderHeroBackLink = {
   href: string;
@@ -21,7 +21,7 @@ type FinderHeroLinkCta = {
   href: string;
   title: string;
   className?: string;
-  intent: "primary" | "secondary" | "white" | "secondaryWhite";
+  intent: 'primary' | 'secondary' | 'white' | 'secondaryWhite';
 };
 
 type FinderHeroCustomCta = {
@@ -36,7 +36,7 @@ function renderFinderHeroCta(
   index: number,
   placement: FinderHeroCtaPlacement,
 ) {
-  if ("render" in cta) {
+  if ('render' in cta) {
     return <Fragment key={cta.key ?? index}>{cta.render(placement)}</Fragment>;
   }
 
@@ -54,10 +54,10 @@ function renderFinderHeroCta(
 
 export const FinderHero = ({
   bgImage,
-  imageAlt = "Find Community",
+  imageAlt = 'Find Community',
   imageLeft = false,
   sectionTitle,
-  sectionTitleColor = "#0092BC",
+  sectionTitleColor = '#0092BC',
   title,
   topic,
   mobileDescription,
@@ -65,6 +65,10 @@ export const FinderHero = ({
   ctas,
   bgColor,
   backLink,
+  /** When true, back link only shows from `md` up (pair with a full-bleed mobile image + overlay control). */
+  backLinkMdUpOnly = false,
+  /** When true, hero image only shows from `md` up (pair with a separate mobile full-width image). */
+  heroImageMdUpOnly = false,
 }: {
   bgColor: FinderHeroBgColor;
   bgImage: string;
@@ -81,65 +85,71 @@ export const FinderHero = ({
   desktopDescription: string;
   ctas?: FinderHeroCta[];
   backLink?: FinderHeroBackLink;
+  backLinkMdUpOnly?: boolean;
+  heroImageMdUpOnly?: boolean;
 }) => {
-  const trimmedSectionTitle = sectionTitle?.trim() ?? "";
+  const trimmedSectionTitle = sectionTitle?.trim() ?? '';
   const showSectionTitle = trimmedSectionTitle.length > 0;
-  const onLightBg = bgColor === "white";
+  const onLightBg = bgColor === 'white';
 
   return (
     <section
       className={cn(
-        !topic ? "lg:h-[65vh] lg:max-h-[590px]" : "h-full",
-        "relative content-padding pt-8 lg:pt-0 pb-12 md:pb-8 flex flex-col items-center justify-center",
-        bgColor === "ocean" && "bg-ocean",
-        bgColor === "navy" && "bg-navy",
-        bgColor === "white" && "bg-white",
+        !topic ? 'lg:h-[65vh] lg:max-h-[590px]' : 'h-full',
+        'relative content-padding pt-4 lg:pt-0 pb-12 md:pb-8 flex flex-col items-center justify-center',
+        bgColor === 'ocean' && 'bg-ocean',
+        bgColor === 'navy' && 'bg-navy',
+        bgColor === 'white' && 'bg-white',
       )}
     >
-      <div className="container mx-auto grid max-w-screen-content items-center justify-center gap-10 sm:grid-cols-2 md:gap-8 lg:grid-cols-5 xl:gap-16">
+      <div className='container mx-auto grid max-w-screen-content items-center justify-center gap-10 sm:grid-cols-2 md:gap-8 lg:grid-cols-5 xl:gap-16'>
         <img
           src={bgImage}
           alt={imageAlt}
           className={cn(
-            "w-full max-w-[400px] lg:max-w-none lg:col-span-2 md:order-2 md:mt-6 lg:mt-0",
-            imageLeft && "order-1!",
-            topic ? "rounded-xl" : "rounded-lg",
+            'w-full max-w-[400px] lg:max-w-none lg:col-span-2 md:order-2 md:mt-6 lg:mt-0',
+            imageLeft && 'order-1!',
+            topic ? 'rounded-xl' : 'rounded-lg',
+            heroImageMdUpOnly && 'hidden md:block',
           )}
         />
 
         <div
           className={cn(
-            "col-span-1 max-w-[620px] md:order-1 lg:col-span-3 xl:max-w-[700px]",
-            onLightBg ? "text-text-primary" : "text-white",
-            imageLeft && "order-2!",
+            'col-span-1 max-w-[620px] md:order-1 lg:col-span-3 xl:max-w-[700px]',
+            onLightBg ? 'text-text-primary' : 'text-white',
+            imageLeft && 'order-2!',
           )}
         >
           {showSectionTitle ? (
-            <div className="absolute top-12 left-8 md:static">
+            <div className='absolute top-12 left-8 md:static'>
               <SectionTitle
                 sectionTitle={trimmedSectionTitle}
                 color={sectionTitleColor}
               />
             </div>
           ) : null}
-          <div className="flex flex-col gap-2">
+          <div className='flex flex-col gap-2'>
             {backLink ? (
               <Link
                 to={backLink.href}
                 onClick={backLink.onNavigate}
-                className="flex items-center gap-2 hover:text-ocean transition-colors mb-10"
+                className={cn(
+                  'flex items-center gap-2 hover:text-ocean transition-colors mb-10',
+                  backLinkMdUpOnly && 'hidden md:flex',
+                )}
               >
-                <Icon size={16} name="arrowBack" />
-                <span className="text-sm font-medium">{backLink.label}</span>
+                <Icon size={16} name='arrowBack' />
+                <span className='text-sm font-medium'>{backLink.label}</span>
               </Link>
             ) : null}
             {topic ? (
               <span
                 className={cn(
-                  "mt-2 inline-flex w-fit rounded-sm px-2 py-1 text-sm",
+                  'mt-2 inline-flex w-fit rounded-sm px-2 py-1 text-sm',
                   onLightBg
-                    ? "bg-gray-100 text-text-primary"
-                    : "bg-white/15 text-white",
+                    ? 'bg-gray-100 text-text-primary'
+                    : 'bg-white/15 text-white',
                 )}
               >
                 {topic}
@@ -148,15 +158,15 @@ export const FinderHero = ({
             <HTMLRenderer
               html={title}
               className={cn(
-                "font-extrabold md:my-6 md:text-[52px] leading-[1.1]!",
-                onLightBg && "text-text-primary",
-                topic ? "text-[32px]" : "text-[40px]",
+                'font-extrabold md:my-6 md:text-[52px] leading-[1.1]!',
+                onLightBg && 'text-text-primary',
+                topic ? 'text-[32px]' : 'text-[40px]',
               )}
             />
             {topic && ctas && ctas.length > 0 && (
-              <div className="md:hidden mt-1 flex flex-wrap gap-4">
+              <div className='md:hidden mt-1 flex flex-wrap gap-4'>
                 {ctas.map((cta, index) =>
-                  renderFinderHeroCta(cta, index, "mobile"),
+                  renderFinderHeroCta(cta, index, 'mobile'),
                 )}
               </div>
             )}
@@ -164,39 +174,39 @@ export const FinderHero = ({
 
           <div
             className={cn(
-              "text-lg",
-              onLightBg ? "text-text-primary" : "text-white",
-              topic ? "mt-12 md:mt-8" : "",
+              'text-lg',
+              onLightBg ? 'text-text-primary' : 'text-white',
+              topic ? 'mt-12 md:mt-8' : '',
             )}
           >
             <HTMLRenderer
               html={desktopDescription}
               className={cn(
-                "hidden lg:block",
+                'hidden lg:block',
                 onLightBg
-                  ? "html-renderer--finder-hero-desc-light"
-                  : "html-renderer--finder-hero-desc",
+                  ? 'html-renderer--finder-hero-desc-light'
+                  : 'html-renderer--finder-hero-desc',
               )}
             />
             <HTMLRenderer
               html={mobileDescription}
               className={cn(
-                "lg:hidden",
+                'lg:hidden',
                 onLightBg
-                  ? "html-renderer--finder-hero-desc-light"
-                  : "html-renderer--finder-hero-desc",
+                  ? 'html-renderer--finder-hero-desc-light'
+                  : 'html-renderer--finder-hero-desc',
               )}
             />
           </div>
           {ctas && ctas.length > 0 && (
             <div
               className={cn(
-                "mt-8 flex gap-2 sm:gap-4",
-                topic ? "hidden lg:flex" : "",
+                'mt-8 flex gap-2 sm:gap-4',
+                topic ? 'hidden lg:flex' : '',
               )}
             >
               {ctas.map((cta, index) =>
-                renderFinderHeroCta(cta, index, "desktop"),
+                renderFinderHeroCta(cta, index, 'desktop'),
               )}
             </div>
           )}

--- a/app/routes/class-finder/class-single/class-single-page.tsx
+++ b/app/routes/class-finder/class-single/class-single-page.tsx
@@ -1,24 +1,25 @@
-import { useLoaderData, useNavigate } from "react-router-dom";
-import { useMemo, type MouseEvent as ReactMouseEvent } from "react";
-import { Configure, InstantSearch, useHits } from "react-instantsearch";
+import { useCallback, useMemo, type MouseEvent as ReactMouseEvent } from 'react';
+import { useLoaderData, useNavigate } from 'react-router-dom';
+import { Configure, InstantSearch, useHits } from 'react-instantsearch';
 
-import { escapeAlgoliaFilterString } from "~/components/finders/finder-algolia.utils";
-import { FinderHero, type FinderHeroCta } from "~/components/finders/hero";
-import { VideoModal } from "~/components/modals/video-modal";
-import { Button } from "~/primitives/button/button.primitive";
-import { ClassFAQ } from "./components/faq.component";
-import { LoaderReturnType } from "./loader";
-import { ClassSingleUpcomingSearch } from "./partials/upcoming-sections.partial";
-import { createSearchClient } from "~/lib/create-search-client";
-import { ClassHitType } from "../types";
+import { escapeAlgoliaFilterString } from '~/components/finders/finder-algolia.utils';
+import { FinderHero, type FinderHeroCta } from '~/components/finders/hero';
+import { VideoModal } from '~/components/modals/video-modal';
+import { Button } from '~/primitives/button/button.primitive';
+import { Icon } from '~/primitives/icon/icon';
+import { ClassFAQ } from './components/faq.component';
+import { LoaderReturnType } from './loader';
+import { ClassSingleUpcomingSearch } from './partials/upcoming-sections.partial';
+import { createSearchClient } from '~/lib/create-search-client';
+import { ClassHitType } from '../types';
 
 function escapeHtml(text: string): string {
   return text
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
 }
 
 function buildClassSingleHeroDescriptionHtml(summary: string): string {
@@ -31,13 +32,13 @@ function buildClassSingleHeroDescriptionHtml(summary: string): string {
 
 const ClassNotFound = () => {
   return (
-    <div className="flex flex-col items-center gap-6 py-20">
-      <h2 className="text-2xl font-bold text-center">Class Not Found</h2>
-      <p className="text-neutral-500 text-center max-w-md">
+    <div className='flex flex-col items-center gap-6 py-20'>
+      <h2 className='text-2xl font-bold text-center'>Class Not Found</h2>
+      <p className='text-neutral-500 text-center max-w-md'>
         We couldn't find the class you're looking for. It may have been removed
         or renamed.
       </p>
-      <Button intent="primary" href="/class-finder">
+      <Button intent='primary' href='/class-finder'>
         Browse All Classes
       </Button>
     </div>
@@ -55,35 +56,35 @@ const ClassSingleContent = ({ hit }: { hit: ClassHitType }) => {
     [summary],
   );
 
-  const heroTitleHtml = useMemo(() => escapeHtml(classType ?? ""), [classType]);
+  const heroTitleHtml = useMemo(() => escapeHtml(classType ?? ''), [classType]);
 
   const ctas = useMemo<FinderHeroCta[]>(() => {
     const items: FinderHeroCta[] = [];
     if (discussionGuideUrl) {
       items.push({
         href: discussionGuideUrl,
-        title: "Discussion Guide",
-        intent: "secondary" as const,
-        className: "text-base font-normal",
+        title: 'Discussion Guide',
+        intent: 'secondary' as const,
+        className: 'text-base font-normal',
       });
     }
     if (classTrailer) {
       items.push({
-        key: "class-trailer",
+        key: 'class-trailer',
         render: () => (
           <VideoModal
             wistiaId={classTrailer}
-            intent="primary"
+            intent='primary'
             ModalButton={({ onClick, ...props }) => (
               <Button
                 {...props}
                 onClick={onClick}
-                className="text-base font-normal"
+                className='text-base font-normal'
               >
                 Class Trailer
               </Button>
             )}
-            videoClassName="w-full h-full rounded-lg"
+            videoClassName='w-full h-full rounded-lg'
           />
         ),
       });
@@ -91,28 +92,51 @@ const ClassSingleContent = ({ hit }: { hit: ClassHitType }) => {
     return items;
   }, [discussionGuideUrl, classTrailer]);
 
-  const backLink = useMemo(
-    () => ({
-      href: "/class-finder",
-      label: "Back to All Classes" as const,
-      onNavigate: (e: ReactMouseEvent<Element>) => {
-        e.preventDefault();
-        if (typeof window !== "undefined" && window.history.length > 1) {
-          navigate(-1);
-        } else {
-          navigate("/class-finder");
-        }
-      },
-    }),
+  const handleBack = useCallback(
+    (e: ReactMouseEvent<Element>) => {
+      e.preventDefault();
+      if (typeof window !== 'undefined' && window.history.length > 1) {
+        navigate(-1);
+      } else {
+        navigate('/class-finder');
+      }
+    },
     [navigate],
   );
 
+  const backLink = useMemo(
+    () => ({
+      href: '/class-finder',
+      label: 'Back to All Classes' as const,
+      onNavigate: handleBack,
+    }),
+    [handleBack],
+  );
+
+  const coverUri = hit.coverImage.sources[0].uri;
+
   return (
-    <section className="flex flex-col items-center dark:bg-gray-900 pt-6">
-      <div className="w-full flex-none">
+    <section className='flex w-full flex-col items-center dark:bg-gray-900 md:pt-6'>
+      <div className='flex w-full flex-none flex-col'>
+        <div className='relative w-full shrink-0 md:hidden'>
+          <img
+            src={coverUri}
+            alt={hit.title}
+            className='aspect-video w-full max-w-screen object-cover'
+          />
+          <button
+            type='button'
+            onClick={handleBack}
+            className='absolute left-4 top-4 flex items-center justify-center rounded-full border border-[#DEE0E3] bg-white p-2 shadow-sm'
+            aria-label='Back to All Classes'
+          >
+            <Icon name='arrowBack' className='text-neutral-darker' />
+          </button>
+        </div>
+
         <FinderHero
-          bgColor="white"
-          bgImage={hit.coverImage.sources[0].uri}
+          bgColor='white'
+          bgImage={coverUri}
           imageAlt={hit.title}
           title={heroTitleHtml}
           topic={topic}
@@ -120,19 +144,21 @@ const ClassSingleContent = ({ hit }: { hit: ClassHitType }) => {
           desktopDescription={heroDescriptionHtml}
           ctas={ctas}
           backLink={backLink}
+          backLinkMdUpOnly
+          heroImageMdUpOnly
         />
       </div>
 
-      <div className="w-full flex flex-col border-t border-[#E8E8E8]">
+      <div className='flex w-full flex-col border-t border-[#E8E8E8]'>
         <ClassSingleUpcomingSearch
           classType={classType}
-          classHeroCoverImageUri={hit.coverImage.sources[0].uri}
+          classHeroCoverImageUri={coverUri}
           onDemandUrl={onDemandUrl}
         />
 
         {/* FAQs */}
-        <div className="content-padding w-full flex flex-col items-center">
-          <div className="w-full max-w-screen-content mx-auto flex flex-col items-center">
+        <div className='content-padding flex w-full flex-col items-center'>
+          <div className='mx-auto flex w-full max-w-screen-content flex-col items-center'>
             <ClassFAQ />
           </div>
         </div>
@@ -152,7 +178,7 @@ export function ClassSinglePage() {
 
   return (
     <InstantSearch
-      indexName="dev_Classes"
+      indexName='dev_Classes'
       searchClient={searchClient}
       future={{
         preserveSharedStateOnUnmount: true,
@@ -173,7 +199,7 @@ const CustomClassSingleHits = () => {
   const { items } = useHits<ClassHitType>();
 
   return (
-    <div className="w-full">
+    <div className='w-full'>
       {items.length > 0 ? (
         items.map((hit) => <ClassSingleContent key={hit.objectID} hit={hit} />)
       ) : (

--- a/app/routes/class-finder/class-single/components/upcoming-session-card.component.tsx
+++ b/app/routes/class-finder/class-single/components/upcoming-session-card.component.tsx
@@ -9,6 +9,9 @@ import { ButtonProps } from '~/primitives/button/button.primitive';
 const cardShellClassName = cn(
   'mx-auto flex h-full min-h-0 w-full max-w-[360px] flex-1 flex-col rounded-lg',
   'md:max-w-[300px] lg:max-w-[333px] xl:max-w-[300px]',
+  // In the upcoming sessions carousel, cards should align to a consistent height per slide.
+  // Content can vary (campus label, class type, etc.), so we enforce a desktop min height.
+  'lg:min-h-[270px]',
   'transition-transform duration-300 ease-out',
   'hover:-translate-y-1',
 );

--- a/app/routes/class-finder/class-single/components/upcoming-session-card.component.tsx
+++ b/app/routes/class-finder/class-single/components/upcoming-session-card.component.tsx
@@ -1,94 +1,97 @@
-import { forwardRef } from "react";
+import { forwardRef } from 'react';
 
-import { Icon } from "~/primitives/icon/icon";
-import { ClassHitType } from "../../types";
-import { cn } from "~/lib/utils";
-import { GroupConnectModal } from "~/components/modals/group-connect/group-connect-modal";
-import { ButtonProps } from "~/primitives/button/button.primitive";
+import { Icon } from '~/primitives/icon/icon';
+import { ClassHitType } from '../../types';
+import { cn } from '~/lib/utils';
+import { GroupConnectModal } from '~/components/modals/group-connect/group-connect-modal';
+import { ButtonProps } from '~/primitives/button/button.primitive';
 
 const cardShellClassName = cn(
-  "mx-auto flex h-full min-h-0 w-full max-w-[360px] flex-1 flex-col rounded-lg",
-  "md:max-w-[300px] lg:max-w-[333px] xl:max-w-[300px]",
-  "transition-transform duration-300 ease-out",
-  "hover:-translate-y-1",
+  'mx-auto flex h-full min-h-0 w-full max-w-[360px] flex-1 flex-col rounded-lg',
+  'md:max-w-[300px] lg:max-w-[333px] xl:max-w-[300px]',
+  'transition-transform duration-300 ease-out',
+  'hover:-translate-y-1',
 );
 
 const UpcomingSessionCardBody = ({ hit }: { hit: ClassHitType }) => {
-  const campusLabel = hit.campus?.trim() ?? "";
-  const campusIcon = campusLabel.toLowerCase().includes("online")
-    ? "globe"
-    : "map";
+  const rawCampusLabel = hit.campus?.trim() ?? '';
+  const campusLabel = rawCampusLabel.toLowerCase().includes('online')
+    ? 'Online'
+    : rawCampusLabel;
+  const campusIcon = campusLabel.toLowerCase().includes('online')
+    ? 'globe'
+    : 'map';
   const { schedule, startDate, endDate, format, language, classType } = hit;
-  const isVirtualFormat = format === "Virtual";
+  const isVirtualFormat = format === 'Virtual';
 
   const geoMeters = hit._rankingInfo?.geoDistance;
   /** Algolia can send `geoDistance: 0` when `aroundLatLng` is unset; only show miles when geo search is meaningful. */
   const milesFromSearchOrigin =
     geoMeters != null &&
-    typeof geoMeters === "number" &&
+    typeof geoMeters === 'number' &&
     !Number.isNaN(geoMeters) &&
     geoMeters > 0
       ? geoMeters / 1609.34
       : null;
 
   const footerLabel = isVirtualFormat
-    ? "Online"
+    ? 'Online'
     : milesFromSearchOrigin != null
       ? `${milesFromSearchOrigin.toFixed(1)} MILES`
       : format;
 
-  const formattedStartDate = new Date(startDate).toLocaleDateString("en-US", {
-    month: "long",
-    day: "numeric",
+  const formattedStartDate = new Date(startDate).toLocaleDateString('en-US', {
+    month: 'long',
+    day: 'numeric',
   });
-  const formattedEndDate = new Date(endDate).toLocaleDateString("en-US", {
-    month: "long",
-    day: "numeric",
+  const formattedEndDate = new Date(endDate).toLocaleDateString('en-US', {
+    month: 'long',
+    day: 'numeric',
   });
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg bg-white">
-      <div className="flex min-h-0 flex-1 flex-col gap-6 px-6 pb-1 pt-5">
-        <div className="flex min-h-0 flex-1 flex-col gap-5">
-          <div className="flex flex-col gap-2">
-            <p className="bg-[#EBEBEB] w-fit flex rounded-sm text-xs font-semibold px-2 py-1">
-              {language}
+    <div className='flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg bg-white'>
+      <div className='flex min-h-0 flex-1 flex-col gap-6 px-6 pb-1 pt-5'>
+        <div className='flex min-h-0 flex-1 flex-col gap-5'>
+          <div className='flex flex-col gap-2'>
+            <p className='bg-[#EBEBEB] w-fit flex rounded-sm text-xs font-semibold px-2 py-1'>
+              {language.toLowerCase() === 'spanish' ? 'Español' : language}
             </p>
-            <h3 className="text-lg font-bold leading-6 line-clamp-2">
+            <h3 className='text-lg font-bold leading-6 line-clamp-2'>
               {classType}
             </h3>
           </div>
 
-          <div className="flex flex-col gap-6 pb-3">
-            <div className="flex flex-col gap-2">
-              <div className="flex items-center gap-2">
-                <Icon name={campusIcon} size={20} color="black" />
-                <p className="text-sm font-semibold">{campusLabel}</p>
+          <div className='flex flex-col gap-6 pb-3 text-neutral-darker'>
+            <div className='flex flex-col gap-2'>
+              <div className='flex items-center gap-2'>
+                <Icon name={campusIcon} size={24} />
+                <p className='text-sm'>{campusLabel}</p>
               </div>
 
-              <div className="flex items-center gap-2">
-                <Icon name="calendarAlt" size={20} color="black" />
-                <p className="text-sm font-semibold">
+              <div className='flex items-center gap-2'>
+                <Icon name='calendarAlt' size={24} />
+                <p className='text-sm'>
                   {formattedStartDate} - {formattedEndDate}
                 </p>
               </div>
 
-              <div className="flex items-center gap-2">
-                <Icon name="timeFive" size={20} color="black" />
-                <p className="text-sm font-semibold">{schedule} EST</p>
+              <div className='flex items-center gap-2'>
+                <Icon name='timeFive' size={24} />
+                <p className='text-sm'>{schedule} EST</p>
               </div>
             </div>
           </div>
         </div>
       </div>
 
-      <div className="mt-auto flex shrink-0 items-center justify-center gap-1.5 rounded-b-lg bg-navy py-4.5 text-white">
+      <div className='mt-auto flex shrink-0 items-center justify-center gap-1.5 rounded-b-lg bg-navy py-3 text-white'>
         <Icon
-          name={isVirtualFormat ? "globe" : "locationArrow"}
+          name={isVirtualFormat ? 'globe' : 'locationArrow'}
           size={16}
-          className="text-gray"
+          className='text-gray'
         />
-        <p className="text-sm font-semibold text-gray">{footerLabel}</p>
+        <p className='text-sm font-semibold text-gray'>{footerLabel}</p>
       </div>
     </div>
   );
@@ -101,12 +104,12 @@ const FullCardModalTrigger = forwardRef<HTMLButtonElement, ButtonProps>(
         ref={ref}
         className={cn(
           cardShellClassName,
-          "border-0 bg-transparent p-0 text-left shadow-none",
-          "cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-ocean focus-visible:ring-offset-2",
+          'border-0 bg-transparent p-0 text-left shadow-none',
+          'cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-ocean focus-visible:ring-offset-2',
           className,
         )}
         {...props}
-        type="button"
+        type='button'
       />
     );
   },
@@ -120,7 +123,7 @@ export const UpcomingSessionCard = ({ hit }: { hit: ClassHitType }) => {
       <GroupConnectModal
         groupId={String(hit.groupId)}
         campus={hit.campus}
-        buttonText="Sign up for this class"
+        buttonText='Sign up for this class'
         triggerChildren={<UpcomingSessionCardBody hit={hit} />}
         ModalButton={(props) => (
           <FullCardModalTrigger

--- a/app/routes/class-finder/class-single/components/upcoming-sessions-carousel.component.tsx
+++ b/app/routes/class-finder/class-single/components/upcoming-sessions-carousel.component.tsx
@@ -101,8 +101,10 @@ export function UpcomingSessionsCarousel({
       <CarouselContent
         className={cn(
           'ml-0 py-3',
-          !isDesktopChunkGrid &&
-            CLASS_SINGLE_CAROUSEL_MOBILE_PEEK_CONTENT_GAP_CLASS,
+          isDesktopChunkGrid ? 'gap-6 xl:gap-8' : null,
+          !isDesktopChunkGrid
+            ? CLASS_SINGLE_CAROUSEL_MOBILE_PEEK_CONTENT_GAP_CLASS
+            : null,
         )}
       >
         {!isDesktopChunkGrid
@@ -120,7 +122,7 @@ export function UpcomingSessionsCarousel({
               <CarouselItem key={slideIndex} className='basis-full pl-0'>
                 <div
                   className={cn(
-                    'grid w-full items-stretch gap-x-4 gap-y-6 xl:gap-x-8',
+                    'grid w-full auto-rows-fr items-stretch gap-x-4 gap-y-6 xl:gap-x-8',
                     classSingleCarouselSlideGridColsClass(
                       DESKTOP_CAROUSEL_CHUNK,
                     ),

--- a/app/routes/class-finder/class-single/components/upcoming-sessions-carousel.component.tsx
+++ b/app/routes/class-finder/class-single/components/upcoming-sessions-carousel.component.tsx
@@ -1,23 +1,23 @@
-import { useMemo } from "react";
+import { useMemo } from 'react';
 
-import { cn } from "~/lib/utils";
+import { cn } from '~/lib/utils';
 import {
   CLASS_SINGLE_CAROUSEL_MOBILE_PEEK_CONTENT_GAP_CLASS,
   CLASS_SINGLE_CAROUSEL_MOBILE_PEEK_ITEM_CLASS,
   classSingleCarouselSlideGridColsClass,
   useMinWidthLg,
-} from "../hooks/use-class-single-carousel-cards-per-slide";
-import { Button } from "~/primitives/shadcn-primitives/button";
+} from '../hooks/use-class-single-carousel-cards-per-slide';
+import { Button } from '~/primitives/shadcn-primitives/button';
 import {
   Carousel,
   CarouselContent,
   CarouselDots,
   CarouselItem,
   useCarousel,
-} from "~/primitives/shadcn-primitives/carousel";
-import Icon from "~/primitives/icon";
-import { UpcomingSessionCard } from "./upcoming-session-card.component";
-import { ClassHitType } from "../../types";
+} from '~/primitives/shadcn-primitives/carousel';
+import Icon from '~/primitives/icon';
+import { UpcomingSessionCard } from './upcoming-session-card.component';
+import { ClassHitType } from '../../types';
 
 function UpcomingCarouselNavRow() {
   const { api, scrollPrev, scrollNext, canScrollPrev, canScrollNext } =
@@ -26,42 +26,42 @@ function UpcomingCarouselNavRow() {
   if (slideCount <= 1) return null;
 
   return (
-    <div className="mt-6 flex w-full flex-row items-center justify-between gap-4 px-1">
+    <div className='mt-6 flex w-full flex-row items-center justify-between gap-4 px-1'>
       <CarouselDots
-        className="justify-start gap-2"
-        activeClassName="h-2 w-2 bg-ocean"
-        inactiveClassName="h-2 w-2 bg-neutral-lighter"
+        className='justify-start gap-2'
+        activeClassName='h-2 w-2 bg-ocean'
+        inactiveClassName='h-2 w-2 bg-neutral-lighter'
       />
-      <div className="flex shrink-0 items-center gap-2">
+      <div className='flex shrink-0 items-center gap-2 pr-5 md:pr-12 lg:pr-0'>
         <Button
-          type="button"
-          variant="outline"
-          size="icon"
+          type='button'
+          variant='outline'
+          size='icon'
           disabled={!canScrollPrev}
           className={cn(
-            "size-12 rounded-full border-ocean text-ocean",
-            "hover:border-navy hover:text-navy",
-            "disabled:border-[#AAAAAA] disabled:text-[#AAAAAA]",
+            'size-12 rounded-full border-ocean text-ocean',
+            'hover:border-navy hover:text-navy',
+            'disabled:border-[#AAAAAA] disabled:text-[#AAAAAA]',
           )}
-          aria-label="Previous slide"
+          aria-label='Previous slide'
           onClick={scrollPrev}
         >
-          <Icon name="arrowBack" className="size-6" />
+          <Icon name='arrowBack' className='size-6' />
         </Button>
         <Button
-          type="button"
-          variant="outline"
-          size="icon"
+          type='button'
+          variant='outline'
+          size='icon'
           disabled={!canScrollNext}
           className={cn(
-            "size-12 rounded-full border-ocean text-ocean",
-            "hover:border-navy hover:text-navy",
-            "disabled:border-[#AAAAAA] disabled:text-[#AAAAAA]",
+            'size-12 rounded-full border-ocean text-ocean',
+            'hover:border-navy hover:text-navy',
+            'disabled:border-[#AAAAAA] disabled:text-[#AAAAAA]',
           )}
-          aria-label="Next slide"
+          aria-label='Next slide'
           onClick={scrollNext}
         >
-          <Icon name="arrowRight" className="size-6" />
+          <Icon name='arrowRight' className='size-6' />
         </Button>
       </div>
     </div>
@@ -94,14 +94,15 @@ export function UpcomingSessionsCarousel({
 
   return (
     <Carousel
-      key={`${resetKey}-${isDesktopChunkGrid ? "lg" : "peek"}`}
-      opts={{ align: "start", containScroll: "trimSnaps" }}
-      className="w-full max-w-[1296px]"
+      key={`${resetKey}-${isDesktopChunkGrid ? 'lg' : 'peek'}`}
+      opts={{ align: 'start', containScroll: 'trimSnaps' }}
+      className='w-full max-w-[1296px]'
     >
       <CarouselContent
         className={cn(
-          "ml-0 py-3",
-          !isDesktopChunkGrid && CLASS_SINGLE_CAROUSEL_MOBILE_PEEK_CONTENT_GAP_CLASS,
+          'ml-0 py-3',
+          !isDesktopChunkGrid &&
+            CLASS_SINGLE_CAROUSEL_MOBILE_PEEK_CONTENT_GAP_CLASS,
         )}
       >
         {!isDesktopChunkGrid
@@ -110,23 +111,25 @@ export function UpcomingSessionsCarousel({
                 key={hit.objectID ?? idx}
                 className={CLASS_SINGLE_CAROUSEL_MOBILE_PEEK_ITEM_CLASS}
               >
-                <div className="flex h-full min-h-0 w-full min-w-0 max-w-full justify-center">
+                <div className='flex h-full min-h-0 w-full min-w-0 max-w-full justify-center'>
                   <UpcomingSessionCard hit={hit} />
                 </div>
               </CarouselItem>
             ))
           : slides.map((chunk, slideIndex) => (
-              <CarouselItem key={slideIndex} className="basis-full pl-0">
+              <CarouselItem key={slideIndex} className='basis-full pl-0'>
                 <div
                   className={cn(
-                    "grid w-full items-stretch gap-x-4 gap-y-6 xl:gap-x-8",
-                    classSingleCarouselSlideGridColsClass(DESKTOP_CAROUSEL_CHUNK),
+                    'grid w-full items-stretch gap-x-4 gap-y-6 xl:gap-x-8',
+                    classSingleCarouselSlideGridColsClass(
+                      DESKTOP_CAROUSEL_CHUNK,
+                    ),
                   )}
                 >
                   {chunk.map((hit, idx) => (
                     <div
                       key={idx}
-                      className="flex h-full min-h-0 w-full justify-center sm:justify-start"
+                      className='flex h-full min-h-0 w-full justify-center sm:justify-start'
                     >
                       <UpcomingSessionCard hit={hit} />
                     </div>

--- a/app/routes/class-finder/class-single/partials/upcoming-sections.partial.tsx
+++ b/app/routes/class-finder/class-single/partials/upcoming-sections.partial.tsx
@@ -1,20 +1,20 @@
-import { useMemo } from "react";
-import { Configure, InstantSearch, useHits } from "react-instantsearch";
+import { useMemo } from 'react';
+import { Configure, InstantSearch, useHits } from 'react-instantsearch';
 
-import { escapeAlgoliaFilterString } from "~/components/finders/finder-algolia.utils";
-import { FinderStickyBar } from "~/components/finders/finder-sticky-bar.component";
-import { SearchFilters } from "~/components/finders/search-filters";
-import { ActiveFilters } from "~/components/finders/search-filters/active-filter.component";
-import { UpcomingSessionsCarousel } from "../components/upcoming-sessions-carousel.component";
+import { escapeAlgoliaFilterString } from '~/components/finders/finder-algolia.utils';
+import { FinderStickyBar } from '~/components/finders/finder-sticky-bar.component';
+import { SearchFilters } from '~/components/finders/search-filters';
+import { ActiveFilters } from '~/components/finders/search-filters/active-filter.component';
+import { UpcomingSessionsCarousel } from '../components/upcoming-sessions-carousel.component';
 import {
   CLASS_SINGLE_UPCOMING_INDEX_NAME,
   useClassSingleUpcomingInstantSearch,
-} from "../hooks/use-class-single-upcoming-instant-search";
-import type { ClassHitType } from "../../types";
-import OnDemandCard from "../components/on-demand-card.component";
-import { ClassSingleGroupsSection } from "./groups.partial";
+} from '../hooks/use-class-single-upcoming-instant-search';
+import type { ClassHitType } from '../../types';
+import OnDemandCard from '../components/on-demand-card.component';
+import { ClassSingleGroupsSection } from './groups.partial';
 
-const LOCATION_FILTERS_HINT = "Location filters are applied.";
+const LOCATION_FILTERS_HINT = 'Location filters are applied.';
 
 /**
  * One Algolia response loads enough hits for carousel slides + geo/virtual ordering (Algolia max per request).
@@ -34,7 +34,7 @@ function compareStartDateAsc(a: ClassHitType, b: ClassHitType): number {
 
 function geoDistanceMeters(hit: ClassHitType): number {
   const d = hit._rankingInfo?.geoDistance;
-  if (d == null || typeof d !== "number" || Number.isNaN(d) || d <= 0) {
+  if (d == null || typeof d !== 'number' || Number.isNaN(d) || d <= 0) {
     return Number.POSITIVE_INFINITY;
   }
   return d;
@@ -54,7 +54,7 @@ function sortUpcomingSessionHitsForDisplay(
   const inPerson: ClassHitType[] = [];
   const virtual: ClassHitType[] = [];
   for (const hit of items) {
-    if (hit.format === "Virtual") virtual.push(hit);
+    if (hit.format === 'Virtual') virtual.push(hit);
     else inPerson.push(hit);
   }
 
@@ -100,46 +100,27 @@ export function ClassSingleUpcomingSearch({
         coordinates={upcoming.coordinates}
       />
 
-      <div className="flex w-full flex-col pagination-scroll-to" id="search">
-        {/* Mobile Filters */}
-        <div className="flex flex-col md:hidden">
-          <div className="content-padding mx-auto w-full max-w-screen-content">
-            <h2 className="w-full text-[28px] font-extrabold">
-              Filter Sessions
-            </h2>
+      <div className='flex w-full flex-col pagination-scroll-to' id='search'>
+        {/*
+          One column wraps heading + sticky filters + results so `position: sticky`
+          on FinderStickyBar is constrained by a tall ancestor (see MDN: sticky is
+          limited to the parent box). Splitting filters and results into siblings
+          made each filter parent too short, so the bar scrolled away on both breakpoints.
+        */}
+        <div className='flex min-w-0 w-full flex-col'>
+          <div className='content-padding mx-auto w-full max-w-screen-content md:hidden'>
+            <h2 className='w-full text-[28px] font-extrabold'>Filter Sessions</h2>
           </div>
-          <div className="flex w-screen min-w-0 flex-col">
-            <FinderStickyBar>
-              <div className="mx-auto flex max-w-screen-content flex-col gap-3 py-4">
-                <SearchFilters
-                  onClearAllToUrl={upcoming.clearAllFiltersFromUrl}
-                  desktopFilters={upcoming.desktopFilters}
-                  compactInlineFilterCount={2}
-                  isFilterPillSupplementallyActive={
-                    upcoming.isFilterPillSupplementallyActive
-                  }
-                />
-              </div>
-              <ActiveFilters
-                onClearAllToUrl={upcoming.clearAllFiltersFromUrl}
-                additionalFiltersActive={upcoming.geoFiltersActive}
-                additionalFiltersHint={LOCATION_FILTERS_HINT}
-              />
-            </FinderStickyBar>
-          </div>
-        </div>
 
-        {/* Desktop Filters */}
-        <div className="relative hidden w-full flex-col md:flex">
           <FinderStickyBar>
-            <div className="mx-auto flex max-w-screen-content flex-col gap-3 pt-8 py-4 lg:min-h-20 lg:flex-row lg:items-center lg:gap-4 pagination-scroll-to">
-              <div className="flex w-fit shrink-0 items-center gap-4">
-                <h2 className="w-fit min-w-[260px] text-[28px] font-extrabold">
+            <div className='mx-auto flex w-full min-w-0 max-w-screen-content flex-col gap-3 py-4 md:pt-8 lg:min-h-20 lg:flex-row lg:items-center lg:gap-4'>
+              <div className='hidden w-fit shrink-0 items-center gap-4 md:flex'>
+                <h2 className='w-fit min-w-[260px] text-[28px] font-extrabold'>
                   Filter Sessions
                 </h2>
-                <div className="hidden h-full w-px bg-text-secondary lg:block" />
+                <div className='hidden h-full w-px bg-text-secondary lg:block' />
               </div>
-              <div className="min-w-0 flex-1">
+              <div className='min-w-0 flex-1'>
                 <SearchFilters
                   onClearAllToUrl={upcoming.clearAllFiltersFromUrl}
                   desktopFilters={upcoming.desktopFilters}
@@ -156,33 +137,33 @@ export function ClassSingleUpcomingSearch({
               additionalFiltersHint={LOCATION_FILTERS_HINT}
             />
           </FinderStickyBar>
-        </div>
 
-        <div className="flex w-full flex-col bg-gray py-8 content-padding md:pt-12 md:pb-20">
-          <div className="mx-auto w-full max-w-screen-content">
-            <ClassSingleUpcomingResults geoActive={upcoming.geoFiltersActive} />
-          </div>
+          <div className='flex w-full flex-col bg-gray py-8 pl-5 md:pl-12 lg:pl-18 lg:pr-18 md:pt-12 md:pb-20'>
+            <div className='mx-auto w-full max-w-screen-content'>
+              <ClassSingleUpcomingResults geoActive={upcoming.geoFiltersActive} />
+            </div>
 
-          {/* On Demand Section*/}
-          <div className="mx-auto w-full max-w-screen-content flex flex-col gap-4 items-center mt-8">
-            {onDemandUrl && (
-              <div className="flex flex-col gap-4 w-full max-w-[1296px] mr-auto py-16 border-t border-neutral-lighter">
-                <h2 className="text-2xl font-extrabold w-full leading-[1.4]">
-                  Take It Anytime
-                </h2>
-                <OnDemandCard
-                  title={classType}
-                  image={classHeroCoverImageUri}
-                  link={onDemandUrl}
-                />
-              </div>
-            )}
+            {/* On Demand Section*/}
+            <div className='mx-auto mt-8 flex w-full max-w-screen-content flex-col items-center gap-4'>
+              {onDemandUrl && (
+                <div className='mr-auto flex w-full max-w-[1296px] flex-col gap-4 border-t border-neutral-lighter py-16'>
+                  <h2 className='w-full text-2xl leading-[1.4] font-extrabold'>
+                    Take It Anytime
+                  </h2>
+                  <OnDemandCard
+                    title={classType}
+                    image={classHeroCoverImageUri}
+                    link={onDemandUrl}
+                  />
+                </div>
+              )}
 
-            <ClassSingleGroupsSection
-              coordinates={upcoming.coordinates}
-              classUrl={upcoming.classUrl}
-              classesIndexClassType={classType}
-            />
+              <ClassSingleGroupsSection
+                coordinates={upcoming.coordinates}
+                classUrl={upcoming.classUrl}
+                classesIndexClassType={classType}
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -210,7 +191,7 @@ export const ResponsiveClassesSingleConfigure = ({
 
   return (
     <Configure
-      key={`${classUrl}-${trimmed}-${coordinates?.lat ?? ""}-${coordinates?.lng ?? ""}`}
+      key={`${classUrl}-${trimmed}-${coordinates?.lat ?? ''}-${coordinates?.lng ?? ''}`}
       hitsPerPage={CLASS_SINGLE_UPCOMING_MAX_HITS}
       filters={classTypeFilter}
       aroundLatLng={
@@ -218,7 +199,7 @@ export const ResponsiveClassesSingleConfigure = ({
           ? `${coordinates.lat}, ${coordinates.lng}`
           : undefined
       }
-      aroundRadius="all"
+      aroundRadius='all'
       aroundLatLngViaIP={false}
       getRankingInfo={true}
     />
@@ -233,17 +214,17 @@ function ClassSingleUpcomingResults({ geoActive }: { geoActive: boolean }) {
     [items, geoActive],
   );
 
-  const carouselResetKey = ordered.map((h) => h.objectID).join("|");
+  const carouselResetKey = ordered.map((h) => h.objectID).join('|');
 
   return (
     <div
       data-upcoming-sessions-results
-      className="scroll-mt-[100px]w-full max-w-[1296px] mr-auto"
+      className='scroll-mt-[100px] w-full max-w-[1296px] mr-auto'
     >
-      <h3 className="pt-2 text-2xl font-extrabold mb-6 md:pt-4">
+      <h3 className='pt-2 text-2xl font-extrabold mb-6 md:pt-4'>
         Join a Class
       </h3>
-      <div className="flex w-full justify-center md:justify-start">
+      <div className='flex w-full justify-center md:justify-start'>
         <UpcomingSessionsCarousel hits={ordered} resetKey={carouselResetKey} />
       </div>
     </div>

--- a/app/routes/class-finder/class-single/partials/upcoming-sections.partial.tsx
+++ b/app/routes/class-finder/class-single/partials/upcoming-sections.partial.tsx
@@ -101,12 +101,6 @@ export function ClassSingleUpcomingSearch({
       />
 
       <div className='flex w-full flex-col pagination-scroll-to' id='search'>
-        {/*
-          One column wraps heading + sticky filters + results so `position: sticky`
-          on FinderStickyBar is constrained by a tall ancestor (see MDN: sticky is
-          limited to the parent box). Splitting filters and results into siblings
-          made each filter parent too short, so the bar scrolled away on both breakpoints.
-        */}
         <div className='flex min-w-0 w-full flex-col max-md:pt-6'>
           <FinderStickyBar className='max-md:shadow-none'>
             <h2 className='w-full pb-2 text-[28px] font-extrabold md:hidden'>

--- a/app/routes/class-finder/class-single/partials/upcoming-sections.partial.tsx
+++ b/app/routes/class-finder/class-single/partials/upcoming-sections.partial.tsx
@@ -107,13 +107,12 @@ export function ClassSingleUpcomingSearch({
           limited to the parent box). Splitting filters and results into siblings
           made each filter parent too short, so the bar scrolled away on both breakpoints.
         */}
-        <div className='flex min-w-0 w-full flex-col'>
-          <div className='content-padding mx-auto w-full max-w-screen-content md:hidden'>
-            <h2 className='w-full text-[28px] font-extrabold'>Filter Sessions</h2>
-          </div>
-
-          <FinderStickyBar>
-            <div className='mx-auto flex w-full min-w-0 max-w-screen-content flex-col gap-3 py-4 md:pt-8 lg:min-h-20 lg:flex-row lg:items-center lg:gap-4'>
+        <div className='flex min-w-0 w-full flex-col max-md:pt-6'>
+          <FinderStickyBar className='max-md:shadow-none'>
+            <h2 className='w-full pb-2 text-[28px] font-extrabold md:hidden'>
+              Filter Sessions
+            </h2>
+            <div className='mx-auto flex w-full min-w-0 max-w-screen-content flex-col gap-3 py-3 md:py-4 md:pt-8 lg:min-h-20 lg:flex-row lg:items-center lg:gap-4'>
               <div className='hidden w-fit shrink-0 items-center gap-4 md:flex'>
                 <h2 className='w-fit min-w-[260px] text-[28px] font-extrabold'>
                   Filter Sessions
@@ -140,7 +139,9 @@ export function ClassSingleUpcomingSearch({
 
           <div className='flex w-full flex-col bg-gray py-8 pl-5 md:pl-12 lg:pl-18 lg:pr-18 md:pt-12 md:pb-20'>
             <div className='mx-auto w-full max-w-screen-content'>
-              <ClassSingleUpcomingResults geoActive={upcoming.geoFiltersActive} />
+              <ClassSingleUpcomingResults
+                geoActive={upcoming.geoFiltersActive}
+              />
             </div>
 
             {/* On Demand Section*/}

--- a/app/routes/class-finder/finder/partials/class-search.partial.tsx
+++ b/app/routes/class-finder/finder/partials/class-search.partial.tsx
@@ -1,51 +1,52 @@
-import { useEffect, useMemo, useState, type ReactNode } from "react";
-import { useLoaderData, useLocation, useSearchParams } from "react-router-dom";
-import { liteClient as algoliasearch } from "algoliasearch/lite";
-import { InstantSearch, SearchBox, useHits } from "react-instantsearch";
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
+import { useLoaderData, useLocation, useSearchParams } from 'react-router-dom';
+import { liteClient as algoliasearch } from 'algoliasearch/lite';
+import { InstantSearch, SearchBox, useHits } from 'react-instantsearch';
 
-import Icon from "~/primitives/icon";
+import Icon from '~/primitives/icon';
 
-import { LoaderReturnType } from "../loader";
-import { ClassHitComponent } from "../components/class-hit-component.component";
-import { AllClassFiltersPopup } from "../components/all-filters.component";
-import { buildIndexInitialUiState } from "~/components/finders/finder-algolia.utils";
-import { FinderResultsStats } from "~/components/finders/finder-results-stats.component";
-import { FinderStickyBar } from "~/components/finders/finder-sticky-bar.component";
+import { LoaderReturnType } from '../loader';
+import { ClassHitComponent } from '../components/class-hit-component.component';
+import { AllClassFiltersPopup } from '../components/all-filters.component';
+import { buildIndexInitialUiState } from '~/components/finders/finder-algolia.utils';
+import { FinderResultsStats } from '~/components/finders/finder-results-stats.component';
+import { FinderStickyBar } from '~/components/finders/finder-sticky-bar.component';
 import {
   SearchFilterDesktopItem,
   SearchFilters,
-} from "~/components/finders/search-filters";
-import { ResponsiveConfigure } from "~/routes/group-finder/partials/group-search.partial";
-import { ClassHitType } from "../../types";
+} from '~/components/finders/search-filters';
+import { ActiveFilters } from '~/components/finders/search-filters/active-filter.component';
+import { ResponsiveConfigure } from '~/routes/group-finder/partials/group-search.partial';
+import { ClassHitType } from '../../types';
 
 import {
   groupClassTypeHits,
   syntheticHitsFromGrouped,
-} from "../components/group-class-type-hits";
-import { useAlgoliaUrlSync } from "~/hooks/use-algolia-url-sync";
-import { useScrollToSearchResultsOnLoad } from "~/hooks/use-scroll-to-search-results-on-load";
-import { HubsTagsRefinementList } from "~/components/hubs-tags-refinement";
+} from '../components/group-class-type-hits';
+import { useAlgoliaUrlSync } from '~/hooks/use-algolia-url-sync';
+import { useScrollToSearchResultsOnLoad } from '~/hooks/use-scroll-to-search-results-on-load';
+import { HubsTagsRefinementList } from '~/components/hubs-tags-refinement';
 import {
   classFinderEmptyState,
   ClassFinderUrlState,
   classFinderUrlStateToParams,
   parseClassFinderUrlState,
-} from "../components/class-finder-url-state";
+} from '../components/class-finder-url-state';
 
-const INDEX_NAME = "dev_Classes";
+const INDEX_NAME = 'dev_Classes';
 
 const CLASS_SEARCH_DESKTOP_FILTERS = [
   {
-    id: "topic",
-    label: "Topic",
-    popupTitle: "Topic",
-    icon: "bookOpen",
+    id: 'topic',
+    label: 'Topic',
+    popupTitle: 'Topic',
+    icon: 'bookOpen',
     data: {
       showFooter: true,
       content: [
         {
-          title: "LEARN ABOUT",
-          attribute: "topic",
+          title: 'LEARN ABOUT',
+          attribute: 'topic',
         },
       ],
     },
@@ -109,12 +110,12 @@ export const ClassSearch = () => {
 
   const fromClassFinderUrl =
     location.pathname +
-    (searchParams.toString() ? `?${searchParams.toString()}` : "");
+    (searchParams.toString() ? `?${searchParams.toString()}` : '');
 
   return (
     <div
-      className="flex w-full min-w-0 max-w-full flex-col gap-4 pagination-scroll-to"
-      id="search"
+      className='flex w-full min-w-0 max-w-full flex-col gap-4 pagination-scroll-to'
+      id='search'
     >
       <InstantSearch
         indexName={INDEX_NAME}
@@ -137,38 +138,38 @@ export const ClassSearch = () => {
         }}
       >
         <ResponsiveConfigure
-          ageInput=""
+          ageInput=''
           coordinates={null}
           hitsPerPageOverride={1000}
         />
-        <div className="flex flex-col bg-white pt-4">
+        <div className='flex flex-col bg-white pt-4'>
           <FinderStickyBar>
-            <div className="mx-auto flex max-w-screen-content flex-col gap-3 py-4 md:flex-row md:items-center md:gap-4">
-              <div className="w-full md:w-[240px] lg:w-[250px] xl:w-[266px] flex items-center rounded-lg border border-[#DEE0E3] focus-within:border-ocean py-2">
+            <div className='mx-auto flex max-w-screen-content flex-col gap-3 py-4 md:flex-row md:items-center md:gap-4'>
+              <div className='w-full md:w-[240px] lg:w-[250px] xl:w-[266px] flex items-center rounded-lg border border-[#DEE0E3] focus-within:border-ocean py-2'>
                 <Icon
-                  name="searchAlt"
-                  className="text-neutral-default ml-3"
+                  name='searchAlt'
+                  className='text-neutral-default ml-3'
                   size={16}
                 />
                 <SearchBox
-                  placeholder="Search"
+                  placeholder='Search'
                   translations={{
-                    submitButtonTitle: "Search",
-                    resetButtonTitle: "Reset",
+                    submitButtonTitle: 'Search',
+                    resetButtonTitle: 'Reset',
                   }}
                   classNames={{
-                    root: "flex-grow",
-                    form: "flex",
+                    root: 'flex-grow',
+                    form: 'flex',
                     input:
-                      "w-full text-base text-neutral-default placeholder:text-neutral-default px-2 py-1 focus:outline-none md:text-sm",
-                    resetIcon: "hidden",
-                    submit: "hidden",
-                    loadingIcon: "hidden",
+                      'w-full text-base text-neutral-default placeholder:text-neutral-default px-2 py-1 focus:outline-none md:text-sm',
+                    resetIcon: 'hidden',
+                    submit: 'hidden',
+                    loadingIcon: 'hidden',
                   }}
                 />
               </div>
 
-              <div className="lg:hidden w-full">
+              <div className='lg:hidden w-full'>
                 <SearchFilters
                   onClearAllToUrl={clearAllFiltersFromUrl}
                   desktopFilters={CLASS_SEARCH_DESKTOP_FILTERS}
@@ -193,18 +194,19 @@ export const ClassSearch = () => {
                 />
               </div>
 
-              <div className="hidden min-w-0 flex-1 lg:block">
+              <div className='hidden min-w-0 flex-1 lg:block'>
                 <HubsTagsRefinementList
-                  attribute="topic"
-                  wrapperClass="flex min-w-0 flex-nowrap gap-2 overflow-x-auto py-1 scrollbar-hide md:gap-3"
+                  attribute='topic'
+                  wrapperClass='flex min-w-0 flex-nowrap gap-2 overflow-x-auto py-1 scrollbar-hide md:gap-3'
                 />
               </div>
             </div>
+            <ActiveFilters onClearAllToUrl={clearAllFiltersFromUrl} />
           </FinderStickyBar>
 
           {/* CLASS SEARCH RESULTS */}
-          <div className="flex flex-col bg-gray py-8 md:pt-12 md:pb-20 w-full content-padding">
-            <div className="max-w-screen-content mx-auto md:w-full">
+          <div className='flex flex-col bg-gray py-8 md:pt-12 md:pb-20 w-full content-padding'>
+            <div className='max-w-screen-content mx-auto md:w-full'>
               <ClassTypeGroupedResults
                 fromClassFinderUrl={fromClassFinderUrl}
               />
@@ -241,11 +243,11 @@ function ClassTypeGroupedResults({
 
   return (
     <>
-      <div className="min-h-[320px]">
+      <div className='min-h-[320px]'>
         <FinderResultsStats hitCount={mappedHits.length} />
 
-        <div className="flex w-full items-center justify-center md:items-start md:justify-start">
-          <div className="grid w-full max-w-[900px] items-stretch lg:max-w-[1296px] gap-y-6 sm:gap-x-8 md:gap-y-8 lg:gap-x-4 lg:gap-y-16 xl:gap-x-8! grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+        <div className='flex w-full items-center justify-center md:items-start md:justify-start'>
+          <div className='grid w-full max-w-[900px] items-stretch lg:max-w-[1296px] gap-y-6 sm:gap-x-8 md:gap-y-8 lg:gap-x-4 lg:gap-y-16 xl:gap-x-8! grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4'>
             {pageHits.map((hit) => (
               <ClassHitComponent
                 key={hit.objectID}
@@ -285,23 +287,23 @@ function ClassSearchPagination({
   const goToPage = (newPage: number) => {
     onPageChange(newPage);
     document
-      .querySelector(".pagination-scroll-to")
-      ?.scrollIntoView({ behavior: "smooth" });
+      .querySelector('.pagination-scroll-to')
+      ?.scrollIntoView({ behavior: 'smooth' });
   };
 
   if (totalPages <= 1) return null;
 
   return (
-    <div className="mt-6 flex justify-center md:justify-start">
-      <div className="flex items-center justify-center gap-2">
+    <div className='mt-6 flex justify-center md:justify-start'>
+      <div className='flex items-center justify-center gap-2'>
         <PaginationControl
           disabled={isFirstPage}
           onClick={() => goToPage(currentPage - 1)}
         >
           <Icon
-            name="chevronLeft"
+            name='chevronLeft'
             size={32}
-            color={isFirstPage ? "#CECECE" : "#0092BC"}
+            color={isFirstPage ? '#CECECE' : '#0092BC'}
           />
         </PaginationControl>
         <p>
@@ -312,9 +314,9 @@ function ClassSearchPagination({
           onClick={() => goToPage(currentPage + 1)}
         >
           <Icon
-            name="chevronRight"
+            name='chevronRight'
             size={32}
-            color={isLastPage ? "#CECECE" : "#0092BC"}
+            color={isLastPage ? '#CECECE' : '#0092BC'}
           />
         </PaginationControl>
       </div>
@@ -341,7 +343,7 @@ function PaginationControl({
 
   return (
     <div>
-      <button type="button" onClick={onClick} className="cursor-pointer">
+      <button type='button' onClick={onClick} className='cursor-pointer'>
         {children}
       </button>
     </div>

--- a/app/routes/group-finder/components/group-hit.component.tsx
+++ b/app/routes/group-finder/components/group-hit.component.tsx
@@ -1,18 +1,18 @@
-import { cn, withRockGetImageSizing } from "~/lib/utils";
-import Icon from "~/primitives/icon";
-import { GroupType, splitGroupTopics } from "../types";
-import { Link } from "react-router-dom";
+import { cn, withRockGetImageSizing } from '~/lib/utils';
+import Icon from '~/primitives/icon';
+import { GroupType, splitGroupTopics } from '../types';
+import { Link } from 'react-router-dom';
 
 export const defaultLeaderPhoto =
-  "https://cloudfront.christfellowship.church/GetAvatar.ashx?PhotoId=&AgeClassification=Adult&Gender=Unknown&RecordTypeId=1&Text=JC&Size=180&Style=icon&BackgroundColor=E4E4E7&ForegroundColor=A1A1AA";
+  'https://cloudfront.christfellowship.church/GetAvatar.ashx?PhotoId=&AgeClassification=Adult&Gender=Unknown&RecordTypeId=1&Text=JC&Size=180&Style=icon&BackgroundColor=E4E4E7&ForegroundColor=A1A1AA';
 
 /** Spanish campuses use a long "Christ Fellowship Español …" label; shorten to "CFE …" on cards. */
 function formatGroupHitCampusName(campusName: string): string {
-  const marker = "Español";
+  const marker = 'Español';
   const i = campusName.indexOf(marker);
   if (i === -1) return campusName;
   const afterMarker = campusName.slice(i + marker.length).trim();
-  return afterMarker ? `CFE ${afterMarker}` : "CFE";
+  return afterMarker ? `CFE ${afterMarker}` : 'CFE';
 }
 
 export function GroupHit({
@@ -22,44 +22,44 @@ export function GroupHit({
   hit: GroupType;
   backUrl?: string;
 }) {
-  const coverImage = hit.coverImage?.sources?.[0]?.uri || "";
-  const preference = hit.groupFor?.trim() || "Anyone";
+  const coverImage = hit.coverImage?.sources?.[0]?.uri || '';
+  const preference = hit.groupFor?.trim() || 'Anyone';
   const topicTags = splitGroupTopics(hit.topics);
 
   // Format the time string to show time with AM/PM and timezone
   const formatTime = (timeString: string) => {
     // If the time string already contains AM/PM, return it as is
     if (
-      timeString.toLowerCase().includes("am") ||
-      timeString.toLowerCase().includes("pm")
+      timeString.toLowerCase().includes('am') ||
+      timeString.toLowerCase().includes('pm')
     ) {
       return timeString;
     }
 
     try {
-      const [hoursStr, minutesStr] = timeString.split(":");
+      const [hoursStr, minutesStr] = timeString.split(':');
       const hours = parseInt(hoursStr, 10);
-      const minutes = parseInt(minutesStr || "0", 10);
+      const minutes = parseInt(minutesStr || '0', 10);
 
       if (isNaN(hours) || isNaN(minutes)) return timeString;
 
-      const ampm = hours >= 12 ? "PM" : "AM";
+      const ampm = hours >= 12 ? 'PM' : 'AM';
       const displayHours = hours % 12 || 12;
-      const displayMinutes = minutes.toString().padStart(2, "0");
+      const displayMinutes = minutes.toString().padStart(2, '0');
 
       // Get current timezone abbreviation
       const timeZone =
         new Date()
-          .toLocaleTimeString("en-US", { timeZoneName: "short" })
-          .split(" ")
-          .pop() || "";
+          .toLocaleTimeString('en-US', { timeZoneName: 'short' })
+          .split(' ')
+          .pop() || '';
 
       // Shorten timezone abbreviations
       const shortTimeZone = timeZone
-        .replace(/E[SD]T/, "ET")
-        .replace(/C[SD]T/, "CT")
-        .replace(/M[SD]T/, "MT")
-        .replace(/P[SD]T/, "PT");
+        .replace(/E[SD]T/, 'ET')
+        .replace(/C[SD]T/, 'CT')
+        .replace(/M[SD]T/, 'MT')
+        .replace(/P[SD]T/, 'PT');
 
       return `${displayHours}:${displayMinutes}${ampm} ${shortTimeZone}`;
     } catch {
@@ -69,56 +69,55 @@ export function GroupHit({
 
   const formattedMeetingDay = (() => {
     const daysOfWeek = [
-      "Monday",
-      "Tuesday",
-      "Wednesday",
-      "Thursday",
-      "Friday",
-      "Saturday",
-      "Sunday",
+      'Monday',
+      'Tuesday',
+      'Wednesday',
+      'Thursday',
+      'Friday',
+      'Saturday',
+      'Sunday',
     ];
-    const day = hit.meetingDay || "";
+    const day = hit.meetingDay || '';
     const isDayOfWeek = daysOfWeek.some((d) => day.includes(d));
     return isDayOfWeek ? day.slice(0, 3) : day;
   })();
   const formattedMeetingTime = formatTime(hit.meetingTime);
 
-  const meetingInfo = formattedMeetingDay + " " + formattedMeetingTime;
+  const meetingInfo = formattedMeetingDay + ' ' + formattedMeetingTime;
 
   const leaders = Array.isArray(hit.leaders) ? hit.leaders : [];
 
-  // TODO: Replace ObjectID with groupGUID later once in Algolia
   return (
     <Link
-      prefetch="intent"
-      to={`/group-finder/${hit.objectID}`}
+      prefetch='intent'
+      to={`/group-finder/${hit.groupGuid}`}
       state={backUrl ? { fromGroupFinder: backUrl } : undefined}
-      className="flex h-full min-h-0 w-full max-w-full flex-col"
+      className='flex h-full min-h-0 w-full max-w-full flex-col'
     >
       <div
         className={cn(
-          "mx-auto flex h-full min-h-0 w-full max-w-[360px] flex-1 cursor-pointer flex-col rounded-lg",
-          "md:max-w-[300px] lg:max-w-[333px] xl:max-w-[300px]",
-          "transition-transform duration-300 ease-out",
-          "hover:-translate-y-1",
+          'mx-auto flex h-full min-h-0 w-full max-w-[360px] flex-1 cursor-pointer flex-col rounded-lg',
+          'md:max-w-[300px] lg:max-w-[333px] xl:max-w-[300px]',
+          'transition-transform duration-300 ease-out',
+          'hover:-translate-y-1',
         )}
       >
-        <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg bg-white">
-          <div className="relative flex flex-col gap-2">
+        <div className='flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg bg-white'>
+          <div className='relative flex flex-col gap-2'>
             <img
               src={coverImage}
               alt={hit.title}
-              className="w-full h-[140px] object-cover overflow-hidden"
+              className='w-full h-[140px] object-cover overflow-hidden'
             />
 
-            <div className="flex gap-1 absolute -bottom-4 lg:-bottom-10 xl:-bottom-4 right-4">
+            <div className='flex gap-1 absolute -bottom-4 lg:-bottom-10 xl:-bottom-4 right-4'>
               {leaders.map((leader, idx) => (
                 <img
                   key={leader.id || idx}
-                  className="rounded-lg border-[1.534px] border-[#EBEBEF] size-[77px] object-cover"
+                  className='rounded-lg border-[1.534px] border-[#EBEBEF] size-[77px] object-cover'
                   style={{
                     boxShadow:
-                      "0px 5.114px 10.228px -2.557px rgba(0, 0, 0, 0.10), 0px 2.557px 5.114px -2.557px rgba(0, 0, 0, 0.06)",
+                      '0px 5.114px 10.228px -2.557px rgba(0, 0, 0, 0.10), 0px 2.557px 5.114px -2.557px rgba(0, 0, 0, 0.06)',
                   }}
                   src={withRockGetImageSizing(
                     leader.photo?.sources?.[0]?.uri ?? defaultLeaderPhoto,
@@ -130,43 +129,43 @@ export function GroupHit({
             </div>
           </div>
 
-          <div className="flex min-h-0 flex-1 flex-col gap-3 pt-[10px]">
-            <div className="flex flex-col px-6 gap-3">
-              <div className="flex flex-col gap-[10px]">
+          <div className='flex min-h-0 flex-1 flex-col gap-3 pt-[10px]'>
+            <div className='flex flex-col px-6 gap-3'>
+              <div className='flex flex-col gap-[10px]'>
                 <div
                   className={`${
-                    preference === "Women"
-                      ? "bg-peach/15 text-[#B33A1B]"
-                      : preference === "Men"
-                        ? "bg-cotton-candy/15 text-cotton-candy"
-                        : preference === "Anyone"
-                          ? "bg-ocean/15 text-ocean"
+                    preference === 'Women'
+                      ? 'bg-peach/15 text-[#B33A1B]'
+                      : preference === 'Men'
+                        ? 'bg-cotton-candy/15 text-cotton-candy'
+                        : preference === 'Anyone'
+                          ? 'bg-ocean/15 text-ocean'
                           : // Couples
-                            "bg-lemon/35 text-[#937200]"
+                            'bg-lemon/35 text-[#937200]'
                   } w-fit flex rounded-sm text-xs font-semibold px-2 py-1`}
                 >
                   {preference}
                 </div>
               </div>
 
-              <div className="flex flex-col gap-1">
-                <h3 className="text-lg font-bold leading-6 line-clamp-2">
+              <div className='flex flex-col gap-1'>
+                <h3 className='text-lg font-bold leading-6 line-clamp-2'>
                   {hit.title}
                 </h3>
-                <p className="text-sm text-neutral-default">{meetingInfo}</p>
+                <p className='text-sm text-neutral-default'>{meetingInfo}</p>
               </div>
             </div>
           </div>
 
-          <div className="flex flex-col mt-auto pt-3.5">
-            <div className="flex flex-wrap px-6 gap-x-2 pb-2">
+          <div className='flex flex-col mt-auto pt-3.5'>
+            <div className='flex flex-wrap px-6 gap-x-2 pb-2'>
               {topicTags.map((topic, index) => (
                 <TagButton key={index} label={topic} />
               ))}
             </div>
-            <div className="w-full px-6 flex items-center justify-center gap-2 py-3 bg-navy text-white ">
-              <Icon name="map" size={20} color="white" />
-              <p className="text-sm font-semibold">
+            <div className='w-full px-6 flex items-center justify-center gap-2 py-3 bg-navy text-white '>
+              <Icon name='map' size={20} color='white' />
+              <p className='text-sm font-semibold'>
                 {formatGroupHitCampusName(hit.campusName)}
               </p>
             </div>
@@ -179,7 +178,7 @@ export function GroupHit({
 
 const TagButton = ({ label }: { label: string }) => {
   return (
-    <div className="bg-navy-subdued text-dark-navy shrink-0 h-6 rounded-sm text-xs font-semibold p-1 mb-2">
+    <div className='bg-navy-subdued text-dark-navy shrink-0 h-6 rounded-sm text-xs font-semibold p-1 mb-2'>
       {label}
     </div>
   );

--- a/app/routes/group-finder/types.ts
+++ b/app/routes/group-finder/types.ts
@@ -1,5 +1,5 @@
 /** Algolia index for small-group search (finder, single group loader, related groups, class-single). */
-export const GROUPS_ALGOLIA_INDEX_NAME = "dev_Groups";
+export const GROUPS_ALGOLIA_INDEX_NAME = 'dev_Groups';
 
 // Image source structure
 export interface ImageSource {
@@ -18,57 +18,57 @@ export interface GroupLeaderHit {
 }
 
 export type GroupMeetingFrequency =
-  | "Weekly"
-  | "Monthly"
-  | "Bi-Weekly"
-  | "Once"
-  | "Daily";
+  | 'Weekly'
+  | 'Monthly'
+  | 'Bi-Weekly'
+  | 'Once'
+  | 'Daily';
 
-export type GroupMeetingLocationType = "Home" | "Church" | "Public Place";
+export type GroupMeetingLocationType = 'Home' | 'Church' | 'Public Place';
 
-export type GroupMeetingType = "In Person" | "Online" | "Virtual";
+export type GroupMeetingType = 'In Person' | 'Online' | 'Virtual';
 
 export type GroupMeetingDay =
-  | "Monday"
-  | "Tuesday"
-  | "Wednesday"
-  | "Thursday"
-  | "Friday"
-  | "Saturday"
-  | "Sunday"
-  | "Daily"
-  | "Not Specified";
+  | 'Monday'
+  | 'Tuesday'
+  | 'Wednesday'
+  | 'Thursday'
+  | 'Friday'
+  | 'Saturday'
+  | 'Sunday'
+  | 'Daily'
+  | 'Not Specified';
 
-export type GroupFor = "Men" | "Women" | "Anyone" | "Couples";
+export type GroupFor = 'Men' | 'Women' | 'Anyone' | 'Couples';
 
 export type GroupPeopleWhoAre =
-  | "Single"
-  | "Married"
-  | "Divorced"
-  | "Engaged"
-  | "Empty Nesters"
-  | "New Believers"
-  | "Parents"
-  | "Professionals";
+  | 'Single'
+  | 'Married'
+  | 'Divorced'
+  | 'Engaged'
+  | 'Empty Nesters'
+  | 'New Believers'
+  | 'Parents'
+  | 'Professionals';
 
-export type GroupLanguage = "English" | "Spanish";
+export type GroupLanguage = 'English' | 'Spanish';
 
 export type GroupTopic =
-  | "Bible Study"
-  | "Prayer"
-  | "Message Discussion"
-  | "Marriage"
-  | "Parenting"
-  | "Finances"
-  | "Friendship"
-  | "Activty/Hobby"
-  | "Book Club"
-  | "Sports"
-  | "Podcast"
-  | "Watch Party";
+  | 'Bible Study'
+  | 'Prayer'
+  | 'Message Discussion'
+  | 'Marriage'
+  | 'Parenting'
+  | 'Finances'
+  | 'Friendship'
+  | 'Activty/Hobby'
+  | 'Book Club'
+  | 'Sports'
+  | 'Podcast'
+  | 'Watch Party';
 
 /** Facet values on `adultsOnly` in Algolia. */
-export type GroupAdultsOnlyFacet = "True" | "False";
+export type GroupAdultsOnlyFacet = 'True' | 'False';
 
 /**
  * Record shape for the `dev_Groups` Algolia index (UI reads these fields directly).
@@ -76,7 +76,7 @@ export type GroupAdultsOnlyFacet = "True" | "False";
  */
 export interface GroupType {
   objectID: string;
-  groupGUID: string;
+  groupGuid: string;
   groupId?: number;
   title: string;
   summary: string;
@@ -84,10 +84,10 @@ export interface GroupType {
   classType?: string;
   coverImage: ImageSource;
   /** Empty string when unset in Rock / Algolia. */
-  meetingLocationType: GroupMeetingLocationType | "";
+  meetingLocationType: GroupMeetingLocationType | '';
   meetingLocation: string;
   /** Empty string when unset in Rock / Algolia. */
-  meetingDay: GroupMeetingDay | "";
+  meetingDay: GroupMeetingDay | '';
   meetingTime: string;
   meetingType: GroupMeetingType;
   meetingFrequency: GroupMeetingFrequency;
@@ -96,10 +96,10 @@ export interface GroupType {
   /** Algolia may return `null` when no leaders are attached. */
   leaders: GroupLeaderHit[] | null;
   /** Empty string when unset in Rock / Algolia. */
-  groupFor: GroupFor | "";
+  groupFor: GroupFor | '';
   peopleWhoAre?: GroupPeopleWhoAre[];
   /** Empty string when unset in Rock / Algolia. */
-  language: GroupLanguage | "";
+  language: GroupLanguage | '';
   /** Often a comma-separated list from Rock; use {@link splitGroupTopics} for tags. */
   topics: string;
   minMaxAge: string;
@@ -112,7 +112,7 @@ export function splitGroupTopics(topics: string | null | undefined): string[] {
     return [];
   }
   return String(topics)
-    .split(",")
+    .split(',')
     .map((s) => s.trim())
     .filter(Boolean);
 }

--- a/app/routes/group-single/loader.tsx
+++ b/app/routes/group-single/loader.tsx
@@ -1,15 +1,19 @@
-import { LoaderFunctionArgs } from "react-router-dom";
-import { AuthenticationError } from "~/lib/.server/error-types";
-import { algoliasearch } from "algoliasearch";
-import { escapeAlgoliaFilterString } from "~/components/finders/finder-algolia.utils";
-import { GroupType, GROUPS_ALGOLIA_INDEX_NAME } from "../group-finder/types";
+import { LoaderFunctionArgs } from 'react-router-dom';
+import { AuthenticationError } from '~/lib/.server/error-types';
+import { algoliasearch } from 'algoliasearch';
+import { escapeAlgoliaFilterString } from '~/components/finders/finder-algolia.utils';
+import { GroupType, GROUPS_ALGOLIA_INDEX_NAME } from '../group-finder/types';
 
 export type LoaderReturnType = {
   ALGOLIA_APP_ID: string;
   ALGOLIA_SEARCH_API_KEY: string;
-  groupGUID: string;
+  groupGuid: string;
   group: GroupType | null;
 };
+
+export function normalizeGroupGuid(value: string): string {
+  return value.trim().toUpperCase();
+}
 
 async function fetchGroupWithFilter(
   filters: string,
@@ -36,50 +40,93 @@ async function fetchGroupWithFilter(
 
     return hit as unknown as GroupType;
   } catch (error) {
-    console.error("Failed to fetch group from Algolia:", error);
+    console.error('Failed to fetch group from Algolia:', error);
     return null;
   }
 }
 
-// TOOD: Replace ObjectID with groupGUID later once in Algolia
+/**
+ * Resolve by `groupGuid` without relying on Algolia facet filters (see volunteer
+ * `VolunteerMissionSpotsAlgoliaProvider`: query + exact GUID match).
+ */
+async function fetchGroupByGuidSearch(
+  segment: string,
+  appId: string,
+  apiKey: string,
+): Promise<GroupType | null> {
+  const trimmed = segment.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  try {
+    const searchClient = algoliasearch(appId, apiKey);
+    const want = normalizeGroupGuid(trimmed);
+
+    const response = await searchClient.searchForHits<Record<string, unknown>>([
+      {
+        indexName: GROUPS_ALGOLIA_INDEX_NAME,
+        params: {
+          query: trimmed,
+          hitsPerPage: 50,
+        },
+      },
+    ]);
+
+    const hits = response.results[0]?.hits ?? [];
+    for (const hit of hits) {
+      const raw = hit.groupGuid as string | undefined;
+      if (typeof raw === 'string' && normalizeGroupGuid(raw) === want) {
+        return hit as unknown as GroupType;
+      }
+    }
+    return null;
+  } catch (error) {
+    console.error('Failed to search group by GUID in Algolia:', error);
+    return null;
+  }
+}
+
 async function fetchGroupByPathSegment(
   segment: string,
   appId: string,
   apiKey: string,
 ): Promise<GroupType | null> {
   const escaped = escapeAlgoliaFilterString(segment);
-  const byGuid = await fetchGroupWithFilter(
-    `objectID:"${escaped}"`,
+
+  /** Legacy URLs used Algolia `objectID` in the path (`objectID` is always filterable). */
+  const byObjectId = await fetchGroupWithFilter(
+    `groupGuid:${escaped}`,
     appId,
     apiKey,
   );
-  if (byGuid) {
-    return byGuid;
+  if (byObjectId) {
+    return byObjectId;
   }
-  /** Legacy URLs used Algolia `objectID` in the path. */
-  return fetchGroupWithFilter(`objectID:"${escaped}"`, appId, apiKey);
+
+  return fetchGroupByGuidSearch(segment, appId, apiKey);
 }
 
 export async function loader({ params }: LoaderFunctionArgs) {
-  const groupGUID = params.path || "";
+  const groupGuid = params.path || '';
 
-  if (!groupGUID) {
-    throw new Error("Group not found");
+  if (!groupGuid) {
+    throw new Error('Group not found');
   }
 
   const appId = process.env.ALGOLIA_APP_ID;
   const searchApiKey = process.env.ALGOLIA_SEARCH_API_KEY;
 
   if (!appId || !searchApiKey) {
-    throw new AuthenticationError("Algolia credentials not found");
+    throw new AuthenticationError('Algolia credentials not found');
   }
 
-  const group = await fetchGroupByPathSegment(groupGUID, appId, searchApiKey);
+  const group = await fetchGroupByPathSegment(groupGuid, appId, searchApiKey);
 
   return Response.json({
     ALGOLIA_APP_ID: appId,
     ALGOLIA_SEARCH_API_KEY: searchApiKey,
-    groupGUID,
+    groupGuid,
     group,
   });
 }

--- a/package.json
+++ b/package.json
@@ -120,5 +120,5 @@
       "jsdom": "26.1.0"
     }
   },
-  "packageManager": "pnpm@10.33.2"
+  "packageManager": "pnpm@10.33.3"
 }


### PR DESCRIPTION
## Summary
Improves the class finder and class detail flows so filter state and navigation match patterns used elsewhere (e.g. group finder), fixes sticky filter behavior on the class single “upcoming sessions” experience, and refreshes the class single hero on small screens.

**Class finder listing:** Renders the shared `ActiveFilters` strip (chips + Clear All, URL-synced) inside the sticky search area so narrow viewports get the same affordances as desktop.

**Class single page:** On viewports below `md`, shows a full-width hero image with a floating back control; the in-flow “Back to All Classes” link and duplicate hero image are hidden until `md` via new optional `FinderHero` props (`backLinkMdUpOnly`, `heroImageMdUpOnly`), with unit tests.

**Class single upcoming sessions:** Restructures the DOM so the sticky filter bar shares a tall column ancestor with the gray results block—`position: sticky` was previously constrained by short sibling wrappers, so the bar scrolled away on both mobile and desktop. Consolidates to a single `FinderStickyBar` and one `SearchFilters` instance with responsive layout (mobile heading stays above the bar; desktop title + divider + filters unchanged in spirit).

**Upcoming sessions carousel:** Adjusts horizontal padding on the carousel nav controls so controls align with the section’s asymmetric padding on smaller breakpoints.

## Screenshots
<img width="1677" height="1315" alt="Screenshot 2026-05-05 at 11 32 30 AM" src="https://github.com/user-attachments/assets/c6c77aff-ab89-4769-a2dc-7d18e2c7b4ce" />


## Testing
**Suggested verification**
- **Class finder (`/class-finder`):** On a narrow viewport, apply refinements; confirm the active filters row and Clear All appear under the search strip and URL updates still behave as before.
- **Class single:** Below `md`, confirm full-bleed hero, overlay back uses browser back when history allows else `/class-finder`; from `md` up, confirm text back link and hero image return.
- **Class single upcoming:** Scroll past “Filter Sessions”; confirm the filter strip stays pinned under the site header through the gray “Join a Class” / carousel area on both mobile and desktop widths.
-`pnpm check` shows no errors or warnings.

## Tickets
[CFDP-3925](https://christfellowshipchurch.atlassian.net/browse/CFDP-3925)

## Changes Made

### New Components Added
- None.

### New Utilities
- None.

### New Assets
- None.

### Dependencies
- None.

### Route Implementation
- `app/routes/class-finder/finder/partials/class-search.partial.tsx` — `ActiveFilters` composed with existing `FinderStickyBar` / URL clear handler.
- `app/routes/class-finder/class-single/class-single-page.tsx` — Mobile hero + overlay back; wires `FinderHero` with `backLinkMdUpOnly` / `heroImageMdUpOnly`.
- `app/routes/class-finder/class-single/partials/upcoming-sections.partial.tsx` — Single sticky filters column wrapping results for correct sticky containment; responsive filter chrome.
- `app/routes/class-finder/class-single/components/upcoming-sessions-carousel.component.tsx` — Carousel nav row padding tweak for alignment with section padding.

### Key Features
- Class finder mobile/tablet: visible active Algolia refinements and Clear All in the sticky header region.
- Class single: mobile hero matches other single-page patterns (full-width image + overlay back); desktop hero/back unchanged in behavior.
- `FinderHero`: optional props to hide back link and/or hero image below `md` when a separate mobile hero is rendered; Vitest coverage for those flags.
- Class single upcoming: sticky “Filter Sessions” bar works while scrolling results on all breakpoints; avoids duplicate `SearchFilters` / InstantSearch widgets.

[CFDP-3925]: https://christfellowshipchurch.atlassian.net/browse/CFDP-3925?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ