### PR TITLE
A Chance Section | Scroll/Short Desktop Fix

### DIFF
--- a/app/routes/home/components/image-scroll-layout.tsx
+++ b/app/routes/home/components/image-scroll-layout.tsx
@@ -87,7 +87,12 @@ export function ImageScrollLayout() {
     <div className='relative'>
       <div className='fixed top-0 left-0 w-screen h-48 md:h-64 short-desktop:h-48 bg-linear-to-b from-white via-white to-transparent z-5 pointer-events-none' />
 
-      <div className='flex flex-col md:flex-row'>
+      <div
+        className={cn(
+          'flex flex-col md:flex-row',
+          'max-w-[1500px] short-desktop:max-w-[1200px] mx-auto short-desktop:px-8',
+        )}
+      >
         {/* Sticky image (md+): stays in view while sections pass, then scrolls with the page after the last section */}
         <div className='hidden md:block w-1/2 shrink-0 relative z-0 pointer-events-none'>
           <div className='sticky top-0 h-screen pl-5 md:pl-12 lg:pl-18 short-desktop:pl-8 short-desktop:lg:pl-12'>

--- a/app/routes/home/components/image-scroll-layout.tsx
+++ b/app/routes/home/components/image-scroll-layout.tsx
@@ -85,14 +85,14 @@ export function ImageScrollLayout() {
 
   return (
     <div className='relative'>
-      <div className='fixed top-0 left-0 w-screen h-48 md:h-64 bg-linear-to-b from-white via-white to-transparent z-5 pointer-events-none' />
+      <div className='fixed top-0 left-0 w-screen h-48 md:h-64 short-desktop:h-48 bg-linear-to-b from-white via-white to-transparent z-5 pointer-events-none' />
 
       <div className='flex flex-col md:flex-row'>
         {/* Sticky image (md+): stays in view while sections pass, then scrolls with the page after the last section */}
         <div className='hidden md:block w-1/2 shrink-0 relative z-0 pointer-events-none'>
-          <div className='sticky top-0 h-screen pl-5 md:pl-12 lg:pl-18'>
+          <div className='sticky top-0 h-screen pl-5 md:pl-12 lg:pl-18 short-desktop:pl-8 short-desktop:lg:pl-12'>
             <div className='flex h-full w-full max-w-[716px] items-center ml-auto'>
-              <div className='relative w-full max-w-md xl:max-w-lg aspect-square'>
+              <div className='relative w-full max-w-md xl:max-w-lg short-desktop:max-w-sm short-desktop:xl:max-w-md aspect-square'>
                 {chanceContent.map((section, index) => (
                   <img
                     key={section.image}
@@ -122,12 +122,12 @@ export function ImageScrollLayout() {
                   sectionRefs.current[index] = el;
                 }}
                 className={cn(
-                  'relative flex items-center p-12 min-h-screen w-full',
+                  'relative flex items-center p-12 min-h-screen w-full short-desktop:p-8',
                   index === 2 && 'pb-24 md:pb-0', // Add padding to the last section on mobile to prevent content from grayed out from gradient
                 )}
                 data-card-index={index}
               >
-                <div className='flex flex-col justify-center items-center gap-12 max-w-2xl mx-auto w-full'>
+                <div className='flex flex-col justify-center items-center gap-12 short-desktop:gap-8 max-w-2xl mx-auto w-full'>
                   {/* Mobile Image */}
                   <img
                     src={section.image}
@@ -137,7 +137,7 @@ export function ImageScrollLayout() {
                     className='md:hidden w-full max-w-sm'
                   />
                   <div
-                    className={`w-full flex flex-col gap-9 transition-all duration-1000 ease-out delay-300 ${
+                    className={`w-full flex flex-col gap-9 short-desktop:gap-6 transition-all duration-1000 ease-out delay-300 ${
                       visibleSections.has(index)
                         ? 'opacity-100 translate-y-0'
                         : 'opacity-0 translate-y-8'

--- a/app/routes/home/components/image-scroll-layout.tsx
+++ b/app/routes/home/components/image-scroll-layout.tsx
@@ -87,82 +87,89 @@ export function ImageScrollLayout() {
     <div className='relative pt-32 md:pt-0'>
       <div className='fixed top-0 left-0 w-screen h-48 md:h-64 bg-linear-to-b from-white via-white to-transparent z-5 pointer-events-none' />
 
-      {/* Fixed Image Container (md+) — viewport-anchored to avoid layout shifts from hiding navbar */}
-      <div className='hidden md:block fixed left-0 top-0 w-1/2 h-screen z-0 pointer-events-none pl-5 md:pl-12 lg:pl-18'>
-        <div className='w-full h-full flex max-w-[716px] ml-auto'>
-          <div className='relative w-full max-w-md xl:max-w-lg aspect-square'>
+      <div className='flex flex-col md:flex-row'>
+        {/* Sticky image (md+): stays in view while sections pass, then scrolls with the page after the last section */}
+        <div className='hidden md:block w-1/2 shrink-0 relative z-0 pointer-events-none'>
+          <div className='sticky top-0 h-screen pl-5 md:pl-12 lg:pl-18'>
+            <div className='flex h-full w-full max-w-[716px] items-center ml-auto'>
+              <div className='relative w-full max-w-md xl:max-w-lg aspect-square'>
+                {chanceContent.map((section, index) => (
+                  <img
+                    key={section.image}
+                    src={section.image}
+                    alt=''
+                    width={section.imageWidth}
+                    height={section.imageHeight}
+                    className={`absolute inset-0 w-full h-full object-contain transition-all duration-700 ${
+                      index === activeSection
+                        ? 'opacity-100 translate-x-0 z-10'
+                        : 'opacity-0 -translate-x-8 z-0'
+                    }`}
+                  />
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Scrollable Content Sections */}
+        <div className='relative z-10 w-full md:flex md:w-1/2 md:min-w-0 md:shrink-0 md:justify-end'>
+          <div className='mx-auto w-full max-w-[716px] md:mx-0'>
             {chanceContent.map((section, index) => (
-              <img
-                key={section.image}
-                src={section.image}
-                alt=''
-                width={section.imageWidth}
-                height={section.imageHeight}
-                className={`absolute inset-0 w-full h-full object-contain transition-all duration-700 ${
-                  index === activeSection
-                    ? 'opacity-100 translate-x-0 z-10'
-                    : 'opacity-0 -translate-x-8 z-0'
-                }`}
-              />
+              <section
+                key={section.title}
+                ref={(el) => {
+                  sectionRefs.current[index] = el;
+                }}
+                className={cn(
+                  'relative flex items-center p-12 min-h-screen w-full',
+                  index === 2 &&
+                    'pb-24 md:pb-0', // Add padding to the last section on mobile to prevent content from grayed out from gradient
+                )}
+                data-card-index={index}
+              >
+                <div className='flex flex-col justify-center items-center gap-12 max-w-2xl mx-auto w-full'>
+                  {/* Mobile Image */}
+                  <img
+                    src={section.image}
+                    alt=''
+                    width={section.imageWidth}
+                    height={section.imageHeight}
+                    className='md:hidden w-full max-w-sm'
+                  />
+                  <div
+                    className={`w-full flex flex-col gap-9 transition-all duration-1000 ease-out delay-300 ${
+                      visibleSections.has(index)
+                        ? 'opacity-100 translate-y-0'
+                        : 'opacity-0 translate-y-8'
+                    }`}
+                  >
+                    <div className='flex flex-col'>
+                      <h2 className='text-3xl font-normal text-pretty'>
+                        <HTMLRenderer html={section.title} />
+                      </h2>
+                      <p className='text-gray-600 leading-relaxed text-pretty'>
+                        {section.description}
+                      </p>
+                    </div>
+                    <IconButton
+                      to={
+                        section.buttonLinkFromLatestMessage
+                          ? (latestMessageUrl ?? section.buttonLink)
+                          : section.buttonLink
+                      }
+                      className='rounded-[400px] hover:text-ocean!'
+                      withRotatingArrow
+                      iconClasses='!bg-navy'
+                    >
+                      {section.buttonTitle}
+                    </IconButton>
+                  </div>
+                </div>
+              </section>
             ))}
           </div>
         </div>
-      </div>
-
-      {/* Scrollable Content Sections */}
-      <div className='md:ml-[50%] relative z-10 max-w-[716px] ml-auto'>
-        {chanceContent.map((section, index) => (
-          <section
-            key={section.title}
-            ref={(el) => {
-              sectionRefs.current[index] = el;
-            }}
-            className={cn(
-              'relative flex items-center p-12 min-h-screen w-full',
-              index === 2 && 'pb-24 md:pb-0', // Add padding to the last section on mobile to prevent content from grayed out from gradient
-            )}
-            data-card-index={index}
-          >
-            <div className='flex flex-col justify-center items-center gap-12 max-w-2xl mx-auto w-full'>
-              {/* Mobile Image */}
-              <img
-                src={section.image}
-                alt=''
-                width={section.imageWidth}
-                height={section.imageHeight}
-                className='md:hidden w-full max-w-sm'
-              />
-              <div
-                className={`w-full flex flex-col gap-9 transition-all duration-1000 ease-out delay-300 ${
-                  visibleSections.has(index)
-                    ? 'opacity-100 translate-y-0'
-                    : 'opacity-0 translate-y-8'
-                }`}
-              >
-                <div className='flex flex-col'>
-                  <h2 className='text-3xl font-normal text-pretty'>
-                    <HTMLRenderer html={section.title} />
-                  </h2>
-                  <p className='text-gray-600 leading-relaxed text-pretty'>
-                    {section.description}
-                  </p>
-                </div>
-                <IconButton
-                  to={
-                    section.buttonLinkFromLatestMessage
-                      ? (latestMessageUrl ?? section.buttonLink)
-                      : section.buttonLink
-                  }
-                  className='rounded-[400px] hover:text-ocean!'
-                  withRotatingArrow
-                  iconClasses='!bg-navy'
-                >
-                  {section.buttonTitle}
-                </IconButton>
-              </div>
-            </div>
-          </section>
-        ))}
       </div>
 
       <div className='absolute bottom-0 left-0 w-screen h-32 md:h-1/8 bg-linear-to-t from-white to-transparent z-30' />

--- a/app/routes/home/components/image-scroll-layout.tsx
+++ b/app/routes/home/components/image-scroll-layout.tsx
@@ -84,7 +84,7 @@ export function ImageScrollLayout() {
   }, []);
 
   return (
-    <div className='relative pt-32 md:pt-0'>
+    <div className='relative'>
       <div className='fixed top-0 left-0 w-screen h-48 md:h-64 bg-linear-to-b from-white via-white to-transparent z-5 pointer-events-none' />
 
       <div className='flex flex-col md:flex-row'>
@@ -123,8 +123,7 @@ export function ImageScrollLayout() {
                 }}
                 className={cn(
                   'relative flex items-center p-12 min-h-screen w-full',
-                  index === 2 &&
-                    'pb-24 md:pb-0', // Add padding to the last section on mobile to prevent content from grayed out from gradient
+                  index === 2 && 'pb-24 md:pb-0', // Add padding to the last section on mobile to prevent content from grayed out from gradient
                 )}
                 data-card-index={index}
               >
@@ -171,8 +170,6 @@ export function ImageScrollLayout() {
           </div>
         </div>
       </div>
-
-      <div className='absolute bottom-0 left-0 w-screen h-32 md:h-1/8 bg-linear-to-t from-white to-transparent z-30' />
     </div>
   );
 }

--- a/app/routes/home/components/location-search/location-search-inner.component.tsx
+++ b/app/routes/home/components/location-search/location-search-inner.component.tsx
@@ -132,7 +132,7 @@ export function LocationSearchInner({
           className={cn(
             'relative w-full md:w-90 z-50 rounded-2xl transition-all duration-300',
             {
-              'bg-white p-4 shadow-md sm:w-[450px] md:w-[620px] lg:w-[430px] lg:-translate-y-30 shorter:-translate-y-70':
+              'bg-white p-4 shadow-md sm:w-[450px] md:w-[620px] lg:w-[430px] lg:-translate-y-30 short-desktop:-translate-y-70':
                 isSearching,
               'bg-transparent': !isSearching,
             },

--- a/app/routes/home/partials/a-chance.partial.tsx
+++ b/app/routes/home/partials/a-chance.partial.tsx
@@ -10,9 +10,9 @@ export function AChanceSection() {
           'relative z-20',
           // Sticks while scrolling this section + ImageScrollLayout; scrolls away with them after the block ends (unlike fixed).
           'sticky top-0',
-          'min-h-64 sm:min-h-72 md:min-h-64',
-          'w-screen text-2xl md:text-[40px] font-extrabold text-center text-pretty',
-          'pt-20 lg:pt-24',
+          'min-h-64 sm:min-h-72 md:min-h-64 short-desktop:min-h-48',
+          'w-screen text-2xl md:text-[40px] short-desktop:text-[32px] font-extrabold text-center text-pretty',
+          'pt-20 lg:pt-24 short-desktop:pt-12 short-desktop:lg:pt-16',
           'px-10 md:px-12',
           'md:w-full',
         )}
@@ -20,7 +20,7 @@ export function AChanceSection() {
         <div
           className={cn(
             'absolute left-0 right-0 top-0 bg-linear-to-b from-white via-white to-transparent z-5',
-            'h-64 sm:h-72 md:h-64',
+            'h-64 sm:h-72 md:h-64 short-desktop:h-48',
             'w-screen',
           )}
         />

--- a/app/routes/home/partials/a-chance.partial.tsx
+++ b/app/routes/home/partials/a-chance.partial.tsx
@@ -7,8 +7,11 @@ export function AChanceSection() {
       <h2
         id='a-chance-title'
         className={cn(
+          'relative z-20',
+          // Sticks while scrolling this section + ImageScrollLayout; scrolls away with them after the block ends (unlike fixed).
+          'sticky top-0',
+          'min-h-64 sm:min-h-72 md:min-h-64',
           'w-screen text-2xl md:text-[40px] font-extrabold text-center text-pretty',
-          'fixed top-0 z-20',
           'pt-20 lg:pt-24',
           'px-10 md:px-12',
           'md:w-full',
@@ -17,7 +20,7 @@ export function AChanceSection() {
         <div
           className={cn(
             'absolute left-0 right-0 top-0 bg-linear-to-b from-white via-white to-transparent z-5',
-            'h-64 sm:h-72 md:h-64 lg:h-96',
+            'h-64 sm:h-72 md:h-64',
             'w-screen',
           )}
         />

--- a/app/styles/tailwind.css
+++ b/app/styles/tailwind.css
@@ -2,8 +2,8 @@
 @import 'tw-animate-css';
 @config "../../tailwind.config.ts";
 
-/* ------------ Custom Variant for shorter viewport ------------ */
-@custom-variant shorter (@media (min-width: 1024px) and (max-height: 900px));
+/* Desktop (lg+) with limited vertical space — e.g. laptop 1024×800 */
+@custom-variant short-desktop (@media (min-width: 1024px) and (max-height: 800px));
 
 /* ------------ Custom Utilities ------------ */
 @utility scrollbar-hide {


### PR DESCRIPTION
## Summary

This branch refines the home page “A Chance” experience and how it behaves on medium and large screens.

The left column image no longer uses a full-viewport `fixed` panel (which could fight the navbar and layout). It now lives in a two-column flex layout with **`sticky top-0`** so the image stays visible while the story sections scroll, then **scrolls away naturally** after the block ends. The outer wrapper uses a **max-width container** so the section does not stretch awkwardly on very wide viewports.

The section title (`AChanceSection`) moves from **`fixed`** to **`sticky`**, so it stays pinned with this scroll region and **releases with the content** instead of overlapping unrelated page content below.

Tailwind’s custom variant was renamed from **`shorter`** to **`short-desktop`** and tightened to **`max-height: 800px`** at `lg+` (was 900px), with matching utility classes for tighter padding, image size, and typography on short laptop-style viewports. The bottom fade gradient on `ImageScrollLayout` was removed; the top fade was adjusted for the new structure and short-desktop.

`LocationSearchInner` was updated to use the renamed variant for the searching-state vertical offset.

## Screenshots

<img width="1306" height="898" alt="image" src="https://github.com/user-attachments/assets/552922dd-18df-4c62-81e2-d6b4a5fee016" />

## Testing

- [x] Manually scrolled the home page through the full “A Chance” / image-scroll block on **md+** and confirmed the left image sticks then scrolls off with the section.
- [x] Tested A Chance section on shorter desktop displays(800px<), and made sure the image/content fit properly and gradient does not cover content that's in view.
- [x] Ran `pnpm lint` — no new errors (warnings noted if any).

## Tickets

[CFDP-3966](https://christfellowshipchurch.atlassian.net/browse/CFDP-3966)

## Changes Made

### Route Implementation

- `app/routes/home/components/image-scroll-layout.tsx` — Flex row layout, sticky image column, max-width shell, `short-desktop` spacing/sizing, removed bottom gradient, removed prior `pt-32 md:pt-0` wrapper padding.
- `app/routes/home/partials/a-chance.partial.tsx` — Title: `fixed` → `sticky`, responsive min-heights and `short-desktop` title/spacing; gradient height aligned with short-desktop.
- `app/routes/home/components/location-search/location-search-inner.component.tsx` — `shorter:` → `short-desktop:` for search panel translate.

### Key Features

- **Sticky image storytelling** on desktop: image follows the scroll narrative without permanent viewport fixation.
- **Sticky section title** that is scoped to the section’s scroll context instead of global `fixed` behavior.
- **`short-desktop` variant** (lg+ and max-height 800px) for denser layouts on short laptop screens, with clearer naming than `shorter`.

[CFDP-3966]: https://christfellowshipchurch.atlassian.net/browse/CFDP-3966?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ