### PR TITLE
Group Single | I'm Interested Button Desktop

### DIFF
--- a/app/routes/group-single/components/group-single-interest-cta.component.tsx
+++ b/app/routes/group-single/components/group-single-interest-cta.component.tsx
@@ -1,0 +1,35 @@
+import { GroupConnectModal } from '~/components/modals/group-connect/group-connect-modal';
+import { Button } from '~/primitives/button/button.primitive';
+
+export function GroupSingleInterestCta({ groupId }: { groupId: string }) {
+  return (
+    <div className='hidden md:flex w-full content-padding pt-10 lg:pt-16 justify-center'>
+      <div className='w-full max-w-screen-content'>
+        <div className='flex items-center gap-6 rounded-2xl border border-neutral-lighter bg-white p-8 lg:p-12 shadow-[0_2px_8px_rgba(0,0,0,0.04)]'>
+          <div className='flex flex-1 flex-col gap-2'>
+            <h3 className='text-xl lg:text-[32px] font-extrabold mb-2'>
+              Interested In This Group?
+            </h3>
+            <p className='text-text-secondary md:text-base lg:text-lg max-w-3xl'>
+              Want to learn more or see if this group is a good fit for you? Let
+              the group leaders know you're interested and they'll reach out
+              with more details, answer questions, and help you get connected.
+            </p>
+          </div>
+
+          <GroupConnectModal
+            groupId={groupId}
+            buttonText="I'm Interested"
+            ModalButton={(props) => (
+              <Button
+                intent='primary'
+                className='shrink-0 min-w-0 px-5 lg:px-6 min-h-0 py-3 text-base lg:text-lg'
+                {...props}
+              />
+            )}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/routes/group-single/group-single-page.tsx
+++ b/app/routes/group-single/group-single-page.tsx
@@ -10,6 +10,7 @@ import { Button } from "~/primitives/button/button.primitive";
 import { useCopyPagePath } from "~/hooks/use-copy-page-path";
 import { GroupType, splitGroupTopics } from "../group-finder/types";
 import { GroupSingleBanner } from "./components/group-single-banner.component";
+import { GroupSingleInterestCta } from "./components/group-single-interest-cta.component";
 import { GroupSingleMobileBottomBar } from "./components/group-single-mobile-bottom-bar.component";
 
 export const GroupNotFound = () => (
@@ -45,6 +46,8 @@ export const GroupSingleContent = ({ hit }: { hit: GroupType }) => {
 
       {/* Hero */}
       <GroupSingleHero hit={hit} />
+
+      <GroupSingleInterestCta groupId={groupId} />
 
       <div className="content-padding w-full flex justify-center">
         <div className="justify-center flex flex-col gap-12 pt-10 lg:pt-16 w-full max-w-screen-content">

--- a/app/routes/group-single/group-single-page.tsx
+++ b/app/routes/group-single/group-single-page.tsx
@@ -1,26 +1,26 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState } from 'react';
 
-import { LoaderReturnType } from "./loader";
-import { GroupSingleHero } from "./partials/group-single-hero.partial";
+import { LoaderReturnType } from './loader';
+import { GroupSingleHero } from './partials/group-single-hero.partial';
 
-import { GroupSingleBasicContent } from "./components/basic-content.component";
-import { RelatedGroupsPartial } from "./partials/related-groups.partial";
-import { Button } from "~/primitives/button/button.primitive";
+import { GroupSingleBasicContent } from './components/basic-content.component';
+import { RelatedGroupsPartial } from './partials/related-groups.partial';
+import { Button } from '~/primitives/button/button.primitive';
 
-import { useCopyPagePath } from "~/hooks/use-copy-page-path";
-import { GroupType, splitGroupTopics } from "../group-finder/types";
-import { GroupSingleBanner } from "./components/group-single-banner.component";
-import { GroupSingleInterestCta } from "./components/group-single-interest-cta.component";
-import { GroupSingleMobileBottomBar } from "./components/group-single-mobile-bottom-bar.component";
+import { useCopyPagePath } from '~/hooks/use-copy-page-path';
+import { GroupType, splitGroupTopics } from '../group-finder/types';
+import { GroupSingleBanner } from './components/group-single-banner.component';
+import { GroupSingleInterestCta } from './components/group-single-interest-cta.component';
+import { GroupSingleMobileBottomBar } from './components/group-single-mobile-bottom-bar.component';
 
 export const GroupNotFound = () => (
-  <div className="flex flex-col items-center justify-center gap-6 h-[70vh] w-screen">
-    <h2 className="text-2xl font-bold text-center">Group Not Found</h2>
-    <p className="text-neutral-500 text-center max-w-md">
+  <div className='flex flex-col items-center justify-center gap-6 h-[70vh] w-screen'>
+    <h2 className='text-2xl font-bold text-center'>Group Not Found</h2>
+    <p className='text-neutral-500 text-center max-w-md'>
       We couldn't find the group you're looking for. It may have been removed or
       renamed.
     </p>
-    <Button intent="primary" href="/group-finder">
+    <Button intent='primary' href='/group-finder'>
       Browse All Groups
     </Button>
   </div>
@@ -32,12 +32,12 @@ export const GroupSingleContent = ({ hit }: { hit: GroupType }) => {
   const groupId = String(hit.groupId ?? hit.objectID);
 
   return (
-    <section className="flex flex-col items-center dark:bg-gray-900 pb-24 md:pb-0">
+    <section className='flex flex-col items-center dark:bg-gray-900'>
       {/* Desktop Only Banner */}
       <GroupSingleBanner
         language={hit.language}
         leaderImages={(hit.leaders ?? []).map(
-          (leader) => leader.photo ?? { sources: [{ uri: "" }] },
+          (leader) => leader.photo ?? { sources: [{ uri: '' }] },
         )}
         topics={topicTags}
         groupName={hit.title}
@@ -49,8 +49,8 @@ export const GroupSingleContent = ({ hit }: { hit: GroupType }) => {
 
       <GroupSingleInterestCta groupId={groupId} />
 
-      <div className="content-padding w-full flex justify-center">
-        <div className="justify-center flex flex-col gap-12 pt-10 lg:pt-16 w-full max-w-screen-content">
+      <div className='content-padding w-full flex justify-center'>
+        <div className='justify-center flex flex-col gap-12 pt-10 lg:pt-16 w-full max-w-screen-content'>
           <GroupSingleBasicContent summary={hit.summary} />
         </div>
       </div>
@@ -85,7 +85,7 @@ export function GroupSinglePage({
   return (
     <div
       className={`min-h-screen ${
-        isVisible ? "animate-fadeIn duration-400" : "opacity-0"
+        isVisible ? 'animate-fadeIn duration-400' : 'opacity-0'
       }`}
     >
       {group ? <GroupSingleContent hit={group} /> : <GroupNotFound />}


### PR DESCRIPTION
## Summary
Introduce a new GroupSingleInterestCta component that displays an "Interested In This Group?" call-to-action with explanatory text and a primary "I'm Interested" GroupConnectModal button (desktop only). Add the component file and import/use it in group-single-page.tsx to surface a way for users to express interest to group leaders; includes layout and styling for responsive placement.

## Screenshots
<img width="1389" height="946" alt="image" src="https://github.com/user-attachments/assets/4ada5856-0460-4e30-8d3a-6dc41d6eec19" />

## Testing
- [x] Visit a group single page on desktop (≥ md breakpoint) and confirm the new "Interested In This Group?" card renders between the hero and the main content.
- [x] Confirm the card is hidden on mobile (the existing `GroupSingleMobileBottomBar` covers that case).
- [x] Click "I'm Interested" and verify the `GroupConnectModal` opens with the correct `groupId`, and that submission flows through as expected.
- [x] Verify layout at `md` and `lg` breakpoints (padding, typography sizes, button sizing, max width).
- [x] Run `pnpm lint` and confirm no new linter errors/warnings.

## Tickets
[CFDP-3940](https://christfellowshipchurch.atlassian.net/browse/CFDP-3940)

## Changes Made

### New Components Added
- `app/routes/group-single/components/group-single-interest-cta.component.tsx` — Desktop-only CTA card prompting visitors to express interest in the group; wraps `GroupConnectModal` with a styled primary `Button`.

### Route Implementation
- `app/routes/group-single/group-single-page.tsx` — Imports and renders the new `GroupSingleInterestCta` directly after `GroupSingleHero`, passing the current `groupId`.

### Key Features
- New "Interested In This Group?" CTA on the group single page that lets prospective members signal interest and triggers the existing group connect flow.
- Desktop/tablet-only (`hidden md:flex`) so it doesn't conflict with `GroupSingleMobileBottomBar` on mobile.
- Reuses the shared `GroupConnectModal` and `Button` primitive, keeping styling and behavior consistent with the rest of the app.
- Responsive typography and spacing (`text-xl lg:text-[32px]`, `p-8 lg:p-12`, etc.) for a clean layout across breakpoints.

[CFDP-3940]: https://christfellowshipchurch.atlassian.net/browse/CFDP-3940?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ