### PR TITLE
Added Give Button to Desktop Navbar

### DIFF
--- a/app/components/navbar/mobile/mobile-menu-content.tsx
+++ b/app/components/navbar/mobile/mobile-menu-content.tsx
@@ -92,14 +92,14 @@ export default function MobileMenuContent({
             Stay up to date with your groups, classes, and more.
           </p>
           <a
-            href='https://legacy-my-groups.vercel.app/login'
+            href='https://legacy-my-groups.vercel.app/'
             target='_blank'
             rel='noreferrer'
             onClick={closeMenu}
             className='bg-ocean text-white p-2 rounded-lg w-full font-medium text-center'
             aria-label='Login'
           >
-            Login
+            Sign In
           </a>
         </section>
 

--- a/app/components/navbar/navbar.component.tsx
+++ b/app/components/navbar/navbar.component.tsx
@@ -1,4 +1,4 @@
-import { useLocation } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { useRouteLoaderData } from 'react-router-dom';
 import { useEffect, useState, useRef } from 'react';
 import { useResponsive } from '~/hooks/use-responsive';
@@ -396,34 +396,25 @@ export function Navbar() {
                 )}
 
                 <div
-                  className={cn('flex gap-2', isSearchOpen && 'hidden xl:flex')}
+                  className={cn(
+                    'flex gap-2 ml-2 xl:ml-6',
+                    isSearchOpen && 'hidden xl:flex',
+                  )}
                 >
-                  {/* We will plan to redirect to legacy my groups site */}
-                  {/* <AuthModal
-                    buttonStyle={cn(
-                      "font-semibold text-sm xl:text-base w-[70px] xl:w-[90px] py-2 min-h-0 h-auto px-0 min-w-0 cursor-pointer hover:text-ocean",
-                      mode === "dark" &&
-                        !openDropdown &&
-                        "border-white text-white group-hover:text-ocean group-hover:border-ocean",
-                    )}
-                    buttonText="Login"
-                  /> */}
-                  <a
-                    href='https://legacy-my-groups.vercel.app/login'
-                    target='_blank'
-                    rel='noreferrer'
-                    aria-label='Login'
+                  <Link
+                    to='/give'
+                    prefetch='intent'
+                    aria-label='Give'
                     className={cn(
-                      'font-semibold text-sm xl:text-base transition-colors h-full my-auto px-6 hover:text-ocean',
-                      mode === 'light' || isSearchOpen
-                        ? 'text-neutral-dark'
-                        : openDropdown
-                          ? 'text-neutral-dark'
-                          : 'text-white group-hover:text-text',
+                      'rounded-lg px-4 font-semibold text-sm xl:text-base',
+                      'border border-ocean cursor-pointer',
+                      'text-ocean transition-colors duration-200',
+                      'hover:bg-ocean/20 transition-colors duration-200',
+                      'flex items-center justify-center',
                     )}
                   >
-                    Login
-                  </a>
+                    Give
+                  </Link>
                   <Button
                     href='/locations'
                     className='font-semibold text-sm xl:text-base w-fit min-w-[180px]'


### PR DESCRIPTION
## Summary

Updates the site navbar so the primary auth-adjacent action is **Give** instead of **Login**. The old external link to the legacy login URL is removed. **Give** is now an in-app `Link` to `/give` with `prefetch="intent"` for faster navigation. Spacing next to the action group is tightened on small screens and increased on xl (`ml-2 xl:ml-6`). Commented-out legacy `AuthModal` code for Login is removed to reduce noise.

## Screenshots

<img width="1446" height="392" alt="image" src="https://github.com/user-attachments/assets/fae23163-9cf1-430e-80da-3fcfe3b5a8e5" />

## Testing

- [x] Manually open the navbar on desktop and mobile; confirm **Give** navigates to `/give` and styling matches light/dark navbar context.
- [x] With search open on smaller breakpoints, confirm the action group still hides/shows as before on xl.
- [x] Run `pnpm lint` and confirm no new issues in `navbar.component.tsx`.

## Tickets

[CFDP-3949](https://christfellowshipchurch.atlassian.net/browse/CFDP-3949)

## Changes Made

### Route Implementation

- None (uses existing `/give` route via client-side `Link`)

### Key Features

- Replaced external **Login** (`https://legacy-my-groups.vercel.app/login`) with internal **Give** link to `/give` using `Link` from `react-router-dom` and `prefetch="intent"`.
- **Give** control uses outlined “ocean” styling (`border-ocean`, hover `bg-ocean/20`) and updated `aria-label` to `Give`.
- Navbar action row spacing: `ml-2 xl:ml-6` on the flex container wrapping **Give** and **Locations**.
- Removed dead commented `AuthModal` / Login block.

[CFDP-3949]: https://christfellowshipchurch.atlassian.net/browse/CFDP-3949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ