### PR TITLE
Plan a Visit

### DIFF
--- a/app/components/modals/set-a-reminder/__tests__/reminder-form.test.tsx
+++ b/app/components/modals/set-a-reminder/__tests__/reminder-form.test.tsx
@@ -68,19 +68,28 @@ describe('ReminderForm', () => {
     expect(screen.getByText('Loading...')).toBeInTheDocument();
   });
 
-  it("shows 'Set A Reminder!' heading for English campus", () => {
+  it("shows 'Plan a Visit!' heading for in-person English campus (visit is plannable)", () => {
     mockLoadFetcher.data = mockFormData;
     renderForm();
+    expect(screen.getByText('Plan a Visit!')).toBeInTheDocument();
+  });
+
+  it("shows 'Set A Reminder!' heading for Online campus (nothing to visit)", () => {
+    mockLoadFetcher.data = {
+      ...mockFormData,
+      campusName: 'Christ Fellowship Online',
+    };
+    renderForm({ ...defaultProps, url: 'cf-everywhere' });
     expect(screen.getByText('Set A Reminder!')).toBeInTheDocument();
   });
 
-  it("shows 'Recuérdame' heading for Español campus", () => {
+  it("shows 'Visítanos' heading for Español campus", () => {
     mockLoadFetcher.data = {
       ...mockFormData,
       campusName: 'Español PBG',
     };
     renderForm();
-    expect(screen.getByText('Recuérdame')).toBeInTheDocument();
+    expect(screen.getByText('Visítanos')).toBeInTheDocument();
   });
 
   it('renders English field labels by default', () => {

--- a/app/components/modals/set-a-reminder/__tests__/reminder-modal.test.tsx
+++ b/app/components/modals/set-a-reminder/__tests__/reminder-modal.test.tsx
@@ -30,12 +30,12 @@ function renderModal(props = {}) {
 }
 
 describe('SetAReminderModal', () => {
-  it("renders 'Set a Reminder' button text for non-iglesia URL", () => {
+  it("renders 'Plan a Visit' for an in-person English campus (visit is plannable)", () => {
     renderModal();
-    expect(screen.getByText('Set a Reminder')).toBeInTheDocument();
+    expect(screen.getByText('Plan a Visit')).toBeInTheDocument();
   });
 
-  it("renders 'Recuérdame' button text when campusUrl includes 'iglesia'", () => {
+  it("renders 'Visítanos' button text when campusUrl includes 'iglesia'", () => {
     vi.doMock('react-router-dom', async () => {
       const actual =
         await vi.importActual<typeof import('react-router-dom')>(
@@ -64,7 +64,7 @@ describe('SetAReminderModal', () => {
   it('opens modal and shows flow content when button is clicked', async () => {
     const user = userEvent.setup();
     renderModal();
-    await user.click(screen.getByText('Set a Reminder'));
+    await user.click(screen.getByText('Plan a Visit'));
     expect(screen.getByText('ReminderFlowContent')).toBeInTheDocument();
   });
 });

--- a/app/components/modals/set-a-reminder/reminder-form.component.tsx
+++ b/app/components/modals/set-a-reminder/reminder-form.component.tsx
@@ -73,6 +73,7 @@ const ReminderForm: React.FC<ReminderProps> = ({
 
   const { serviceTimes, campusName, user } = formData || {};
   const isEspanol = campusName?.includes('Español');
+  const isOnline = url?.includes('everywhere');
   const firstName = user?.firstName || null;
   const lastName = user?.lastName || null;
   const phoneNumber = null;
@@ -81,7 +82,11 @@ const ReminderForm: React.FC<ReminderProps> = ({
   return (
     <>
       <h2 className='mb-6 text-3xl text-navy font-bold'>
-        {isEspanol ? 'Recuérdame' : 'Set A Reminder!'}
+        {isEspanol
+          ? 'Visítanos'
+          : isOnline
+            ? 'Set A Reminder!'
+            : 'Plan a Visit!'}
       </h2>
       <Form.Root
         onSubmit={handleSubmit}

--- a/app/components/modals/set-a-reminder/reminder-modal.component.tsx
+++ b/app/components/modals/set-a-reminder/reminder-modal.component.tsx
@@ -31,6 +31,15 @@ export function SetAReminderModal({
     }
   };
 
+  // Online campuses keep "Set a Reminder" wording (there is no visit to plan).
+  const isOnline = campusUrl?.includes('everywhere');
+  const isSpanish = campusUrl?.includes('iglesia');
+  const buttonLabel = isSpanish
+    ? 'Visítanos'
+    : isOnline
+      ? 'Set a Reminder'
+      : 'Plan a Visit';
+
   return (
     <Modal open={openModal} onOpenChange={handleOpenChange}>
       <Modal.Button asChild className={cn('mr-2', triggerClassName)}>
@@ -42,7 +51,7 @@ export function SetAReminderModal({
             className,
           )}
         >
-          {campusUrl?.includes('iglesia') ? 'Recuérdame' : 'Set a Reminder'}
+          {buttonLabel}
         </ModalButton>
       </Modal.Button>
       <Modal.Content>

--- a/app/routes/locations/location-single/components/ctas.component.tsx
+++ b/app/routes/locations/location-single/components/ctas.component.tsx
@@ -47,11 +47,7 @@ export const CTAs = ({
     <div className='w-full md:mx-auto md:max-w-md lg:mx-0 lg:max-w-full'>
       <div className='grid w-full grid-cols-3 items-stretch gap-4 lg:gap-6'>
         <div className={ctaSlotClassName}>
-          <CTAButton
-            icon='calendarAlt'
-            title={reminderTitle}
-            isSetAReminder
-          />
+          <CTAButton icon='calendarAlt' title={reminderTitle} isSetAReminder />
         </div>
         <div className={ctaSlotClassName}>
           <CTAButton

--- a/app/routes/locations/location-single/components/ctas.component.tsx
+++ b/app/routes/locations/location-single/components/ctas.component.tsx
@@ -30,14 +30,26 @@ const CTAButtonContent = ({
 const ctaSlotClassName =
   'flex min-h-0 min-w-0 flex-col items-stretch [&>*]:flex [&>*]:min-h-0 [&>*]:w-full [&>*]:flex-1 [&>*]:flex-col [&>*]:items-center [&>*]:justify-stretch';
 
-export const CTAs = ({ isSpanish }: { isSpanish?: boolean }) => {
+export const CTAs = ({
+  isSpanish,
+  isOnline,
+}: {
+  isSpanish?: boolean;
+  isOnline?: boolean;
+}) => {
+  // Online campuses keep "Set a Reminder" wording (there is no visit to plan).
+  const reminderTitle = isSpanish
+    ? 'Visítanos'
+    : isOnline
+      ? 'Set a Reminder'
+      : 'Plan a Visit';
   return (
     <div className='w-full md:mx-auto md:max-w-md lg:mx-0 lg:max-w-full'>
       <div className='grid w-full grid-cols-3 items-stretch gap-4 lg:gap-6'>
         <div className={ctaSlotClassName}>
           <CTAButton
             icon='calendarAlt'
-            title={isSpanish ? 'Recuérdame' : 'Set a Reminder'}
+            title={reminderTitle}
             isSetAReminder
           />
         </div>

--- a/app/routes/locations/location-single/components/tabs-component/about-us/connect-with-us.tsx
+++ b/app/routes/locations/location-single/components/tabs-component/about-us/connect-with-us.tsx
@@ -14,6 +14,13 @@ export const ConnectWithUs = ({
 }) => {
   const isOnline = campusName.toLowerCase().includes('online');
 
+  // Online campuses keep "Set a Reminder" wording (there is no visit to plan).
+  const reminderLabel = isSpanish
+    ? 'Visítanos'
+    : isOnline
+      ? 'Set a Reminder'
+      : 'Plan a Visit';
+
   const CustomButton = React.forwardRef<HTMLButtonElement, ButtonProps>(
     ({ className, ...props }, ref) => (
       <Button
@@ -25,7 +32,7 @@ export const ConnectWithUs = ({
         )}
         {...props}
       >
-        Set a Reminder
+        {reminderLabel}
       </Button>
     ),
   );

--- a/app/routes/locations/location-single/partials/campus-info.partial.tsx
+++ b/app/routes/locations/location-single/partials/campus-info.partial.tsx
@@ -237,7 +237,7 @@ const OnlineCampusInfo = ({
           <div className='flex flex-col gap-16'>
             {/* Desktop CTAs */}
             <div className='hidden max-w-[450px] flex-col gap-8 lg:flex'>
-              <CTAs />
+              <CTAs isOnline />
             </div>
           </div>
         </div>
@@ -250,7 +250,7 @@ const OnlineCampusInfo = ({
 
         {/* Mobile CTAs */}
         <div className='flex flex-col gap-16 md:items-center lg:hidden'>
-          <CTAs />
+          <CTAs isOnline />
         </div>
       </div>
     </div>

--- a/app/routes/locations/location-single/partials/location-content.tsx
+++ b/app/routes/locations/location-single/partials/location-content.tsx
@@ -150,7 +150,7 @@ export function LocationSingle({ hit }: { hit: LocationHitType }) {
   const heading2 = isSpanish ? 'lugar para ti' : 'welcome here';
   const ctas = [
     {
-      title: isSpanish ? 'Recuérdame' : 'Set a Reminder',
+      title: isSpanish ? 'Visítanos' : 'Plan a Visit',
       href: '#',
       isSetAReminder: true,
     },


### PR DESCRIPTION
## Summary
Adjust reminder/visit copy to distinguish in-person vs online campuses: English in-person labels now read 'Plan a Visit', Spanish labels read 'Visítanos', while online campuses retain 'Set a Reminder'. Adds isOnline checks and a computed button/heading label, threads isOnline into CTAs, and updates tests to reflect the new copy. Affected files: reminder form & modal components and tests, CTAs, connect-with-us, campus-info partial, and location-content.

## Screenshots
<img width="1511" height="667" alt="Screenshot 2026-05-13 at 4 24 57 PM" src="https://github.com/user-attachments/assets/c3de3a1d-c0ae-4b64-aaa0-bd16361c0b4a" />


## Testing
- [x] Ensure copy for buttons and title in English say "Plan a Visit" instead of "Set a Reminder" (except for Online campus, there it stays "Set a Reminder".
- [x] Ensure in Spanish it now says "Visítanos". I do not remember seeing copy for this so I translated myself, waiting on confirmation from Katie and what CFE or María want this to be.
- [ ] `pnpm run check` shows no errors/warnings

## Tickets
[CFDP-3901](https://christfellowshipchurch.atlassian.net/browse/CFDP-3901)

## Changes Made

### New Components Added

- List any new React components created
- Include file paths and brief descriptions

### New Utilities

- List any new utility functions or helper components
- Include file paths and descriptions

### New Assets

- List any new images, animations, or other static assets
- Include file paths and descriptions

### Dependencies

- List any new dependencies added to package.json
- Include version numbers

### Route Implementation

- List any new routes or route modifications
- Include file paths and descriptions

### Key Features

- Highlight the main features implemented
- Focus on user-facing functionality
- Include any performance optimizations or accessibility improvements


[CFDP-3901]: https://christfellowshipchurch.atlassian.net/browse/CFDP-3901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ