### PR TITLE
Add overscroll/viewport utilities and touch fixes

### DIFF
--- a/app/components/navbar/desktop/search/search-popup.component.tsx
+++ b/app/components/navbar/desktop/search/search-popup.component.tsx
@@ -190,7 +190,7 @@ export const SearchPopup = ({
       <ContentItemsHitsCollector onHitsChange={setContentHits} />
 
       <div className="mt-2 space-y-4">
-        <div className="flex flex-col overflow-y-scroll max-h-[300px] scrollbar-thin [&::-webkit-scrollbar]:w-1 [&::-webkit-scrollbar-thumb]:bg-neutral-default/60 [&::-webkit-scrollbar-track]:bg-gray">
+        <div className="flex flex-col overflow-y-scroll overscroll-contain max-h-[300px] scrollbar-thin [&::-webkit-scrollbar]:w-1 [&::-webkit-scrollbar-thumb]:bg-neutral-default/60 [&::-webkit-scrollbar-track]:bg-gray">
           {combinedHits.map((hit) => (
             <div
               key={hit.objectID}

--- a/app/components/navbar/mobile/mobile-menu-content.tsx
+++ b/app/components/navbar/mobile/mobile-menu-content.tsx
@@ -38,7 +38,7 @@ export default function MobileMenuContent({
   };
 
   return (
-    <div className="h-full overflow-y-auto bg-white">
+    <div className="h-full overflow-y-auto overscroll-contain bg-white">
       <div className="pb-24">
         <MenuSection
           title="Welcome to Church"

--- a/app/components/navbar/mobile/mobile-menu.component.tsx
+++ b/app/components/navbar/mobile/mobile-menu.component.tsx
@@ -5,7 +5,7 @@ import { Button } from "~/primitives/button/button.primitive";
 import { MobileSearch } from "./search/mobile-search.component";
 import { useResponsive } from "~/hooks/use-responsive";
 const mobileMenuButtonStyle =
-  "cursor-pointer transition-colors duration-300 active:scale-95 active:opacity-80";
+  "cursor-pointer touch-manipulation transition-colors duration-300 active:scale-95 active:opacity-80";
 
 export default function MobileMenu({
   mode,
@@ -35,6 +35,9 @@ export default function MobileMenu({
     };
   }, [isOpen, isSearchOpen]);
 
+  // TODO(scroll-audit): This fixed drawer/search UI is rendered inside the navbar, which can receive `-translate-y-full`; hoist it to a portal if fixed-position anchoring still jitters in Blink.
+  // TODO(scroll-audit): Nested scroll container: the fixed drawer panel and MobileMenuContent both scroll; flatten after confirming drawer header/footer sizing.
+  // TODO(scroll-audit): Nested scroll container: the fixed search panel and MobileSearch both scroll; flatten after confirming sticky search header behavior.
   return (
     <div
       className={`lg:hidden ${
@@ -128,7 +131,7 @@ export default function MobileMenu({
       <div
         className={`fixed ${
           showSiteBanner ? "top-[48px]" : "top-[0px]"
-        } right-0 w-4/5 max-w-[400px] h-full bg-white z-50 transform transition-all duration-300 overflow-y-auto
+        } right-0 bottom-0 w-4/5 max-w-[400px] bg-white z-50 transform transition-all duration-300 overflow-y-auto overscroll-contain
           ${
             !isOpen
               ? "translate-x-full invisible opacity-0"
@@ -150,7 +153,7 @@ export default function MobileMenu({
       <div
         className={`fixed ${
           showSiteBanner ? "top-[48px]" : "top-[0px]"
-        } right-0 w-full h-full bg-white z-50 transform transition-all duration-300 overflow-y-auto
+        } right-0 bottom-0 w-full bg-white z-50 transform transition-all duration-300 overflow-y-auto overscroll-contain
           ${
             !isSearchOpen
               ? "translate-x-full invisible opacity-0"

--- a/app/components/navbar/mobile/search/mobile-search.component.tsx
+++ b/app/components/navbar/mobile/search/mobile-search.component.tsx
@@ -62,7 +62,7 @@ export const MobileSearch = ({
       : emptySearchClient);
 
   return (
-    <div className="h-full overflow-y-auto bg-white">
+    <div className="h-full overflow-y-auto overscroll-contain bg-white">
       <InstantSearch
         indexName="dev_contentItems"
         searchClient={searchClient}

--- a/app/primitives/Modal/modal.primitive.tsx
+++ b/app/primitives/Modal/modal.primitive.tsx
@@ -42,7 +42,7 @@ function ModalContent({
           transform: 'translate(-50%, -50%)',
         }}
         className={cn(
-          "sm:h-auto max-h-[90vh] data-[state=closed]:animate-dialogContentHide data-[state=open]:animate-dialogContentShow z-500 content-padding"
+          "sm:h-auto max-h-modal-dynamic overflow-y-auto overscroll-contain data-[state=closed]:animate-dialogContentHide data-[state=open]:animate-dialogContentShow z-500 content-padding"
         )}
       >
         <div

--- a/app/primitives/button/button.primitive.tsx
+++ b/app/primitives/button/button.primitive.tsx
@@ -14,6 +14,7 @@ export const button = cva(
     "delay-50",
     "rounded-md",
     "cursor-pointer",
+    "touch-manipulation",
     "font-semibold",
   ],
   {

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -108,7 +108,7 @@ export default function App() {
     <AuthProvider>
       <CookieConsentProvider>
         <NavbarVisibilityProvider>
-          <div className="min-h-screen flex flex-col text-pretty">
+          <div className="min-h-dvh-fallback flex flex-col text-pretty">
             <Navbar />
             <main>
               <Outlet />

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -34,7 +34,7 @@ export const meta: MetaFunction = () => {
 export default function HomePage() {
   return (
     <>
-      <div className='w-screen h-screen absolute top-0 left-0 bg-white -z-100' />
+      <div className='w-screen h-dvh-fallback absolute top-0 left-0 bg-white -z-100' />
       <HeroSection />
       <AChanceSection />
       <WhatWeOfferSection />

--- a/app/routes/about/components/leaders-scroll.component.tsx
+++ b/app/routes/about/components/leaders-scroll.component.tsx
@@ -59,7 +59,7 @@ export function LeaderScroll() {
       </Modal>
 
       {/* Other Leaders */}
-      <div className="flex items-start lg:items-end gap-3 overflow-scroll sm:mr-4 md:mr-12 pr-4">
+      <div className="flex items-start lg:items-end gap-3 overflow-scroll overscroll-x-contain sm:mr-4 md:mr-12 pr-4">
         {otherLeaderItems.map((leader, index) => (
           <MobileLeaderCard key={leader.id} leader={leader} index={index} />
         ))}

--- a/app/routes/home/components/hero/desktop-hero.component.tsx
+++ b/app/routes/home/components/hero/desktop-hero.component.tsx
@@ -7,7 +7,7 @@ export function DesktopHeroSection() {
   const [isSearching, setIsSearching] = useState(false);
 
   return (
-    <section className='h-[110vh] max-h-[1200px] w-full bg-white mt-[-26px] hidden lg:block relative z-30'>
+    <section className='h-home-hero-desktop max-h-[1200px] w-full bg-white mt-[-26px] hidden lg:block relative z-30'>
       {/* background image and video */}
       <div className='grid grid-cols-2 size-full relative'>
         {/* Left Column */}

--- a/app/routes/home/components/hero/mobile-hero.component.tsx
+++ b/app/routes/home/components/hero/mobile-hero.component.tsx
@@ -18,7 +18,7 @@ export const MobileHeroSection = () => {
   }, []);
 
   return (
-    <section className="h-dvh w-full bg-white pb-8 relative max-h-[700px] block lg:hidden z-30">
+    <section className="h-dvh-fallback w-full bg-white pb-8 relative max-h-[700px] block lg:hidden z-30">
       {/*  Background Video — poster image paints first; iframe loads after idle */}
       <div className="absolute inset-0 w-full h-full z-1">
         {showVideo ? (

--- a/app/routes/home/components/image-scroll-layout.tsx
+++ b/app/routes/home/components/image-scroll-layout.tsx
@@ -88,7 +88,7 @@ export function ImageScrollLayout() {
       <div className="fixed top-0 left-0 w-screen h-48 md:h-64 bg-linear-to-b from-white via-white to-transparent z-5 pointer-events-none" />
 
       {/* Fixed Image Container (md+) — viewport-anchored to avoid layout shifts from hiding navbar */}
-      <div className="hidden md:block fixed left-0 top-0 w-1/2 h-screen z-0 pointer-events-none pl-5 md:pl-12 lg:pl-18">
+      <div className="hidden md:block fixed left-0 top-0 w-1/2 h-dvh-fallback z-0 pointer-events-none pl-5 md:pl-12 lg:pl-18">
         <div className="w-full h-full flex max-w-[716px] ml-auto">
           <div className="relative w-full max-w-md xl:max-w-lg aspect-square">
             {chanceContent.map((section, index) => (
@@ -118,7 +118,7 @@ export function ImageScrollLayout() {
               sectionRefs.current[index] = el;
             }}
             className={cn(
-              "relative flex items-center p-12 min-h-screen w-full",
+              "relative flex items-center p-12 min-h-dvh-fallback w-full",
               index === 2 && "pb-24 md:pb-0", // Add padding to the last section on mobile to prevent content from grayed out from gradient
             )}
             data-card-index={index}

--- a/app/routes/home/components/location-search/search-popup.tsx
+++ b/app/routes/home/components/location-search/search-popup.tsx
@@ -15,7 +15,7 @@ export const SearchPopup = ({
       <div className="space-y-4">
         <Hits
           classNames={{
-            root: "flex flex-col overflow-y-auto max-h-[300px]",
+            root: "flex flex-col overflow-y-auto overscroll-contain max-h-[300px]",
             item: "flex w-full rounded-xl transition-transform duration-300 border-[1px] border-[#E8E8E8] [&:first-child]:!border-navy hover:border-navy",
             list: "flex flex-col gap-3",
           }}

--- a/app/routes/home/components/we-offer-tabs/mobile.component.tsx
+++ b/app/routes/home/components/we-offer-tabs/mobile.component.tsx
@@ -104,6 +104,7 @@ export const WhatWeOfferMobile = ({
                 style={{
                   paddingLeft: "calc(50vw - 36vw)",
                   paddingRight: "calc(50vw - 36vw)",
+                  scrollPaddingInline: "calc(50vw - 36vw)",
                 }}
               >
                 {tab.content.map((content, index) => (

--- a/app/styles/tailwind.css
+++ b/app/styles/tailwind.css
@@ -14,6 +14,26 @@
   }
 }
 
+@utility h-dvh-fallback {
+  height: 100vh;
+  height: 100dvh;
+}
+
+@utility min-h-dvh-fallback {
+  min-height: 100vh;
+  min-height: 100dvh;
+}
+
+@utility h-home-hero-desktop {
+  height: 110vh;
+  height: 110dvh;
+}
+
+@utility max-h-modal-dynamic {
+  max-height: 90vh;
+  max-height: 90dvh;
+}
+
 /* ------------ Custom Animation Tokens ------------ */
 @theme {
   /* Navbar */
@@ -113,6 +133,18 @@
   --color-link-primary: var(--color-black);
   --color-link-secondary: var(--color-neutral-default);
   --color-link-alternate: var(--color-white);
+}
+
+@layer base {
+  html {
+    scrollbar-gutter: stable;
+  }
+
+  :where(a, button, [role="button"]) {
+    touch-action: manipulation;
+  }
+
+  /* TODO(scroll-audit): Validate whether Chrome Android pull-to-refresh conflicts with the home hero search and fixed navbar before adding `overscroll-behavior-y: contain` to html/body. */
 }
 
 /* ------------ Custom Keyframes ------------ */


### PR DESCRIPTION
## Summary

This branch improves mobile scrolling and viewport behavior across the app: it introduces **dynamic viewport height (`dvh`) fallbacks** so layouts respect mobile browser chrome (address bar / safe areas), adds **`overscroll-contain`** on nested scroll regions (nav search, mobile menu, modals, horizontal leader carousel) to reduce scroll chaining and rubber-banding bleed-through, and applies **`touch-manipulation`** on buttons and interactive controls for more predictable tap behavior. The mobile nav drawer panels are anchored with **`bottom-0`** (replacing `h-full`) alongside **`overscroll-contain`**. Global **`scrollbar-gutter: stable`** on `html` reduces layout shift when scrollbars appear. The home “What we offer” mobile carousel gets **`scrollPaddingInline`** for better centered snap alignment. Scroll-audit TODOs note follow-ups (portal for fixed drawer, flattening nested scroll, validating pull-to-refresh vs hero).

## Screenshots

[Paste your screenshots here]

## Testing

- [ ] How were these changes tested?
  - Manual smoke on iOS Safari / Chrome Android recommended: home hero, image scroll sections, mobile nav open/close + search, modal overflow, horizontal leader strip on About.
- [ ] What steps can someone follow to verify functionality?
  - Open home on a narrow viewport; scroll hero and “A chance” image layout; open mobile menu and search; scroll long lists inside popovers; open a modal with tall content; on About, horizontally scroll the leaders row and confirm the page behind doesn’t steal scroll unexpectedly.
- [ ] Was any new linter errors/warnings?
  - Run `pnpm lint` after merge candidate.

## Tickets

[insert Jira ticket reference here]

## Changes Made

### New Utilities

- **`app/styles/tailwind.css`** — Tailwind v4 `@utility` helpers:
  - `h-dvh-fallback` / `min-h-dvh-fallback` — `100vh` with `100dvh` override for stable full-viewport sizing on mobile.
  - `h-home-hero-desktop` — desktop hero height using `110vh` / `110dvh`.
  - `max-h-modal-dynamic` — modal max height `90vh` / `90dvh`.
- **`@layer base`** in the same file: `scrollbar-gutter: stable` on `html`; `touch-action: manipulation` on links and buttons (`a`, `button`, `[role="button"]`).

### Route Implementation

- **`app/root.tsx`** — root shell uses `min-h-dvh-fallback` instead of `min-h-screen`.
- **`app/routes/_index.tsx`** — full-bleed background layer uses `h-dvh-fallback` instead of `h-screen`.
- **`app/routes/home/components/hero/mobile-hero.component.tsx`** — hero section `h-dvh` → `h-dvh-fallback`.
- **`app/routes/home/components/hero/desktop-hero.component.tsx`** — hero height → `h-home-hero-desktop`.
- **`app/routes/home/components/image-scroll-layout.tsx`** — fixed image column and section min-heights use `h-dvh-fallback` / `min-h-dvh-fallback`.
- **`app/routes/home/components/location-search/search-popup.tsx`** — hits list root adds `overscroll-contain`.
- **`app/routes/home/components/we-offer-tabs/mobile.component.tsx`** — inline `scrollPaddingInline` for horizontal snap alignment.
- **`app/routes/about/components/leaders-scroll.component.tsx`** — horizontal scroller adds `overscroll-x-contain`.

### Key Features

- **Viewport-aware heights** — Shared utilities reduce mobile layout jumps when `100vh` and real viewport height disagree (address bar show/hide).
- **Contained overscroll** — Popovers, mobile menu/search stacks, modals, and horizontal carousels limit scroll chaining for a cleaner mobile feel.
- **Touch tuning** — `touch-manipulation` on the shared button primitive and base interactive elements; mobile menu trigger includes `touch-manipulation`.
- **Mobile nav drawer** — Fixed panels use `bottom-0` + `overscroll-contain`; TODO comments document possible portal / flatten-scroll follow-ups.
- **Modal body scroll** — Dialog content scrolls with `max-h-modal-dynamic` and `overscroll-contain`.
- **Accessibility / UX** — Stable scrollbar gutter on `html` mitigates horizontal shift when vertical scrollbar toggles.