### PR TITLE
Pastors Todd & Julie Image Update

### DIFF
--- a/app/routes/about/components/leaders-data.ts
+++ b/app/routes/about/components/leaders-data.ts
@@ -15,7 +15,7 @@ export const leaders: LeaderProfile[] = [
     bio: "Pastors Todd and Julie Mullins are the Senior Pastors of Christ Fellowship Church. Under their leadership, Christ Fellowship has continued its growth as a multi-site congregation that gathers thousands in South Florida each week and digitally reaches thousands beyond the region through Christ Fellowship Everywhere. <br /> <br /> Their leadership expands beyond the walls of Christ Fellowship as they serve the South Florida region and beyond. They are the founders of Church United, a partnership of local churches across various denominations that join together to transform South Florida. Todd and Julie also serve on the lead team of the Association of Related Churches (ARC) and on the board of directors for Place of Hope Children's Home in South Florida. They are both frequently invited to speak at churches and conferences around the globe, and Todd recently authored his debut book, Don't Let Doubt Take You Out. Together, they have a son, Jefferson, who also serves in ministry at Christ Fellowship alongside his wife, Cassie.",
     pathname: 'todd-julie-mullins',
     profilePhoto:
-      'https://cloudfront.christfellowship.church/GetImage.ashx?id=3166893',
+      'https://cloudfront.christfellowship.church/GetImage.ashx?id=3169737',
   },
   {
     id: '2',


### PR DESCRIPTION
## Summary
Updates the Todd & Julie Mullins profile photo URL in `leaders-data.ts` so the correct image is served. Home and About both use this data (via the shared home loader), so both pages stay in sync.

## Screenshots
<img width="1512" height="829" alt="Screenshot 2026-05-06 at 1 17 08 PM" src="https://github.com/user-attachments/assets/a64dbb71-62db-478f-82b2-1d1e6dac66e9" />

## Testing
- [ ] Open `/` and confirm the senior pastors photo in the leadership section matches the intended image.
- [ ] Open `/about`, scroll to leadership, and confirm the same photo (grid and scroll where applicable).
- [ ] Confirm both desktop & mobile views show the correct image.
- [ ] `pnpm run check` shows no errors or warnings.

## Tickets
[CFDP-3927](https://christfellowshipchurch.atlassian.net/browse/CFDP-3927)

## Changes Made

### New Components Added
- None

### New Utilities
- None

### New Assets
- None (CloudFront image ID only: `3166893` → `3169737`)

### Dependencies
- None

### Route Implementation
- `app/routes/about/components/leaders-data.ts` — Mullins `profilePhoto` URL updated

### Key Features
- Correct senior pastors image on Home and About leadership UI

[CFDP-3927]: https://christfellowshipchurch.atlassian.net/browse/CFDP-3927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ