### PR TITLE
Feature/community serving native signup

### DIFF
--- a/app/components/dynamic-hero/index.tsx
+++ b/app/components/dynamic-hero/index.tsx
@@ -1,11 +1,11 @@
-import { useLocation } from "react-router-dom";
-import { Breadcrumbs } from "../breadcrumbs";
-import { IconButton } from "~/primitives/button/icon-button.primitive";
-import { Button } from "~/primitives/button/button.primitive";
-import HTMLRenderer from "~/primitives/html-renderer";
-import { cn } from "~/lib/utils";
-import { SetAReminderModal } from "../modals/set-a-reminder/reminder-modal.component";
-import { Video } from "~/primitives/video/video.primitive";
+import { useLocation } from 'react-router-dom';
+import { Breadcrumbs } from '../breadcrumbs';
+import { IconButton } from '~/primitives/button/icon-button.primitive';
+import { Button } from '~/primitives/button/button.primitive';
+import HTMLRenderer from '~/primitives/html-renderer';
+import { cn } from '~/lib/utils';
+import { SetAReminderModal } from '../modals/set-a-reminder/reminder-modal.component';
+import { Video } from '~/primitives/video/video.primitive';
 
 export type DynamicHeroOverlay = 'gradient' | 'full' | 'none';
 
@@ -37,45 +37,46 @@ export const DynamicHero = ({
   overlay = 'gradient',
 }: DynamicHeroTypes) => {
   const location = useLocation();
+  const hasCtas = Boolean(ctas?.length);
 
   const pagePath =
     location.pathname
-      .split("/")
+      .split('/')
       .filter(Boolean)
       .map((segment) =>
         segment
-          .split("-")
+          .split('-')
           .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-          .join(" "),
-      )[0] || "Home";
+          .join(' '),
+      )[0] || 'Home';
 
   return (
     <div
       style={{
-        ["--mobile-height" as string]: mobileHeight || "720px",
-        ["--ipad-height" as string]: ipadHeight || mobileHeight || "640px",
-        ["--desktop-height" as string]:
-          desktopHeight || ipadHeight || mobileHeight || "640px",
+        ['--mobile-height' as string]: mobileHeight || '720px',
+        ['--ipad-height' as string]: ipadHeight || mobileHeight || '640px',
+        ['--desktop-height' as string]:
+          desktopHeight || ipadHeight || mobileHeight || '640px',
       }}
       className={cn(
-        "relative flex items-center justify-start self-stretch",
-        "h-(--mobile-height)",
-        "md:h-(--ipad-height)",
-        "lg:h-(--desktop-height)",
+        'relative flex items-center justify-start self-stretch',
+        hasCtas ? 'h-(--mobile-height)' : 'max-md:aspect-square max-md:h-auto',
+        'md:h-(--ipad-height)',
+        'lg:h-(--desktop-height)',
       )}
       aria-label={`${pagePath} Hero`}
     >
       {/* Video if passed in */}
       {/* z-0 traps poster/video/dim layer below gradient + content (inner z-[15] stays inside this context) */}
-      <div className="absolute inset-0 z-0 size-full overflow-hidden">
+      <div className='absolute inset-0 z-0 size-full overflow-hidden'>
         {/* Use <img> (not CSS background) so fetchPriority applies when Wistia + poster */}
         {wistiaId && imagePath && (
           <img
             src={imagePath}
-            alt=""
-            fetchPriority="high"
-            decoding="async"
-            className="absolute inset-0 z-0 w-full h-full object-cover"
+            alt=''
+            fetchPriority='high'
+            decoding='async'
+            className='absolute inset-0 z-0 w-full h-full object-cover'
             aria-hidden
           />
         )}
@@ -86,13 +87,13 @@ export const DynamicHero = ({
             autoPlay
             muted
             loop
-            className="relative z-10"
+            className='relative z-10'
           />
         )}
         {/* Above poster + video: outer ::before sat behind the absolute media layer */}
         {wistiaId && (
           <div
-            className="pointer-events-none absolute inset-0 z-15 bg-black/50"
+            className='pointer-events-none absolute inset-0 z-15 bg-black/50'
             aria-hidden
           />
         )}
@@ -100,9 +101,9 @@ export const DynamicHero = ({
         {imagePath && !wistiaId && (
           <img
             src={imagePath}
-            alt="Hero Background"
-            fetchPriority="high"
-            className="absolute inset-0 w-full h-full object-cover"
+            alt='Hero Background'
+            fetchPriority='high'
+            className='absolute inset-0 w-full h-full object-cover'
           />
         )}
       </div>
@@ -123,98 +124,112 @@ export const DynamicHero = ({
       {/* Content */}
       <div
         className={cn(
-          "relative z-10 flex flex-col w-full items-start justify-end self-stretch",
-          "px-5 md:px-12 lg:px-18",
+          'relative z-10 flex flex-col w-full items-start justify-end self-stretch',
+          'px-5 md:px-12 lg:px-18',
         )}
       >
         <div
           className={cn(
-            "w-full max-w-screen-content mx-auto flex flex-col",
-            "gap-5 pb-8 md:gap-12 md:pb-16",
+            'w-full max-w-screen-content mx-auto flex flex-col',
+            'gap-5 pb-8 md:gap-12 md:pb-16',
+            !hasCtas && 'max-md:gap-0',
           )}
         >
-          <h1 className="font-extrabold heading-h1 text-[3rem] md:text-[4rem] lg:text-[100px] text-white">
+          <h1 className='font-extrabold heading-h1 text-[3rem] md:text-[4rem] lg:text-[100px] text-white'>
             {customTitle ? <HTMLRenderer html={customTitle} /> : pagePath}
           </h1>
-          <div
-            role="separator"
-            aria-hidden="true"
-            className="hidden md:block h-[2px] self-stretch bg-[#D9D9D9] opacity-50"
-          />
-          <div className="flex items-center justify-between self-stretch">
-            {/* Breadcrumbs */}
-            <div className="flex flex-col gap-3 w-full md:px-0 md:flex-row md:items-center md:justify-between md:gap-0">
-              <div className="hidden lg:block">
-                <Breadcrumbs mode="light" />
-              </div>
-              <div
-                role="separator"
-                aria-hidden="true"
-                className="md:hidden h-[2px] self-stretch bg-[#D9D9D9] opacity-50"
-              />
-              {/* Desktop CTAs */}
-              <div className="hidden lg:flex mt-5 flex-wrap justify-between gap-3 pr-1">
-                {ctas?.map((cta, i) => {
-                  if (cta.isSetAReminder) {
-                    return (
-                      <SetAReminderModal
-                        key={i}
-                        intent="secondary"
-                        className="text-white border-[#FAFAFC] rounded-none border hover:bg-white/10!"
-                      />
-                    );
-                  } else {
-                    return (
-                      <IconButton
-                        key={i}
-                        to={cta.href}
-                        className="text-white border-[#FAFAFC] border"
-                        withRotatingArrow={i === ctas.length - 1}
-                        target={cta.target}
-                      >
-                        {cta.title}
-                      </IconButton>
-                    );
-                  }
-                })}
-              </div>
+          <div className={cn(!hasCtas && 'max-md:hidden')}>
+            <div
+              role='separator'
+              aria-hidden='true'
+              className={cn(
+                'h-[2px] self-stretch bg-[#D9D9D9] opacity-50',
+                hasCtas ? 'hidden md:block' : 'hidden lg:block',
+              )}
+            />
+            <div className='flex items-center justify-between self-stretch mt-5'>
+              {/* Breadcrumbs */}
+              <div className='flex flex-col gap-3 w-full md:px-0 md:flex-row md:items-center md:justify-between md:gap-0'>
+                <div className='hidden lg:block'>
+                  <Breadcrumbs mode='light' />
+                </div>
+                <div
+                  role='separator'
+                  aria-hidden='true'
+                  className='md:hidden h-[2px] self-stretch bg-[#D9D9D9] opacity-50'
+                />
+                {/* Desktop CTAs */}
+                {hasCtas ? (
+                  <div className='hidden lg:flex flex-wrap justify-between gap-3 pr-1'>
+                    {ctas?.map((cta, i) => {
+                      if (cta.isSetAReminder) {
+                        return (
+                          <SetAReminderModal
+                            key={i}
+                            intent='secondary'
+                            className='text-white border-[#FAFAFC] rounded-none border hover:bg-white/10!'
+                          />
+                        );
+                      } else {
+                        return (
+                          <IconButton
+                            key={i}
+                            to={cta.href}
+                            className='text-white border-[#FAFAFC] border'
+                            withRotatingArrow={i === ctas.length - 1}
+                            target={cta.target}
+                          >
+                            {cta.title}
+                          </IconButton>
+                        );
+                      }
+                    })}
+                  </div>
+                ) : null}
 
-              {/* Mobile CTAs */}
-              <div className="lg:hidden flex flex-col-reverse md:flex-row-reverse md:justify-end gap-3 w-full pt-8 md:pt-0 md:px-0">
-                {ctas?.map((cta, i) => {
-                  if (cta.isSetAReminder) {
-                    return (
-                      <SetAReminderModal
-                        key={i}
-                        intent={
-                          i === 0 && ctas.length > 1 ? "secondary" : "primary"
-                        }
-                        className={cn(
-                          "w-full md:w-auto min-w-[280px]",
-                          i !== 0 ? "" : "text-white border-white",
-                        )}
-                      />
-                    );
-                  } else {
-                    return (
-                      <Button
-                        key={i}
-                        intent={
-                          i === 0 && ctas.length > 1 ? "secondary" : "primary"
-                        }
-                        href={cta.href}
-                        className={cn(
-                          "w-full md:w-auto min-w-[280px]",
-                          i == 0 &&
-                            ctas.length > 1 &&
-                            "text-white border-white",
-                        )}
-                      >
-                        {cta.title}
-                      </Button>
-                    );
-                  }
-                })}
+                {/* Mobile CTAs */}
+                {hasCtas ? (
+                  <div className='lg:hidden flex flex-col-reverse md:flex-row-reverse md:justify-end gap-3 w-full pt-8 md:pt-0 md:px-0'>
+                    {ctas?.map((cta, i) => {
+                      if (cta.isSetAReminder) {
+                        return (
+                          <SetAReminderModal
+                            key={i}
+                            intent={
+                              i === 0 && ctas.length > 1
+                                ? 'secondary'
+                                : 'primary'
+                            }
+                            className={cn(
+                              'w-full md:w-auto min-w-[280px]',
+                              i !== 0 ? '' : 'text-white border-white',
+                            )}
+                          />
+                        );
+                      } else {
+                        return (
+                          <Button
+                            key={i}
+                            intent={
+                              i === 0 && ctas.length > 1
+                                ? 'secondary'
+                                : 'primary'
+                            }
+                            href={cta.href}
+                            className={cn(
+                              'w-full md:w-auto min-w-[280px]',
+                              i == 0 &&
+                                ctas.length > 1 &&
+                                'text-white border-white',
+                            )}
+                          >
+                            {cta.title}
+                          </Button>
+                        );
+                      }
+                    })}
+                  </div>
+                ) : null}
               </div>
             </div>
           </div>

--- a/app/lib/.server/__tests__/rock-signup.test.ts
+++ b/app/lib/.server/__tests__/rock-signup.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   findOrCreateRockPersonForSignup,
+  launchCommunityServingSignupWorkflow,
   launchGroupClassSignupWorkflow,
 } from '../rock-signup';
 
@@ -224,5 +225,48 @@ describe('launchGroupClassSignupWorkflow', () => {
     const [call] = mockPostRockData.mock.calls[0] as [{ endpoint: string; body: Record<string, string> }];
     expect(call.endpoint).toContain('workflowTypeId=654');
     expect(call.body).toEqual({ GroupId: 'group-1', PersonId: 'person-2' });
+  });
+});
+
+describe('launchCommunityServingSignupWorkflow', () => {
+  // Verifies the body shape required by the Community Serving Opportunity
+  // Sign Up workflow (id 164) on the Rock side: GroupGuid via `Group`, plus
+  // Birthdate / Campus / waiver-key (note the trailing period in the key).
+  it('posts to workflowTypeId=164 with the expected body when waiver is accepted', async () => {
+    mockPostRockData.mockResolvedValue({});
+
+    await launchCommunityServingSignupWorkflow({
+      groupGuid: 'AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE',
+      personId: 'person-42',
+      birthdate: '1990-05-15',
+      campus: 'Palm Beach Gardens',
+      waiverAccepted: true,
+    });
+
+    expect(mockPostRockData).toHaveBeenCalledOnce();
+    const [call] = mockPostRockData.mock.calls[0] as [{ endpoint: string; body: Record<string, string> }];
+    expect(call.endpoint).toContain('workflowTypeId=164');
+    expect(call.body).toEqual({
+      Group: 'AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE',
+      PersonId: 'person-42',
+      Birthdate: '1990-05-15',
+      Campus: 'Palm Beach Gardens',
+      'IacceptthetermsoftheChristFellowshipwaiver.': 'Yes',
+    });
+  });
+
+  it('sends an empty waiver value when waiver is not accepted', async () => {
+    mockPostRockData.mockResolvedValue({});
+
+    await launchCommunityServingSignupWorkflow({
+      groupGuid: 'AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE',
+      personId: 'person-42',
+      birthdate: '1990-05-15',
+      campus: 'Palm Beach Gardens',
+      waiverAccepted: false,
+    });
+
+    const [call] = mockPostRockData.mock.calls[0] as [{ endpoint: string; body: Record<string, string> }];
+    expect(call.body['IacceptthetermsoftheChristFellowshipwaiver.']).toBe('');
   });
 });

--- a/app/lib/.server/__tests__/rock-signup.test.ts
+++ b/app/lib/.server/__tests__/rock-signup.test.ts
@@ -21,14 +21,20 @@ vi.mock('../authentication/rock-authentication', () => ({
   createUserProfile: vi.fn(),
 }));
 vi.mock('../authentication/sms-authentication', () => ({
-  parsePhoneNumberUtil: vi.fn(() => ({ significantNumber: '5551234567', countryCode: 1 })),
+  parsePhoneNumberUtil: vi.fn(() => ({
+    significantNumber: '5551234567',
+    countryCode: 1,
+  })),
   createPhoneNumberInRock: vi.fn(),
 }));
 vi.mock('../redis-config', () => ({ default: null }));
 
 import { fetchRockData, postRockData } from '../fetch-rock-data';
 import { updatePerson } from '../rock-person';
-import { fetchUserLogin, createUserProfile } from '../authentication/rock-authentication';
+import {
+  fetchUserLogin,
+  createUserProfile,
+} from '../authentication/rock-authentication';
 import { createPhoneNumberInRock } from '../authentication/sms-authentication';
 
 const mockFetchRockData = fetchRockData as ReturnType<typeof vi.fn>;
@@ -36,7 +42,9 @@ const mockPostRockData = postRockData as ReturnType<typeof vi.fn>;
 const mockUpdatePerson = updatePerson as ReturnType<typeof vi.fn>;
 const mockFetchUserLogin = fetchUserLogin as ReturnType<typeof vi.fn>;
 const mockCreateUserProfile = createUserProfile as ReturnType<typeof vi.fn>;
-const mockCreatePhoneNumberInRock = createPhoneNumberInRock as ReturnType<typeof vi.fn>;
+const mockCreatePhoneNumberInRock = createPhoneNumberInRock as ReturnType<
+  typeof vi.fn
+>;
 
 const defaultInput = {
   firstName: 'Jane',
@@ -58,7 +66,10 @@ describe('findOrCreateRockPersonForSignup', () => {
 
   it('Step 1 — returns personId when email login matches the submitted name', async () => {
     mockFetchUserLogin.mockResolvedValueOnce({ personId: 42 });
-    mockFetchRockData.mockResolvedValueOnce({ firstName: 'Jane', lastName: 'Doe' });
+    mockFetchRockData.mockResolvedValueOnce({
+      firstName: 'Jane',
+      lastName: 'Doe',
+    });
 
     const result = await findOrCreateRockPersonForSignup(defaultInput);
 
@@ -96,7 +107,10 @@ describe('findOrCreateRockPersonForSignup', () => {
     mockFetchUserLogin
       .mockResolvedValueOnce(null)
       .mockResolvedValueOnce({ personId: 99 });
-    mockFetchRockData.mockResolvedValueOnce({ firstName: 'Jane', lastName: 'Doe' });
+    mockFetchRockData.mockResolvedValueOnce({
+      firstName: 'Jane',
+      lastName: 'Doe',
+    });
 
     const result = await findOrCreateRockPersonForSignup(defaultInput);
 
@@ -180,9 +194,7 @@ describe('findOrCreateRockPersonForSignup', () => {
 
   it('Step 5 — creates new person when no match found', async () => {
     mockFetchUserLogin.mockResolvedValue(null);
-    mockFetchRockData
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([]);
+    mockFetchRockData.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
     mockCreateUserProfile.mockResolvedValue({ id: 123 });
 
     const result = await findOrCreateRockPersonForSignup(defaultInput);
@@ -199,9 +211,7 @@ describe('findOrCreateRockPersonForSignup', () => {
 
   it('Step 5 — supports legacy numeric create profile responses', async () => {
     mockFetchUserLogin.mockResolvedValue(null);
-    mockFetchRockData
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([]);
+    mockFetchRockData.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
     mockCreateUserProfile.mockResolvedValue(456);
 
     const result = await findOrCreateRockPersonForSignup(defaultInput);
@@ -222,7 +232,9 @@ describe('launchGroupClassSignupWorkflow', () => {
     await launchGroupClassSignupWorkflow('group-1', 'person-2');
 
     expect(mockPostRockData).toHaveBeenCalledOnce();
-    const [call] = mockPostRockData.mock.calls[0] as [{ endpoint: string; body: Record<string, string> }];
+    const [call] = mockPostRockData.mock.calls[0] as [
+      { endpoint: string; body: Record<string, string> },
+    ];
     expect(call.endpoint).toContain('workflowTypeId=654');
     expect(call.body).toEqual({ GroupId: 'group-1', PersonId: 'person-2' });
   });
@@ -243,28 +255,32 @@ describe('launchCommunityServingSignupWorkflow', () => {
   };
 
   // Verifies the body shape required by the Community Serving Opportunity
-  // Sign Up workflow (id 164): group key (lowercase), contact fields, campus Guid
+  // Sign Up workflow (id 1840): PascalCase attribute keys, campus Guid
   // (resolved from name), and the waiver attribute key (note trailing period).
-  it('posts to workflowTypeId=164 with the campus Guid (not name) when waiver is accepted', async () => {
+  it('posts to workflowTypeId=1840 with the campus Guid (not name) when waiver is accepted', async () => {
     mockFetchRockData.mockResolvedValueOnce({ guid: CAMPUS_GUID });
     mockPostRockData.mockResolvedValue({});
 
     await launchCommunityServingSignupWorkflow(defaultWorkflowInput);
 
     expect(mockFetchRockData).toHaveBeenCalledOnce();
-    const [fetchCall] = mockFetchRockData.mock.calls[0] as [{ endpoint: string; queryParams: Record<string, string> }];
+    const [fetchCall] = mockFetchRockData.mock.calls[0] as [
+      { endpoint: string; queryParams: Record<string, string> },
+    ];
     expect(fetchCall.endpoint).toBe('Campuses');
     expect(fetchCall.queryParams.$filter).toContain('Palm Beach Gardens');
 
     expect(mockPostRockData).toHaveBeenCalledOnce();
-    const [postCall] = mockPostRockData.mock.calls[0] as [{ endpoint: string; body: Record<string, string> }];
-    expect(postCall.endpoint).toContain('workflowTypeId=164');
+    const [postCall] = mockPostRockData.mock.calls[0] as [
+      { endpoint: string; body: Record<string, string> },
+    ];
+    expect(postCall.endpoint).toContain('workflowTypeId=1840');
     expect(postCall.body).toEqual({
-      group: 'AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE',
+      Group: 'AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE',
       FirstName: 'Jane',
       LastName: 'Doe',
       Email: 'jane.doe@example.com',
-      cellPhone: '5615550123',
+      CellPhone: '5615550123',
       Birthdate: '1990-05-15',
       Campus: CAMPUS_GUID,
       'IacceptthetermsoftheChristFellowshipwaiver.': 'Yes',
@@ -280,8 +296,12 @@ describe('launchCommunityServingSignupWorkflow', () => {
       waiverAccepted: false,
     });
 
-    const [postCall] = mockPostRockData.mock.calls[0] as [{ endpoint: string; body: Record<string, string> }];
-    expect(postCall.body['IacceptthetermsoftheChristFellowshipwaiver.']).toBe('');
+    const [postCall] = mockPostRockData.mock.calls[0] as [
+      { endpoint: string; body: Record<string, string> },
+    ];
+    expect(postCall.body['IacceptthetermsoftheChristFellowshipwaiver.']).toBe(
+      '',
+    );
   });
 
   it('throws when Rock returns no campus for the given name', async () => {

--- a/app/lib/.server/__tests__/rock-signup.test.ts
+++ b/app/lib/.server/__tests__/rock-signup.test.ts
@@ -231,20 +231,25 @@ describe('launchGroupClassSignupWorkflow', () => {
 describe('launchCommunityServingSignupWorkflow', () => {
   const CAMPUS_GUID = 'A1B2C3D4-E5F6-7890-ABCD-EF1234567890';
 
+  const defaultWorkflowInput = {
+    groupGuid: 'AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE',
+    firstName: 'Jane',
+    lastName: 'Doe',
+    email: 'jane.doe@example.com',
+    phoneNumber: '5615550123',
+    birthdate: '1990-05-15',
+    campus: 'Palm Beach Gardens',
+    waiverAccepted: true,
+  };
+
   // Verifies the body shape required by the Community Serving Opportunity
-  // Sign Up workflow (id 164) on the Rock side: GroupGuid via `Group`, plus
-  // Birthdate / Campus Guid / waiver-key (note the trailing period in the key).
+  // Sign Up workflow (id 164): group key (lowercase), contact fields, campus Guid
+  // (resolved from name), and the waiver attribute key (note trailing period).
   it('posts to workflowTypeId=164 with the campus Guid (not name) when waiver is accepted', async () => {
     mockFetchRockData.mockResolvedValueOnce({ guid: CAMPUS_GUID });
     mockPostRockData.mockResolvedValue({});
 
-    await launchCommunityServingSignupWorkflow({
-      groupGuid: 'AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE',
-      personId: 'person-42',
-      birthdate: '1990-05-15',
-      campus: 'Palm Beach Gardens',
-      waiverAccepted: true,
-    });
+    await launchCommunityServingSignupWorkflow(defaultWorkflowInput);
 
     expect(mockFetchRockData).toHaveBeenCalledOnce();
     const [fetchCall] = mockFetchRockData.mock.calls[0] as [{ endpoint: string; queryParams: Record<string, string> }];
@@ -255,8 +260,11 @@ describe('launchCommunityServingSignupWorkflow', () => {
     const [postCall] = mockPostRockData.mock.calls[0] as [{ endpoint: string; body: Record<string, string> }];
     expect(postCall.endpoint).toContain('workflowTypeId=164');
     expect(postCall.body).toEqual({
-      Group: 'AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE',
-      PersonId: 'person-42',
+      group: 'AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE',
+      FirstName: 'Jane',
+      LastName: 'Doe',
+      Email: 'jane.doe@example.com',
+      cellPhone: '5615550123',
       Birthdate: '1990-05-15',
       Campus: CAMPUS_GUID,
       'IacceptthetermsoftheChristFellowshipwaiver.': 'Yes',
@@ -268,10 +276,7 @@ describe('launchCommunityServingSignupWorkflow', () => {
     mockPostRockData.mockResolvedValue({});
 
     await launchCommunityServingSignupWorkflow({
-      groupGuid: 'AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE',
-      personId: 'person-42',
-      birthdate: '1990-05-15',
-      campus: 'Palm Beach Gardens',
+      ...defaultWorkflowInput,
       waiverAccepted: false,
     });
 
@@ -284,11 +289,8 @@ describe('launchCommunityServingSignupWorkflow', () => {
 
     await expect(
       launchCommunityServingSignupWorkflow({
-        groupGuid: 'AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE',
-        personId: 'person-42',
-        birthdate: '1990-05-15',
+        ...defaultWorkflowInput,
         campus: 'Unknown Campus',
-        waiverAccepted: true,
       }),
     ).rejects.toThrow('Campus not found in Rock: "Unknown Campus"');
   });

--- a/app/lib/.server/__tests__/rock-signup.test.ts
+++ b/app/lib/.server/__tests__/rock-signup.test.ts
@@ -229,10 +229,13 @@ describe('launchGroupClassSignupWorkflow', () => {
 });
 
 describe('launchCommunityServingSignupWorkflow', () => {
+  const CAMPUS_GUID = 'A1B2C3D4-E5F6-7890-ABCD-EF1234567890';
+
   // Verifies the body shape required by the Community Serving Opportunity
   // Sign Up workflow (id 164) on the Rock side: GroupGuid via `Group`, plus
-  // Birthdate / Campus / waiver-key (note the trailing period in the key).
-  it('posts to workflowTypeId=164 with the expected body when waiver is accepted', async () => {
+  // Birthdate / Campus Guid / waiver-key (note the trailing period in the key).
+  it('posts to workflowTypeId=164 with the campus Guid (not name) when waiver is accepted', async () => {
+    mockFetchRockData.mockResolvedValueOnce({ guid: CAMPUS_GUID });
     mockPostRockData.mockResolvedValue({});
 
     await launchCommunityServingSignupWorkflow({
@@ -243,19 +246,25 @@ describe('launchCommunityServingSignupWorkflow', () => {
       waiverAccepted: true,
     });
 
+    expect(mockFetchRockData).toHaveBeenCalledOnce();
+    const [fetchCall] = mockFetchRockData.mock.calls[0] as [{ endpoint: string; queryParams: Record<string, string> }];
+    expect(fetchCall.endpoint).toBe('Campuses');
+    expect(fetchCall.queryParams.$filter).toContain('Palm Beach Gardens');
+
     expect(mockPostRockData).toHaveBeenCalledOnce();
-    const [call] = mockPostRockData.mock.calls[0] as [{ endpoint: string; body: Record<string, string> }];
-    expect(call.endpoint).toContain('workflowTypeId=164');
-    expect(call.body).toEqual({
+    const [postCall] = mockPostRockData.mock.calls[0] as [{ endpoint: string; body: Record<string, string> }];
+    expect(postCall.endpoint).toContain('workflowTypeId=164');
+    expect(postCall.body).toEqual({
       Group: 'AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE',
       PersonId: 'person-42',
       Birthdate: '1990-05-15',
-      Campus: 'Palm Beach Gardens',
+      Campus: CAMPUS_GUID,
       'IacceptthetermsoftheChristFellowshipwaiver.': 'Yes',
     });
   });
 
   it('sends an empty waiver value when waiver is not accepted', async () => {
+    mockFetchRockData.mockResolvedValueOnce({ guid: CAMPUS_GUID });
     mockPostRockData.mockResolvedValue({});
 
     await launchCommunityServingSignupWorkflow({
@@ -266,7 +275,21 @@ describe('launchCommunityServingSignupWorkflow', () => {
       waiverAccepted: false,
     });
 
-    const [call] = mockPostRockData.mock.calls[0] as [{ endpoint: string; body: Record<string, string> }];
-    expect(call.body['IacceptthetermsoftheChristFellowshipwaiver.']).toBe('');
+    const [postCall] = mockPostRockData.mock.calls[0] as [{ endpoint: string; body: Record<string, string> }];
+    expect(postCall.body['IacceptthetermsoftheChristFellowshipwaiver.']).toBe('');
+  });
+
+  it('throws when Rock returns no campus for the given name', async () => {
+    mockFetchRockData.mockResolvedValueOnce(null);
+
+    await expect(
+      launchCommunityServingSignupWorkflow({
+        groupGuid: 'AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE',
+        personId: 'person-42',
+        birthdate: '1990-05-15',
+        campus: 'Unknown Campus',
+        waiverAccepted: true,
+      }),
+    ).rejects.toThrow('Campus not found in Rock: "Unknown Campus"');
   });
 });

--- a/app/lib/.server/rock-signup.ts
+++ b/app/lib/.server/rock-signup.ts
@@ -180,7 +180,10 @@ const resolveRockCampusGuidByName = async (
 
 export interface CommunityServingSignupInput {
   groupGuid: string;
-  personId: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  phoneNumber: string;
   /** ISO yyyy-mm-dd from <input type="date">. */
   birthdate: string;
   /** Rock canonical campus name (matches RockCampuses[].name in rock-config.ts). Resolved to a Guid before posting. */
@@ -195,10 +198,13 @@ export const launchCommunityServingSignupWorkflow = async (
 
   await postRockData({
     endpoint:
-      'Workflows/LaunchWorkflow/0?workflowTypeId=164&workflowName=Community%20Serving%20Opportunity%20Sign%20Up',
+      'Workflows/LaunchWorkflow/0?workflowTypeId=1840&workflowName=Community%20Serving%20Opportunity%20Sign%20Up',
     body: {
       Group: input.groupGuid,
-      PersonId: input.personId,
+      FirstName: input.firstName,
+      LastName: input.lastName,
+      Email: input.email,
+      CellPhone: input.phoneNumber,
       Birthdate: input.birthdate,
       Campus: campusGuid,
       'IacceptthetermsoftheChristFellowshipwaiver.': input.waiverAccepted

--- a/app/lib/.server/rock-signup.ts
+++ b/app/lib/.server/rock-signup.ts
@@ -156,3 +156,30 @@ export const launchGroupClassSignupWorkflow = async (
     body: { GroupId: groupId, PersonId: personId },
   });
 };
+
+export interface CommunityServingSignupInput {
+  groupGuid: string;
+  personId: string;
+  /** ISO yyyy-mm-dd from <input type="date">. */
+  birthdate: string;
+  /** Campus name string (matches CAMPUS const). */
+  campus: string;
+  waiverAccepted: boolean;
+}
+
+export const launchCommunityServingSignupWorkflow = async (
+  input: CommunityServingSignupInput,
+): Promise<void> => {
+  await postRockData({
+    endpoint:
+      'Workflows/LaunchWorkflow/0?workflowTypeId=164&workflowName=Community%20Serving%20Opportunity%20Sign%20Up',
+    body: {
+      Group: input.groupGuid,
+      PersonId: input.personId,
+      Birthdate: input.birthdate,
+      Campus: input.campus,
+      'IacceptthetermsoftheChristFellowshipwaiver.':
+        input.waiverAccepted ? 'Yes' : '',
+    },
+  });
+};

--- a/app/lib/.server/rock-signup.ts
+++ b/app/lib/.server/rock-signup.ts
@@ -34,7 +34,9 @@ const personNameMatches = async (
     ttl: TTL.NONE,
   });
 
-  const person = Array.isArray(personDetails) ? personDetails[0] : personDetails;
+  const person = Array.isArray(personDetails)
+    ? personDetails[0]
+    : personDetails;
 
   return (
     normalizeName(person?.firstName) === normalizeName(firstName) &&
@@ -157,12 +159,31 @@ export const launchGroupClassSignupWorkflow = async (
   });
 };
 
+const resolveRockCampusGuidByName = async (
+  campusName: string,
+): Promise<string> => {
+  const result = await fetchRockData({
+    endpoint: 'Campuses',
+    queryParams: {
+      $filter: `Name eq '${escapeOData(campusName)}'`,
+      $select: 'Guid',
+    },
+    ttl: TTL.NONE,
+  });
+
+  const record = Array.isArray(result) ? result[0] : result;
+  if (!record?.guid || typeof record.guid !== 'string') {
+    throw new Error(`Campus not found in Rock: "${campusName}"`);
+  }
+  return record.guid;
+};
+
 export interface CommunityServingSignupInput {
   groupGuid: string;
   personId: string;
   /** ISO yyyy-mm-dd from <input type="date">. */
   birthdate: string;
-  /** Campus name string (matches CAMPUS const). */
+  /** Rock canonical campus name (matches RockCampuses[].name in rock-config.ts). Resolved to a Guid before posting. */
   campus: string;
   waiverAccepted: boolean;
 }
@@ -170,6 +191,8 @@ export interface CommunityServingSignupInput {
 export const launchCommunityServingSignupWorkflow = async (
   input: CommunityServingSignupInput,
 ): Promise<void> => {
+  const campusGuid = await resolveRockCampusGuidByName(input.campus);
+
   await postRockData({
     endpoint:
       'Workflows/LaunchWorkflow/0?workflowTypeId=164&workflowName=Community%20Serving%20Opportunity%20Sign%20Up',
@@ -177,9 +200,10 @@ export const launchCommunityServingSignupWorkflow = async (
       Group: input.groupGuid,
       PersonId: input.personId,
       Birthdate: input.birthdate,
-      Campus: input.campus,
-      'IacceptthetermsoftheChristFellowshipwaiver.':
-        input.waiverAccepted ? 'Yes' : '',
+      Campus: campusGuid,
+      'IacceptthetermsoftheChristFellowshipwaiver.': input.waiverAccepted
+        ? 'Yes'
+        : '',
     },
   });
 };

--- a/app/routes/ministry-builder/ministry-builder-page.tsx
+++ b/app/routes/ministry-builder/ministry-builder-page.tsx
@@ -1,24 +1,24 @@
-import { useLoaderData, useLocation } from "react-router-dom";
-import { DynamicHero } from "~/components";
-import { PageBuilderLoader } from "../page-builder/types";
-import { renderSection } from "../page-builder/page-builder-page";
-import { MinistryServiceTimes } from "./components/ministry-service-times.component";
-import { displayServiceTimes } from "./utils";
+import { useLoaderData, useLocation } from 'react-router-dom';
+import { DynamicHero } from '~/components';
+import { PageBuilderLoader } from '../page-builder/types';
+import { renderSection } from '../page-builder/page-builder-page';
+import { MinistryServiceTimes } from './components/ministry-service-times.component';
+import { displayServiceTimes } from './utils';
 
 export function MinistryBuilderRoute() {
   const { title, heroImage, callsToAction, sections, services } =
     useLoaderData<PageBuilderLoader>();
   const { pathname } = useLocation();
 
-  const cleanPathname = pathname.split("/")[2].toLowerCase();
+  const cleanPathname = pathname.split('/')[2].toLowerCase();
 
   const shouldDisplayServiceTimes = displayServiceTimes(
     services || [],
-    cleanPathname
+    cleanPathname,
   );
 
   return (
-    <div className="bg-white">
+    <div className='bg-white'>
       <DynamicHero
         customTitle={title}
         imagePath={heroImage}

--- a/app/routes/volunteer-form/types.ts
+++ b/app/routes/volunteer-form/types.ts
@@ -1,3 +1,5 @@
+import { RockCampuses, type RockCampusName } from '~/lib/rock-config';
+
 // Types for Volunteer Form multi-step process
 export const INTERESTS = [
   "Children & Youth",
@@ -23,31 +25,14 @@ export interface VolunteerFormWelcome {
   // No fields needed, just a welcome step
 }
 
-export const CAMPUS = [
-  "Palm Beach Gardens",
-  "Port St. Lucie",
-  "Royal Palm Beach",
-  "Boynton Beach",
-  "Downtown West Palm Beach",
-  "Jupiter",
-  "Stuart",
-  "Okeechobee",
-  "Belle Glade",
-  "Vero Beach",
-  "Boca Raton",
-  "Riviera Beach",
-  "Trinity Church",
-  "Westlake",
-  "En Español Palm Beach Gardens",
-  "En Español Royal Palm Beach",
-];
+export const CAMPUS = RockCampuses.map((c) => c.name);
 
 export interface VolunteerFormPersonalInfo {
   firstName: string;
   lastName: string;
   email: string;
   phone?: string;
-  campus?: (typeof CAMPUS)[number];
+  campus?: RockCampusName;
   dateOfBirth?: string;
 }
 

--- a/app/routes/volunteer/outreach-opportunity/action.ts
+++ b/app/routes/volunteer/outreach-opportunity/action.ts
@@ -1,0 +1,112 @@
+import type { ActionFunctionArgs } from 'react-router';
+
+import {
+  findOrCreateRockPersonForSignup,
+  launchCommunityServingSignupWorkflow,
+} from '~/lib/.server/rock-signup';
+import { CAMPUS } from '~/routes/volunteer-form/types';
+
+const ROCK_GUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const CAMPUSES = new Set<string>(CAMPUS);
+
+const isTruthyCheckbox = (value: string): boolean =>
+  value === 'true' || value === 'on' || value === 'yes' || value === 'Yes';
+
+export const action = async ({ request, params }: ActionFunctionArgs) => {
+  try {
+    const formData = Object.fromEntries(await request.formData());
+
+    const firstName = formData.firstName?.toString().trim() ?? '';
+    const lastName = formData.lastName?.toString().trim() ?? '';
+    const phoneNumber = formData.phoneNumber?.toString().trim() ?? '';
+    const email = formData.email?.toString().trim() ?? '';
+    const birthdate = formData.birthdate?.toString().trim() ?? '';
+    const campus = formData.campus?.toString().trim() ?? '';
+    const waiverAccepted = isTruthyCheckbox(
+      formData.waiverAccepted?.toString() ?? '',
+    );
+
+    const rawGuid = (params.groupGuid ?? '').trim();
+    const groupGuid = rawGuid.toUpperCase();
+
+    if (
+      !firstName ||
+      !lastName ||
+      !phoneNumber ||
+      !email ||
+      !birthdate ||
+      !campus ||
+      !groupGuid
+    ) {
+      return Response.json(
+        { error: 'Please fill in all required fields.' },
+        { status: 400 },
+      );
+    }
+
+    if (!ROCK_GUID_RE.test(groupGuid)) {
+      return Response.json(
+        { error: 'Invalid opportunity reference.' },
+        { status: 400 },
+      );
+    }
+
+    if (!ISO_DATE_RE.test(birthdate)) {
+      return Response.json(
+        { error: 'Please enter a valid birthdate.' },
+        { status: 400 },
+      );
+    }
+
+    const birthdateMs = Date.parse(`${birthdate}T00:00:00Z`);
+    if (!Number.isFinite(birthdateMs) || birthdateMs >= Date.now()) {
+      return Response.json(
+        { error: 'Please enter a valid birthdate.' },
+        { status: 400 },
+      );
+    }
+
+    if (!CAMPUSES.has(campus)) {
+      return Response.json(
+        { error: 'Please select a valid campus.' },
+        { status: 400 },
+      );
+    }
+
+    if (!waiverAccepted) {
+      return Response.json(
+        { error: 'You must accept the waiver to sign up.' },
+        { status: 400 },
+      );
+    }
+
+    const personId = await findOrCreateRockPersonForSignup({
+      firstName,
+      lastName,
+      email,
+      phoneNumber,
+    });
+
+    await launchCommunityServingSignupWorkflow({
+      groupGuid,
+      personId,
+      birthdate,
+      campus,
+      waiverAccepted: true,
+    });
+
+    return Response.json({ success: true });
+  } catch (error) {
+    return Response.json(
+      {
+        error:
+          error instanceof Error
+            ? error.message
+            : 'Something went wrong. Please try again.',
+      },
+      { status: 400 },
+    );
+  }
+};

--- a/app/routes/volunteer/outreach-opportunity/action.ts
+++ b/app/routes/volunteer/outreach-opportunity/action.ts
@@ -1,9 +1,6 @@
 import type { ActionFunctionArgs } from 'react-router';
 
-import {
-  findOrCreateRockPersonForSignup,
-  launchCommunityServingSignupWorkflow,
-} from '~/lib/.server/rock-signup';
+import { launchCommunityServingSignupWorkflow } from '~/lib/.server/rock-signup';
 import { RockCampuses } from '~/lib/rock-config';
 
 const ROCK_GUID_RE =
@@ -84,16 +81,12 @@ export const action = async ({ request, params }: ActionFunctionArgs) => {
       );
     }
 
-    const personId = await findOrCreateRockPersonForSignup({
+    await launchCommunityServingSignupWorkflow({
+      groupGuid,
       firstName,
       lastName,
       email,
       phoneNumber,
-    });
-
-    await launchCommunityServingSignupWorkflow({
-      groupGuid,
-      personId,
       birthdate,
       campus,
       waiverAccepted: true,

--- a/app/routes/volunteer/outreach-opportunity/action.ts
+++ b/app/routes/volunteer/outreach-opportunity/action.ts
@@ -4,12 +4,14 @@ import {
   findOrCreateRockPersonForSignup,
   launchCommunityServingSignupWorkflow,
 } from '~/lib/.server/rock-signup';
-import { CAMPUS } from '~/routes/volunteer-form/types';
+import { RockCampuses } from '~/lib/rock-config';
 
 const ROCK_GUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
-const CAMPUSES = new Set<string>(CAMPUS);
+const CAMPUSES = new Set<string>(
+  RockCampuses.filter((c) => c.name !== 'Online').map((c) => c.name),
+);
 
 const isTruthyCheckbox = (value: string): boolean =>
   value === 'true' || value === 'on' || value === 'yes' || value === 'Yes';

--- a/app/routes/volunteer/outreach-opportunity/components/signup-form.component.tsx
+++ b/app/routes/volunteer/outreach-opportunity/components/signup-form.component.tsx
@@ -114,7 +114,7 @@ const SignupForm: React.FC<SignupFormProps> = ({
       </Form.Field>
 
       <Form.Field name='campus' className='flex flex-col'>
-        <Form.Label className='font-bold text-sm mb-1'>Home Campus*</Form.Label>
+        <Form.Label className='font-bold text-sm mb-1'>Campus*</Form.Label>
         <Form.Control asChild>
           <select
             required

--- a/app/routes/volunteer/outreach-opportunity/components/signup-form.component.tsx
+++ b/app/routes/volunteer/outreach-opportunity/components/signup-form.component.tsx
@@ -5,7 +5,7 @@ import { useFetcher } from 'react-router';
 import { Button } from '~/primitives/button/button.primitive';
 import { defaultTextInputStyles } from '~/primitives/inputs/text-field/text-field.primitive';
 import { pushFormEvent } from '~/lib/gtm';
-import { CAMPUS } from '~/routes/volunteer-form/types';
+import { RockCampuses } from '~/lib/rock-config';
 
 interface SignupFormProps {
   groupGuid: string;
@@ -124,9 +124,9 @@ const SignupForm: React.FC<SignupFormProps> = ({
             <option value='' disabled>
               Select campus
             </option>
-            {CAMPUS.map((c) => (
-              <option key={c} value={c}>
-                {c}
+            {RockCampuses.filter((c) => c.name !== 'Online').map((c) => (
+              <option key={c.name} value={c.name}>
+                {c.name}
               </option>
             ))}
           </select>

--- a/app/routes/volunteer/outreach-opportunity/components/signup-form.component.tsx
+++ b/app/routes/volunteer/outreach-opportunity/components/signup-form.component.tsx
@@ -9,7 +9,7 @@ import { CAMPUS } from '~/routes/volunteer-form/types';
 
 interface SignupFormProps {
   groupGuid: string;
-  waiverLinkText: string;
+  waiverPdfUrl: string;
   /** Path to POST to — the outreach-opportunity route's own action. */
   actionPath: string;
   onSuccess: () => void;
@@ -17,7 +17,7 @@ interface SignupFormProps {
 
 const SignupForm: React.FC<SignupFormProps> = ({
   groupGuid,
-  waiverLinkText,
+  waiverPdfUrl,
   actionPath,
   onSuccess,
 }) => {
@@ -51,73 +51,77 @@ const SignupForm: React.FC<SignupFormProps> = ({
   return (
     <Form.Root
       onSubmit={handleSubmit}
-      className="flex flex-col text-left gap-y-4 md:grid md:grid-cols-2 md:gap-x-6 md:gap-y-4"
+      className='flex flex-col text-left gap-y-4 md:grid md:grid-cols-2 md:gap-x-6 md:gap-y-4'
     >
-      <input type="hidden" name="groupGuid" value={groupGuid} />
+      <input type='hidden' name='groupGuid' value={groupGuid} />
 
-      <Form.Field name="firstName" className="flex flex-col">
-        <Form.Label className="font-bold text-sm mb-1">First Name*</Form.Label>
+      <Form.Field name='firstName' className='flex flex-col'>
+        <Form.Label className='font-bold text-sm mb-1'>First Name*</Form.Label>
         <Form.Control asChild>
-          <input type="text" required className={defaultTextInputStyles} />
+          <input type='text' required className={defaultTextInputStyles} />
         </Form.Control>
-        <Form.Message className="text-alert text-sm" match="valueMissing">
+        <Form.Message className='text-alert text-sm' match='valueMissing'>
           Please enter your first name
         </Form.Message>
       </Form.Field>
 
-      <Form.Field name="lastName" className="flex flex-col">
-        <Form.Label className="font-bold text-sm mb-1">Last Name*</Form.Label>
+      <Form.Field name='lastName' className='flex flex-col'>
+        <Form.Label className='font-bold text-sm mb-1'>Last Name*</Form.Label>
         <Form.Control asChild>
-          <input type="text" required className={defaultTextInputStyles} />
+          <input type='text' required className={defaultTextInputStyles} />
         </Form.Control>
-        <Form.Message className="text-alert text-sm" match="valueMissing">
+        <Form.Message className='text-alert text-sm' match='valueMissing'>
           Please enter your last name
         </Form.Message>
       </Form.Field>
 
-      <Form.Field name="phoneNumber" className="flex flex-col">
-        <Form.Label className="font-bold text-sm mb-1">Cell Phone*</Form.Label>
+      <Form.Field name='phoneNumber' className='flex flex-col'>
+        <Form.Label className='font-bold text-sm mb-1'>Cell Phone*</Form.Label>
         <Form.Control asChild>
-          <input type="tel" required className={defaultTextInputStyles} />
+          <input type='tel' required className={defaultTextInputStyles} />
         </Form.Control>
-        <Form.Message className="text-alert text-sm" match="valueMissing">
+        <Form.Message className='text-alert text-sm' match='valueMissing'>
           Please enter your phone number
         </Form.Message>
       </Form.Field>
 
-      <Form.Field name="email" className="flex flex-col">
-        <Form.Label className="font-bold text-sm mb-1">Email*</Form.Label>
+      <Form.Field name='email' className='flex flex-col'>
+        <Form.Label className='font-bold text-sm mb-1'>Email*</Form.Label>
         <Form.Control asChild>
-          <input type="email" required className={defaultTextInputStyles} />
+          <input type='email' required className={defaultTextInputStyles} />
         </Form.Control>
-        <Form.Message className="text-alert text-sm" match="valueMissing">
+        <Form.Message className='text-alert text-sm' match='valueMissing'>
           Please enter your email
         </Form.Message>
-        <Form.Message className="text-alert text-sm" match="typeMismatch">
+        <Form.Message className='text-alert text-sm' match='typeMismatch'>
           Please enter a valid email
         </Form.Message>
       </Form.Field>
 
-      <Form.Field name="birthdate" className="flex flex-col">
-        <Form.Label className="font-bold text-sm mb-1">Birthdate*</Form.Label>
+      <Form.Field name='birthdate' className='flex flex-col'>
+        <Form.Label className='font-bold text-sm mb-1'>Birthdate*</Form.Label>
         <Form.Control asChild>
           <input
-            type="date"
+            type='date'
             required
             max={new Date().toISOString().slice(0, 10)}
             className={defaultTextInputStyles}
           />
         </Form.Control>
-        <Form.Message className="text-alert text-sm" match="valueMissing">
+        <Form.Message className='text-alert text-sm' match='valueMissing'>
           Please enter your birthdate
         </Form.Message>
       </Form.Field>
 
-      <Form.Field name="campus" className="flex flex-col">
-        <Form.Label className="font-bold text-sm mb-1">Home Campus*</Form.Label>
+      <Form.Field name='campus' className='flex flex-col'>
+        <Form.Label className='font-bold text-sm mb-1'>Home Campus*</Form.Label>
         <Form.Control asChild>
-          <select required className={`appearance-none ${defaultTextInputStyles}`} defaultValue="">
-            <option value="" disabled>
+          <select
+            required
+            className={`appearance-none ${defaultTextInputStyles}`}
+            defaultValue=''
+          >
+            <option value='' disabled>
               Select campus
             </option>
             {CAMPUS.map((c) => (
@@ -127,47 +131,53 @@ const SignupForm: React.FC<SignupFormProps> = ({
             ))}
           </select>
         </Form.Control>
-        <Form.Message className="text-alert text-sm" match="valueMissing">
+        <Form.Message className='text-alert text-sm' match='valueMissing'>
           Please select your home campus
         </Form.Message>
       </Form.Field>
 
-      <Form.Field name="waiverAccepted" className="flex flex-col gap-2 md:col-span-2">
-        <label className="flex items-start gap-3 cursor-pointer select-none">
+      <Form.Field
+        name='waiverAccepted'
+        className='flex flex-col gap-2 md:col-span-2 my-1 md:my-4'
+      >
+        <label className='flex items-center gap-3 cursor-pointer select-none'>
           <Form.Control asChild>
             <input
-              type="checkbox"
+              type='checkbox'
               required
-              value="true"
-              className="mt-1 h-5 w-5 shrink-0 rounded border border-ocean accent-ocean"
+              value='true'
+              className='h-5 w-5 shrink-0 rounded border border-ocean accent-ocean'
             />
           </Form.Control>
-          <span className="text-sm">
-            I accept the terms of the Christ Fellowship waiver.*
+          <span className='text-sm'>
+            I accept the terms of the{' '}
+            <a
+              href={waiverPdfUrl}
+              target='_blank'
+              rel='noopener noreferrer'
+              className='font-semibold text-ocean underline underline-offset-2 decoration-ocean/80 hover:text-ocean/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ocean'
+              onClick={(event) => event.stopPropagation()}
+            >
+              Christ Fellowship liability waiver
+            </a>
+            *
           </span>
         </label>
-        <Form.Message className="text-alert text-sm" match="valueMissing">
+        <Form.Message className='text-alert text-sm' match='valueMissing'>
           You must accept the waiver to sign up.
         </Form.Message>
-        {waiverLinkText ? (
-          <div
-            className="text-sm text-text-secondary [&_a]:text-ocean [&_a]:underline"
-            // Rock-admin-controlled HTML attribute (WaiverLinkText default value).
-            dangerouslySetInnerHTML={{ __html: waiverLinkText }}
-          />
-        ) : null}
       </Form.Field>
 
       {error ? (
-        <p className="text-alert text-sm md:col-span-2 text-center">{error}</p>
+        <p className='text-alert text-sm md:col-span-2 text-center'>{error}</p>
       ) : null}
 
-      <Form.Submit className="mt-2 mx-auto md:col-span-2" asChild>
+      <Form.Submit className='mt-2 mx-auto md:col-span-2' asChild>
         <Button
-          intent="primary"
-          className="w-40 h-12 rounded-full"
-          size="md"
-          type="submit"
+          intent='primary'
+          className='w-40 h-12 rounded-full'
+          size='md'
+          type='submit'
           disabled={isSubmitting}
         >
           {isSubmitting ? 'Submitting…' : 'Submit'}

--- a/app/routes/volunteer/outreach-opportunity/components/signup-form.component.tsx
+++ b/app/routes/volunteer/outreach-opportunity/components/signup-form.component.tsx
@@ -1,0 +1,180 @@
+import * as Form from '@radix-ui/react-form';
+import { useEffect, useState } from 'react';
+import { useFetcher } from 'react-router';
+
+import { Button } from '~/primitives/button/button.primitive';
+import { defaultTextInputStyles } from '~/primitives/inputs/text-field/text-field.primitive';
+import { pushFormEvent } from '~/lib/gtm';
+import { CAMPUS } from '~/routes/volunteer-form/types';
+
+interface SignupFormProps {
+  groupGuid: string;
+  waiverLinkText: string;
+  /** Path to POST to — the outreach-opportunity route's own action. */
+  actionPath: string;
+  onSuccess: () => void;
+}
+
+const SignupForm: React.FC<SignupFormProps> = ({
+  groupGuid,
+  waiverLinkText,
+  actionPath,
+  onSuccess,
+}) => {
+  const [error, setError] = useState<string | null>(null);
+  const fetcher = useFetcher();
+  const isSubmitting = fetcher.state === 'submitting';
+
+  useEffect(() => {
+    if (fetcher.state === 'idle' && fetcher.data) {
+      const data = fetcher.data as { error?: string; success?: boolean };
+      if (data.error) {
+        setError(data.error);
+      } else if (data.success) {
+        pushFormEvent(
+          'form_complete',
+          'community_serving_signup',
+          'Community Serving Opportunity Sign Up',
+        );
+        onSuccess();
+      }
+    }
+  }, [fetcher.state, fetcher.data, onSuccess]);
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+    const formData = new FormData(event.currentTarget);
+    fetcher.submit(formData, { method: 'post', action: actionPath });
+  };
+
+  return (
+    <Form.Root
+      onSubmit={handleSubmit}
+      className="flex flex-col text-left gap-y-4 md:grid md:grid-cols-2 md:gap-x-6 md:gap-y-4"
+    >
+      <input type="hidden" name="groupGuid" value={groupGuid} />
+
+      <Form.Field name="firstName" className="flex flex-col">
+        <Form.Label className="font-bold text-sm mb-1">First Name*</Form.Label>
+        <Form.Control asChild>
+          <input type="text" required className={defaultTextInputStyles} />
+        </Form.Control>
+        <Form.Message className="text-alert text-sm" match="valueMissing">
+          Please enter your first name
+        </Form.Message>
+      </Form.Field>
+
+      <Form.Field name="lastName" className="flex flex-col">
+        <Form.Label className="font-bold text-sm mb-1">Last Name*</Form.Label>
+        <Form.Control asChild>
+          <input type="text" required className={defaultTextInputStyles} />
+        </Form.Control>
+        <Form.Message className="text-alert text-sm" match="valueMissing">
+          Please enter your last name
+        </Form.Message>
+      </Form.Field>
+
+      <Form.Field name="phoneNumber" className="flex flex-col">
+        <Form.Label className="font-bold text-sm mb-1">Cell Phone*</Form.Label>
+        <Form.Control asChild>
+          <input type="tel" required className={defaultTextInputStyles} />
+        </Form.Control>
+        <Form.Message className="text-alert text-sm" match="valueMissing">
+          Please enter your phone number
+        </Form.Message>
+      </Form.Field>
+
+      <Form.Field name="email" className="flex flex-col">
+        <Form.Label className="font-bold text-sm mb-1">Email*</Form.Label>
+        <Form.Control asChild>
+          <input type="email" required className={defaultTextInputStyles} />
+        </Form.Control>
+        <Form.Message className="text-alert text-sm" match="valueMissing">
+          Please enter your email
+        </Form.Message>
+        <Form.Message className="text-alert text-sm" match="typeMismatch">
+          Please enter a valid email
+        </Form.Message>
+      </Form.Field>
+
+      <Form.Field name="birthdate" className="flex flex-col">
+        <Form.Label className="font-bold text-sm mb-1">Birthdate*</Form.Label>
+        <Form.Control asChild>
+          <input
+            type="date"
+            required
+            max={new Date().toISOString().slice(0, 10)}
+            className={defaultTextInputStyles}
+          />
+        </Form.Control>
+        <Form.Message className="text-alert text-sm" match="valueMissing">
+          Please enter your birthdate
+        </Form.Message>
+      </Form.Field>
+
+      <Form.Field name="campus" className="flex flex-col">
+        <Form.Label className="font-bold text-sm mb-1">Home Campus*</Form.Label>
+        <Form.Control asChild>
+          <select required className={`appearance-none ${defaultTextInputStyles}`} defaultValue="">
+            <option value="" disabled>
+              Select campus
+            </option>
+            {CAMPUS.map((c) => (
+              <option key={c} value={c}>
+                {c}
+              </option>
+            ))}
+          </select>
+        </Form.Control>
+        <Form.Message className="text-alert text-sm" match="valueMissing">
+          Please select your home campus
+        </Form.Message>
+      </Form.Field>
+
+      <Form.Field name="waiverAccepted" className="flex flex-col gap-2 md:col-span-2">
+        <label className="flex items-start gap-3 cursor-pointer select-none">
+          <Form.Control asChild>
+            <input
+              type="checkbox"
+              required
+              value="true"
+              className="mt-1 h-5 w-5 shrink-0 rounded border border-ocean accent-ocean"
+            />
+          </Form.Control>
+          <span className="text-sm">
+            I accept the terms of the Christ Fellowship waiver.*
+          </span>
+        </label>
+        <Form.Message className="text-alert text-sm" match="valueMissing">
+          You must accept the waiver to sign up.
+        </Form.Message>
+        {waiverLinkText ? (
+          <div
+            className="text-sm text-text-secondary [&_a]:text-ocean [&_a]:underline"
+            // Rock-admin-controlled HTML attribute (WaiverLinkText default value).
+            dangerouslySetInnerHTML={{ __html: waiverLinkText }}
+          />
+        ) : null}
+      </Form.Field>
+
+      {error ? (
+        <p className="text-alert text-sm md:col-span-2 text-center">{error}</p>
+      ) : null}
+
+      <Form.Submit className="mt-2 mx-auto md:col-span-2" asChild>
+        <Button
+          intent="primary"
+          className="w-40 h-12 rounded-full"
+          size="md"
+          type="submit"
+          disabled={isSubmitting}
+        >
+          {isSubmitting ? 'Submitting…' : 'Submit'}
+        </Button>
+      </Form.Submit>
+    </Form.Root>
+  );
+};
+
+export default SignupForm;

--- a/app/routes/volunteer/outreach-opportunity/components/signup-modal.component.tsx
+++ b/app/routes/volunteer/outreach-opportunity/components/signup-modal.component.tsx
@@ -1,0 +1,70 @@
+import { useEffect, useState } from 'react';
+
+import Modal from '~/primitives/Modal';
+import { Button } from '~/primitives/button/button.primitive';
+
+import SignupForm from './signup-form.component';
+
+interface SignupModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  groupGuid: string;
+  waiverLinkText: string;
+  /** Path the form posts to — the outreach-opportunity route's own action. */
+  actionPath: string;
+}
+
+export function SignupModal({
+  open,
+  onOpenChange,
+  groupGuid,
+  waiverLinkText,
+  actionPath,
+}: SignupModalProps) {
+  const [succeeded, setSucceeded] = useState(false);
+
+  // Reset to form view whenever the modal is reopened.
+  useEffect(() => {
+    if (open) setSucceeded(false);
+  }, [open]);
+
+  return (
+    <Modal open={open} onOpenChange={onOpenChange}>
+      <Modal.Content>
+        <div className="text-text-primary p-6 md:p-10 overflow-auto overflow-x-hidden w-[90vw] max-w-2xl max-h-[85vh] md:max-h-[90vh]">
+          {succeeded ? (
+            <div className="flex flex-col items-center gap-4 text-center">
+              <h2 className="text-2xl md:text-3xl font-bold text-navy">
+                You&apos;re signed up!
+              </h2>
+              <p className="text-text-secondary">
+                Thanks for signing up. We&apos;ll be in touch with next steps.
+              </p>
+              <Button
+                intent="primary"
+                className="rounded-full w-52 mt-2"
+                onClick={() => onOpenChange(false)}
+              >
+                Close
+              </Button>
+            </div>
+          ) : (
+            <>
+              <h2 className="text-2xl md:text-3xl font-bold text-navy text-center mb-6">
+                Sign up to serve
+              </h2>
+              <SignupForm
+                groupGuid={groupGuid}
+                waiverLinkText={waiverLinkText}
+                actionPath={actionPath}
+                onSuccess={() => setSucceeded(true)}
+              />
+            </>
+          )}
+        </div>
+      </Modal.Content>
+    </Modal>
+  );
+}
+
+export default SignupModal;

--- a/app/routes/volunteer/outreach-opportunity/components/signup-modal.component.tsx
+++ b/app/routes/volunteer/outreach-opportunity/components/signup-modal.component.tsx
@@ -9,7 +9,7 @@ interface SignupModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   groupGuid: string;
-  waiverLinkText: string;
+  waiverPdfUrl: string;
   /** Path the form posts to — the outreach-opportunity route's own action. */
   actionPath: string;
 }
@@ -18,7 +18,7 @@ export function SignupModal({
   open,
   onOpenChange,
   groupGuid,
-  waiverLinkText,
+  waiverPdfUrl,
   actionPath,
 }: SignupModalProps) {
   const [succeeded, setSucceeded] = useState(false);
@@ -55,7 +55,7 @@ export function SignupModal({
               </h2>
               <SignupForm
                 groupGuid={groupGuid}
-                waiverLinkText={waiverLinkText}
+                waiverPdfUrl={waiverPdfUrl}
                 actionPath={actionPath}
                 onSuccess={() => setSucceeded(true)}
               />

--- a/app/routes/volunteer/outreach-opportunity/loader.ts
+++ b/app/routes/volunteer/outreach-opportunity/loader.ts
@@ -1,17 +1,18 @@
 import type { LoaderFunction } from "react-router-dom";
 
-import {
-  fetchCommunityServingWaiverLinkText,
-  fetchVolunteerMissionDetailFromRock,
-} from "./outreach-mission-rock.server";
+import { fetchVolunteerMissionDetailFromRock } from "./outreach-mission-rock.server";
 import type { VolunteerMissionDetail } from "./types";
+
+/** Static PDF — Community Serving liability waiver. */
+const COMMUNITY_SERVING_WAIVER_PDF_URL =
+  "https://rock.gocf.org/Content/Missions/cfliabilitywaivermissions.pdf";
 
 export type LoaderReturnType = {
   /** Rock GUID from the URL (uppercase) — canonical for links and meta. */
   groupGuid: string;
   mission: VolunteerMissionDetail;
-  /** HTML for the waiver link (with three-language links), from workflow type 164. */
-  waiverLinkText: string;
+  /** URL to the liability waiver PDF (shown as inline link in the signup checkbox). */
+  waiverPdfUrl: string;
   /** Optional — used only for Algolia `spotsLeft` on the mission intro. */
   ALGOLIA_APP_ID: string;
   ALGOLIA_SEARCH_API_KEY: string;
@@ -33,10 +34,7 @@ export const loader: LoaderFunction = async ({ params }) => {
 
   const groupGuid = raw.toUpperCase();
 
-  const [mission, waiverLinkText] = await Promise.all([
-    fetchVolunteerMissionDetailFromRock(groupGuid),
-    fetchCommunityServingWaiverLinkText(),
-  ]);
+  const mission = await fetchVolunteerMissionDetailFromRock(groupGuid);
 
   if (!mission) {
     throw new Response("Mission not found", { status: 404 });
@@ -45,7 +43,7 @@ export const loader: LoaderFunction = async ({ params }) => {
   return Response.json({
     groupGuid,
     mission,
-    waiverLinkText,
+    waiverPdfUrl: COMMUNITY_SERVING_WAIVER_PDF_URL,
     ALGOLIA_APP_ID: process.env.ALGOLIA_APP_ID ?? "",
     ALGOLIA_SEARCH_API_KEY: process.env.ALGOLIA_SEARCH_API_KEY ?? "",
   } satisfies LoaderReturnType);

--- a/app/routes/volunteer/outreach-opportunity/loader.ts
+++ b/app/routes/volunteer/outreach-opportunity/loader.ts
@@ -1,12 +1,17 @@
 import type { LoaderFunction } from "react-router-dom";
 
-import { fetchVolunteerMissionDetailFromRock } from "./outreach-mission-rock.server";
+import {
+  fetchCommunityServingWaiverLinkText,
+  fetchVolunteerMissionDetailFromRock,
+} from "./outreach-mission-rock.server";
 import type { VolunteerMissionDetail } from "./types";
 
 export type LoaderReturnType = {
   /** Rock GUID from the URL (uppercase) — canonical for links and meta. */
   groupGuid: string;
   mission: VolunteerMissionDetail;
+  /** HTML for the waiver link (with three-language links), from workflow type 164. */
+  waiverLinkText: string;
   /** Optional — used only for Algolia `spotsLeft` on the mission intro. */
   ALGOLIA_APP_ID: string;
   ALGOLIA_SEARCH_API_KEY: string;
@@ -28,7 +33,11 @@ export const loader: LoaderFunction = async ({ params }) => {
 
   const groupGuid = raw.toUpperCase();
 
-  const mission = await fetchVolunteerMissionDetailFromRock(groupGuid);
+  const [mission, waiverLinkText] = await Promise.all([
+    fetchVolunteerMissionDetailFromRock(groupGuid),
+    fetchCommunityServingWaiverLinkText(),
+  ]);
+
   if (!mission) {
     throw new Response("Mission not found", { status: 404 });
   }
@@ -36,6 +45,7 @@ export const loader: LoaderFunction = async ({ params }) => {
   return Response.json({
     groupGuid,
     mission,
+    waiverLinkText,
     ALGOLIA_APP_ID: process.env.ALGOLIA_APP_ID ?? "",
     ALGOLIA_SEARCH_API_KEY: process.env.ALGOLIA_SEARCH_API_KEY ?? "",
   } satisfies LoaderReturnType);

--- a/app/routes/volunteer/outreach-opportunity/outreach-mission-rock.server.ts
+++ b/app/routes/volunteer/outreach-opportunity/outreach-mission-rock.server.ts
@@ -210,36 +210,6 @@ async function resolveContact(attrs: AttrBag | undefined): Promise<{
   };
 }
 
-type RockWorkflowTypeAttribute = {
-  key?: string;
-  defaultValue?: string;
-};
-
-/**
- * Fetches the `WaiverLinkText` default value from workflow type 164
- * ("Community Serving Opportunity Sign Up"). HTML — admin-controlled in Rock.
- */
-export async function fetchCommunityServingWaiverLinkText(): Promise<string> {
-  try {
-    const result = await fetchRockData({
-      endpoint: "WorkflowTypes/164",
-      queryParams: { $expand: "Attributes" },
-      ttl: TTL.LONG,
-    });
-
-    const attrs = (
-      Array.isArray((result as { attributes?: unknown })?.attributes)
-        ? (result as { attributes: RockWorkflowTypeAttribute[] }).attributes
-        : []
-    ) as RockWorkflowTypeAttribute[];
-
-    const waiver = attrs.find((a) => a?.key === "WaiverLinkText");
-    return waiver?.defaultValue?.trim() ?? "";
-  } catch {
-    return "";
-  }
-}
-
 /**
  * Loads one volunteer / mission opportunity from Rock by GUID (default: `Groups.Guid`).
  */

--- a/app/routes/volunteer/outreach-opportunity/outreach-mission-rock.server.ts
+++ b/app/routes/volunteer/outreach-opportunity/outreach-mission-rock.server.ts
@@ -210,6 +210,36 @@ async function resolveContact(attrs: AttrBag | undefined): Promise<{
   };
 }
 
+type RockWorkflowTypeAttribute = {
+  key?: string;
+  defaultValue?: string;
+};
+
+/**
+ * Fetches the `WaiverLinkText` default value from workflow type 164
+ * ("Community Serving Opportunity Sign Up"). HTML — admin-controlled in Rock.
+ */
+export async function fetchCommunityServingWaiverLinkText(): Promise<string> {
+  try {
+    const result = await fetchRockData({
+      endpoint: "WorkflowTypes/164",
+      queryParams: { $expand: "Attributes" },
+      ttl: TTL.LONG,
+    });
+
+    const attrs = (
+      Array.isArray((result as { attributes?: unknown })?.attributes)
+        ? (result as { attributes: RockWorkflowTypeAttribute[] }).attributes
+        : []
+    ) as RockWorkflowTypeAttribute[];
+
+    const waiver = attrs.find((a) => a?.key === "WaiverLinkText");
+    return waiver?.defaultValue?.trim() ?? "";
+  } catch {
+    return "";
+  }
+}
+
 /**
  * Loads one volunteer / mission opportunity from Rock by GUID (default: `Groups.Guid`).
  */

--- a/app/routes/volunteer/outreach-opportunity/outreach-opportunity-page.tsx
+++ b/app/routes/volunteer/outreach-opportunity/outreach-opportunity-page.tsx
@@ -31,7 +31,7 @@ export function OutreachOpportunityPage() {
   const {
     mission,
     groupGuid,
-    waiverLinkText,
+    waiverPdfUrl,
     ALGOLIA_APP_ID,
     ALGOLIA_SEARCH_API_KEY,
   } = useLoaderData<LoaderReturnType>();
@@ -172,7 +172,7 @@ export function OutreachOpportunityPage() {
           open={signupOpen}
           onOpenChange={setSignupOpen}
           groupGuid={groupGuid}
-          waiverLinkText={waiverLinkText}
+          waiverPdfUrl={waiverPdfUrl}
           actionPath={actionPath}
         />
       </article>

--- a/app/routes/volunteer/outreach-opportunity/outreach-opportunity-page.tsx
+++ b/app/routes/volunteer/outreach-opportunity/outreach-opportunity-page.tsx
@@ -1,7 +1,8 @@
-import { useLoaderData, useNavigate } from 'react-router-dom';
-import { useCallback, useEffect, useState } from 'react';
+import { useLoaderData, useLocation, useNavigate } from 'react-router-dom';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { useCopyPagePath } from '~/hooks/use-copy-page-path';
+import { pushFormEvent } from '~/lib/gtm';
 
 import { VolunteerDetailNav } from '../components/volunteer-detail/volunteer-detail-nav.component';
 import { VolunteerDetailHero } from '../components/volunteer-detail/volunteer-detail-hero.component';
@@ -17,6 +18,7 @@ import {
 } from './components/outreach-details.component';
 import { OutreachIntro } from './components/outreach-intro.component';
 import { VolunteerMissionSpotsAlgoliaProvider } from './components/outreach-spots-algolia.component';
+import { SignupModal } from './components/signup-modal.component';
 import {
   About,
   MobileBottomBar,
@@ -26,10 +28,31 @@ import {
 } from './partials/outreach-partials.partial';
 
 export function OutreachOpportunityPage() {
-  const { mission, groupGuid, ALGOLIA_APP_ID, ALGOLIA_SEARCH_API_KEY } =
-    useLoaderData<LoaderReturnType>();
+  const {
+    mission,
+    groupGuid,
+    waiverLinkText,
+    ALGOLIA_APP_ID,
+    ALGOLIA_SEARCH_API_KEY,
+  } = useLoaderData<LoaderReturnType>();
   const navigate = useNavigate();
+  const location = useLocation();
   const [isVisible, setIsVisible] = useState(false);
+  const [signupOpen, setSignupOpen] = useState(false);
+
+  const actionPath = useMemo(
+    () => `${location.pathname}${location.search}`,
+    [location.pathname, location.search],
+  );
+
+  const handleSignupOpen = useCallback(() => {
+    setSignupOpen(true);
+    pushFormEvent(
+      'form_start',
+      'community_serving_signup',
+      'Community Serving Opportunity Sign Up',
+    );
+  }, []);
 
   /** Session payload from finder card click; `navigate(-1)` restores `/volunteer?…` when filters exist. */
   const onBackToOpportunities = useCallback(() => {
@@ -58,7 +81,6 @@ export function OutreachOpportunityPage() {
   const category = str(mission.category) || 'Volunteer opportunity';
   const coverImage = str(mission.coverImageUrl) || undefined;
   const aboutBody = str(mission.summary) || '';
-  const signupHref = str(mission.missionsUrl) || '';
   const contactName = str(mission.contactName);
   const contactEmail = str(mission.contactEmail);
 
@@ -124,7 +146,7 @@ export function OutreachOpportunityPage() {
 
             <Sidebar
               mission={mission}
-              signupHref={signupHref}
+              onSignUpClick={handleSignupOpen}
               copied={copied}
               onCopyPath={copyPath}
             />
@@ -143,7 +165,15 @@ export function OutreachOpportunityPage() {
         <MobileBottomBar
           copied={copied}
           onCopyPath={copyPath}
-          signupHref={signupHref}
+          onSignUpClick={handleSignupOpen}
+        />
+
+        <SignupModal
+          open={signupOpen}
+          onOpenChange={setSignupOpen}
+          groupGuid={groupGuid}
+          waiverLinkText={waiverLinkText}
+          actionPath={actionPath}
         />
       </article>
     </div>

--- a/app/routes/volunteer/outreach-opportunity/partials/outreach-partials.partial.tsx
+++ b/app/routes/volunteer/outreach-opportunity/partials/outreach-partials.partial.tsx
@@ -97,12 +97,12 @@ export function Questions({
 
 export function Sidebar({
   mission,
-  signupHref,
+  onSignUpClick,
   copied,
   onCopyPath,
 }: {
   mission: VolunteerMissionDetail;
-  signupHref: string;
+  onSignUpClick: () => void;
   copied: boolean;
   onCopyPath: () => void;
 }) {
@@ -113,7 +113,8 @@ export function Sidebar({
       <div className="flex flex-col gap-3">
         <Button
           intent="primary"
-          href={signupHref}
+          type="button"
+          onClick={onSignUpClick}
           className="w-full rounded-full"
         >
           Sign Up
@@ -137,11 +138,11 @@ export function Sidebar({
 export function MobileBottomBar({
   copied,
   onCopyPath,
-  signupHref,
+  onSignUpClick,
 }: {
   copied: boolean;
   onCopyPath: () => void;
-  signupHref: string;
+  onSignUpClick: () => void;
 }) {
   const [mountToBody, setMountToBody] = useState(false);
 
@@ -176,9 +177,9 @@ export function MobileBottomBar({
       </button>
       <Button
         intent="primary"
-        href={signupHref}
-        linkClassName="flex-1 min-w-0"
-        className="min-h-12 w-full rounded-full text-base font-bold"
+        type="button"
+        onClick={onSignUpClick}
+        className="flex-1 min-w-0 min-h-12 rounded-full text-base font-bold"
       >
         Sign Up
       </Button>

--- a/app/routes/volunteer_.outreach.$groupGuid.tsx
+++ b/app/routes/volunteer_.outreach.$groupGuid.tsx
@@ -1,6 +1,7 @@
 import { OutreachOpportunityPage } from './volunteer/outreach-opportunity/outreach-opportunity-page';
 
 export { loader } from './volunteer/outreach-opportunity/loader';
+export { action } from './volunteer/outreach-opportunity/action';
 export { meta } from './volunteer/outreach-opportunity/meta';
 
 export default OutreachOpportunityPage;


### PR DESCRIPTION
## Summary
This branch replaces the outreach opportunity “Sign up” external link with an in-app modal that collects contact details, campus, birthdate, and waiver acceptance, then submits to Rock via the **Community Serving Opportunity Sign Up** workflow (`workflowTypeId=1840`). Campus names from the form are resolved to Rock campus **Guids** before launch. The volunteer form campus list is sourced from `RockCampuses` in `rock-config` (typed as `RockCampusName`) instead of a duplicated string array. The loader exposes a **static PDF** waiver URL (`cfliabilitywaivermissions.pdf`) for the checkbox link, and GTM records a `form_start` event when the modal opens.

## Screenshots
<img width="1396" height="984" alt="image" src="https://github.com/user-attachments/assets/a13a93ef-3b83-47d5-9b78-b31109973cef" />

## Testing
- [x] Manually open `/volunteer/outreach/:groupGuid`, click **Sign Up**, complete the modal, and confirm Rock receives the workflow and the success state appears. _*Be sure to remove yourself from group when finished testing_
- [x] `pnpm test` and `pnpm check` return no lint, type, or testing errors.

## Tickets
[CFDP-3941](https://christfellowshipchurch.atlassian.net/browse/CFDP-3941)

## Changes Made

### New Components Added
- `app/routes/volunteer/outreach-opportunity/components/signup-form.component.tsx` — form fields + `useFetcher` POST to the route action; waiver link to PDF; campus `<select>`.
- `app/routes/volunteer/outreach-opportunity/components/signup-modal.component.tsx` — modal wrapper, success state, resets when reopened.

### New Utilities
- `app/lib/.server/rock-signup.ts` — `resolveRockCampusGuidByName`, `CommunityServingSignupInput`, `launchCommunityServingSignupWorkflow` (OData campus lookup + `postRockData` workflow launch).
- `app/routes/volunteer/outreach-opportunity/action.ts` — validates form data, group GUID, ISO birthdate, campus allowlist (excludes Online), waiver; calls `launchCommunityServingSignupWorkflow`.

### New Assets
- None in-repo; waiver uses hosted PDF: `https://rock.gocf.org/Content/Missions/cfliabilitywaivermissions.pdf` (see loader constant).

### Dependencies
- None.

### Route Implementation
- `app/routes/volunteer_.outreach.$groupGuid.tsx` — re-exports `action` from `volunteer/outreach-opportunity/action`.
- `app/routes/volunteer/outreach-opportunity/loader.ts` — adds `waiverPdfUrl` to loader JSON.
- `app/routes/volunteer/outreach-opportunity/outreach-opportunity-page.tsx` — wires `SignupModal`, `actionPath`, GTM `form_start` on open.
- `app/routes/volunteer/outreach-opportunity/partials/outreach-partials.partial.tsx` — **Sign Up** is a button + `onSignUpClick` instead of `signupHref`.

### Key Features
- Native community-serving signup on the outreach opportunity page (no navigation to Rock missions URL for signup).
- Server-side validation and Rock workflow launch with campus Guid resolution.
- Shared campus names with `RockCampuses` / `RockCampusName` in `app/routes/volunteer-form/types.ts`.

[CFDP-3941]: https://christfellowshipchurch.atlassian.net/browse/CFDP-3941?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ