### PR TITLE
Add Privacy Policy and Terms of Use pages

### DIFF
--- a/app/components/legal/legal-html-document.component.tsx
+++ b/app/components/legal/legal-html-document.component.tsx
@@ -1,4 +1,6 @@
-import { sanitizeCmsHtml } from '~/lib/sanitize';
+import HTMLRenderer from '~/primitives/html-renderer';
+
+import './legal-html-document.styles.css';
 
 interface LegalHtmlDocumentProps {
   title: string;
@@ -8,14 +10,19 @@ interface LegalHtmlDocumentProps {
 export function LegalHtmlDocument({ title, html }: LegalHtmlDocumentProps) {
   return (
     <main className='flex flex-col min-h-screen bg-white'>
-      <div className='mx-auto w-full max-w-4xl px-6 py-16 md:px-10 md:py-24'>
-        <h1 className='mb-10 text-4xl font-bold tracking-tight text-gray-900 md:text-5xl'>
-          {title}
-        </h1>
-        <div
-          className='prose prose-neutral max-w-none text-base leading-relaxed text-gray-700'
-          dangerouslySetInnerHTML={{ __html: sanitizeCmsHtml(html) }}
-        />
+      {/* Page header banner */}
+      <div className='bg-dark-navy'>
+        <div className='mx-auto w-full max-w-4xl px-6 py-16 md:px-10 md:py-24'>
+          <p className='mb-3 text-sm font-semibold uppercase tracking-widest text-ocean'>
+            Christ Fellowship
+          </p>
+          <h1 className='heading-h2 text-white'>{title}</h1>
+        </div>
+      </div>
+
+      {/* Content — HTMLRenderer sanitizes; typography in legal-html-document.styles.css */}
+      <div className='mx-auto w-full max-w-4xl px-6 py-14 md:px-10 md:py-20'>
+        <HTMLRenderer html={html} className='legal-html-document' />
       </div>
     </main>
   );

--- a/app/components/legal/legal-html-document.component.tsx
+++ b/app/components/legal/legal-html-document.component.tsx
@@ -1,0 +1,22 @@
+import { sanitizeCmsHtml } from '~/lib/sanitize';
+
+interface LegalHtmlDocumentProps {
+  title: string;
+  html: string;
+}
+
+export function LegalHtmlDocument({ title, html }: LegalHtmlDocumentProps) {
+  return (
+    <main className='flex flex-col min-h-screen bg-white'>
+      <div className='mx-auto w-full max-w-4xl px-6 py-16 md:px-10 md:py-24'>
+        <h1 className='mb-10 text-4xl font-bold tracking-tight text-gray-900 md:text-5xl'>
+          {title}
+        </h1>
+        <div
+          className='prose prose-neutral max-w-none text-base leading-relaxed text-gray-700'
+          dangerouslySetInnerHTML={{ __html: sanitizeCmsHtml(html) }}
+        />
+      </div>
+    </main>
+  );
+}

--- a/app/components/legal/legal-html-document.styles.css
+++ b/app/components/legal/legal-html-document.styles.css
@@ -1,0 +1,66 @@
+/* Legal pages (privacy / terms): CMS HTML via HTMLRenderer — explicit weights
+   so <b>/<strong> read bolder than body copy (Tailwind arbitrary variants only
+   set color on b/strong, which is not enough). */
+
+.legal-html-document {
+  font-size: 1rem;
+  line-height: 1.625;
+  color: var(--color-text-secondary);
+}
+
+.legal-html-document h3 {
+  margin-top: 2.5rem;
+  margin-bottom: 1rem;
+  padding-left: 1rem;
+  border-left: 4px solid var(--color-ocean);
+  color: var(--color-dark-navy);
+  font-weight: 800;
+  font-size: 28px;
+  line-height: 1.4;
+}
+
+@media (min-width: 1024px) {
+  .legal-html-document h3 {
+    font-size: 1.5rem;
+    line-height: 1.3;
+  }
+}
+
+.legal-html-document p {
+  margin-bottom: 1.5rem;
+}
+
+.legal-html-document div {
+  margin-bottom: 1rem;
+}
+
+/* CMS uses <br> between blocks; spacing comes from margins */
+.legal-html-document br {
+  display: none;
+}
+
+.legal-html-document b,
+.legal-html-document strong {
+  font-weight: 700;
+  color: var(--color-text-primary);
+}
+
+.legal-html-document a {
+  color: var(--color-ocean);
+  text-underline-offset: 2px;
+}
+
+.legal-html-document a:hover {
+  text-decoration: underline;
+}
+
+.legal-html-document ul {
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+  padding-left: 1.5rem;
+  list-style-type: disc;
+}
+
+.legal-html-document li {
+  margin-bottom: 0.25rem;
+}

--- a/app/lib/legal/privacy-policy-and-terms.data.ts
+++ b/app/lib/legal/privacy-policy-and-terms.data.ts
@@ -1,0 +1,1061 @@
+export const privacyPolicy = `<p>
+  As noted in the policy below, the English version of the Privacy Policy and
+  Terms of Use will govern your relationship with Christ Fellowship. You can
+  also view the documents in your language using an automatic translation tool
+  like Google Translate.
+</p>
+<br />
+<h3>Introduction to Our Privacy Policy</h3>
+<p>
+  There are many different ways you can interact online with Christ Fellowship
+  Church, Inc. and our affiliated legal entities ("Christ Fellowship", "we",
+  "us" or "our"), like watching or reading content, being generous through
+  giving, connecting with other people, or taking your next step. We appreciate
+  your interest in our church and respect your privacy as you interact with us
+  online or on our Mobile App.
+</p>
+<br />
+<p>
+  This Privacy Policy describes how we may treat your information that we have
+  gathered from our websites and applications offered by Christ Fellowship,
+  including but not limited to: https://www.christfellowship.church/,
+  https://cf.church/, gochristfellowship.com,
+  https://cf-church.square.site/home, rock.christfellowship.church;
+  (collectively, our "Websites"), and the services and tools related to the
+  Websites (including, but not limited to, mobile and other software
+  applications downloaded from the Websites or obtained elsewhere)
+  (collectively, the "Services").
+</p>
+<br />
+<p>
+  Please read this Privacy Policy carefully. We did our best to keep the
+  document simple, but if you have any questions regarding this Privacy Policy
+  or the use of your data, please contact our Data Privacy Team at Christ
+  Fellowship Church.Inc., Attn.: Data Privacy, 5343 Northlake Blvd, Palm Beach
+  Gardens, FL 33418 or at data.privacy@Christfellowship.church.
+</p>
+<br />
+<p>
+  By accessing or using any of our Christ Fellowship sites, you agree to this
+  Privacy Policy and our Terms of Use.
+</p>
+<br />
+<p>
+  NOTICE REGARDING DISPUTE RESOLUTION: In keeping with 1 Corinthians 6:1-8, all
+  disputes or claims arising under this Privacy Policy, or relating in any way
+  to your use of the Websites, Mobile App, or Services, will be resolved by
+  mediation, and, if not resolved by mediation, then by final and binding
+  arbitration as provided for in Section 9 of our Terms of Use. Unless you
+  opt-out, you will only be able to pursue claims against Christ Fellowship
+  Church, Inc. on an inpidual basis, not as part of any class or representative
+  action or proceeding, and you will only be permitted to seek relief (including
+  monetary, injunctive, and declaratory relief) on an inpidual basis.
+</p>
+<br />
+<h3>Application of Our Privacy Policy</h3>
+<p>
+  This Privacy Policy applies only to information collected by the Websites,
+  Mobile Apps or Services. It does not apply to information either collected by
+  us offline or collected by unaffiliated Websites, Mobile Apps, or Services.
+  Furthermore, this Privacy Policy governs only information provided to and
+  communicated from the Websites, Mobile App, or Services directly and does not
+  govern any other information or communications that may reference this
+  Website, the Services, or Christ Fellowship.
+</p>
+<br />
+<p>
+  If you click "like" or make a comment on or about Christ Fellowship sites
+  using Facebook, Instagram, Twitter, Pinterest, or other social media plugins,
+  your activity may be published on Facebook, Instagram, Twitter, Pinterest, or
+  other social media website(s), and be shown to other inpiduals who visit our
+  Websites. We encourage you to read each social media site's respective privacy
+  policy for more information.
+</p>
+<br />
+<h3>Information We Collect About You and How We Collect It</h3>
+<p>
+  Below is an overview of the personal information collected on the Christ
+  Fellowship Websites, Mobile apps, and services and the purpose of our
+  collection. Please note: The processing of your information depends on the
+  information you choose to provide and the functionality of our services you
+  choose to use. A more detailed description of our processing of your
+  information is available below.
+</p>
+<br />
+<p>
+  Personal Identifiers (name, aliases, Internet Protocol address, email address,
+  phone number, address, and similar identifiers): Collected to the extent you
+  provide it to us to create an account or for association with your account to
+  ensure proper use and authentication for your account. Your personal
+  information is also used to contact you in connection with your requests and
+  account, as discussed in our Privacy Policy.
+</p>
+<br />
+<p>
+  No mobile information will be shared with third parties or affiliates for
+  marketing or promotional purposes. All the above categories exclude text
+  messaging originator opt-in data and consent; this information will not be
+  shared with any third parties.
+</p>
+<p>
+  Messages from us may incur carrier messaging and data charges. Please reply
+  HELP to get assistance or STOP or REMOVE to unsubscribe.
+</p>
+<br />
+<p>
+  Government-Issued Identifications (Social Security numbers, driver's license
+  number, passport numbers, and similar information): Collected and processed to
+  the extent you provide an employment application or to volunteer to do a
+  background check and otherwise process your application.
+</p>
+<br />
+<p>
+  Financial information (credit card information, banking information, and
+  similar information): Collected to the extent you provide a donation to or
+  purchase merchandise from us in person. Otherwise, financial information
+  provided to us online is processed by third-party service providers, as
+  discussed in our Privacy Policy.
+</p>
+<br />
+<p>
+  Internet or other network activity (browsing history, search history,
+  information on your interaction with our websites, apps, and other services):
+  Collected as you use our sites and services to monitor and ensure the proper
+  operation of our websites, apps, and services; to improve and customize your
+  experience with regard to the same; to improve, modify, and update our
+  services and content generally, and to analyze the same internally; and
+  provide de-identified statistical information to third parties.
+</p>
+<br />
+<p>
+  Geolocation data (physical location or movements): Collected if you choose to
+  use the location-based functionality of our services; however, this
+  information is maintained only on your device and is not stored by Christ
+  Fellowship Church.
+</p>
+<br />
+<p>
+  Professional or employment-related information or non-public educational
+  information: Collected and processed only to the extent you provide an
+  application for employment or volunteer opportunity to do a background check
+  and otherwise process your application.
+</p>
+<br />
+<p>
+  Sensitive Information (religious information, national origin, sexual
+  orientation, race, marital status, health-related information, genetic
+  information, and similar sensitive data): Your use of our Websites, Mobile
+  apps, and services does not reflect any specific sensitive information, and we
+  do not require that you provide us with the same to use our services. To the
+  extent you choose to provide sensitive information to us through your use of
+  our services, we will process it only with your consent.
+</p>
+<br />
+<p>
+  Commercial Information (records concerning your personal property, products or
+  services purchased, obtained, or considered, or other purchasing or consuming
+  histories or tendencies): Collected and processed only for purposes of
+  donations and to the extent you provide a donation to or purchase merchandise
+  from us.
+</p>
+<br />
+<p>
+  Inferences we make about our users based on data available to us. Collected as
+  you use our Websites, Mobile apps, and services to improve and customize your
+  experience with regard to our services and to suggest additional functionality
+  and services.
+</p>
+<br />
+<h3>How We Use Your Information</h3>
+<p>
+  We collect personal data when you provide it, both offline and online. You do
+  not need to provide personal information to use Christ Fellowship websites and
+  services. You can create a profile, which allows us to tailor our sites and
+  services to be a more personalized experience. To create a profile, we require
+  your first and last name, email address, phone number, and password to
+  authenticate you when accessing your profile. Beyond the personal information
+  needed to create a profile, you have choices about what additional information
+  you provide to us, which may include your zip code, the names of family
+  members, gender, and marital status, all of which will be stored in
+  association with your profile. Certain information may be required based on
+  your specific request, such as your social security number for employment
+  inquiries and volunteer requests; we will notify you of this at the time of
+  such a request.
+</p>
+<br />
+<p>
+  We also collect information about you when you send, receive, or engage in
+  communications with us, including when you submit personal information or
+  requests by emailing hello@christfellowship.church. We retain those
+  communications to process your inquiries, respond to requests, and improve our
+  sites and services.
+</p>
+<br />
+<p>
+  When you interact with us, the information you provide us is generally stored
+  internally in our third-party relationship management system, or "CRM system."
+  We will use this information to authenticate you and allow you to access your
+  specific profile, when available. We also create user profiles for offline
+  purposes, including volunteerism and inquiries concerning employment. We may
+  combine the information you provide us for your profile and interactions with
+  our websites and mobile apps with the information you provide us through other
+  Christ Fellowship sites, services, and products and inferences we make from
+  the same for our internal development to improve the overall quality of our
+  sites, services, and products. We may also recommend other Christ Fellowship
+  services based on the information you provide, and we infer.
+</p>
+<br />
+<h3>Your Posts</h3>
+<p>
+  Our Christ Fellowship Websites, Mobile apps, and services have a wide array of
+  functionality, including streaming video, creating prayer requests, and
+  identifying and communicating with your Christ Fellowship groups and teams.
+  Some Christ Fellowship Websites, Mobile apps, and services may allow you to
+  publish, distribute, and display content to specific inpiduals or the public.
+  We will refer to how you provide content and information as "posted" and the
+  content and information posted as "user contributions." User contributions may
+  be made on public areas of websites and social media accounts you access
+  through our sites or may otherwise be transmitted to third parties. Your user
+  contributions are processed by us to facilitate your ability to create, use,
+  store, and distribute user contributions as you choose. We will associate your
+  user contributions with your account if you opt not to delete them.
+</p>
+<br />
+<p>
+  If you disclose personal information, whether through collaborative postings,
+  social media, message boards, or otherwise, this information may be collected
+  and used by others. User contributions are posted and transmitted at your own
+  risk. We cannot control the actions of other users or third parties with whom
+  you choose to share your user contributions. Therefore, we cannot and do not
+  guarantee that unauthorized persons will not view your user contributions, nor
+  do we accept any liability associated with your user contributions.
+</p>
+<br />
+<h3>Giving</h3>
+<p>
+  If you choose to provide a donation through one of the Christ Fellowship
+  Websites, Mobile apps, and services, then and only then will you be prompted
+  and required to provide a credit card, bank account, and other financial
+  information necessary to process the transaction. We will collect the
+  designation for your donation if you provide one and personal information such
+  as your name, address, phone number, and/or email address to ensure that your
+  donation is used for the purpose you request and to provide you with an annual
+  giving statement that itemizes your donation(s). We will also contact you
+  periodically to inquire if you would like to give to another program,
+  location, or cause. We may contact you through push notifications, SMS, email,
+  mail, or in-app messages to share these opportunities.
+</p>
+<br />
+<p>
+  This information, excluding your financial information, is stored in our CRM
+  system. As of the date of this Policy, we use PushPay to process your online
+  donation payments. For information on how third parties process your
+  information, please refer to their privacy policies found here:
+  https://pushpay.com/legal-center/privacy/
+</p>
+<br />
+<p>
+  For donations you provide to us in person or by mail, we store your financial
+  information in our databases in an encrypted form for as long as necessary to
+  process your donation and as required by applicable law and GAAP accounting
+  principles.
+</p>
+<br />
+<h3>Christ Fellowship Merchandise</h3>
+<p>
+  For Christ Fellowship sites where you can purchase Christ Fellowship-branded
+  clothing and other items, including our cafe locations, your personal and
+  financial information is provided and shared with our third-party contractors,
+  who will process your order. The third parties are identified at the time of
+  your purchase. For details on how those companies use, store, maintain, and
+  disclose your information, please refer to their respective privacy policies
+  or contact them directly.
+</p>
+<br />
+<h3>Volunteers and Employment Inquiries</h3>
+<p>
+  You may apply to volunteer for miscellaneous activities and events in person
+  at a Christ Fellowship location or through one or more of our sites. You may
+  also apply for employment in person and through our sites.
+</p>
+<br />
+<p>
+  The information we require for volunteer and employment applications are your
+  first and last name, telephone number, address, social security number, date
+  of birth, and your employment history in the case of a job inquiry. We will
+  store and use this information to process your application and associate it
+  with your profile if one exists. We will use your social security number and
+  date of birth solely for a background check regarding your application to be a
+  volunteer and/or employee. We will not share either with any third party
+  except for third-party service providers that enable us to perform background
+  checks. We are obligated not to share or use your information for any other
+  purpose. If you become an employee of Christ Fellowship Church, your personal
+  information is also used in connection with your employment.
+</p>
+<br />
+<p>
+  As a volunteer, you may have access to third-party software that allows you to
+  schedule and check in to your volunteer activity and manage other volunteer
+  activities. This location-based information is stored in association with your
+  profile to enable you to see your past volunteerism, and we also use it for
+  our internal analysis.
+</p>
+<br />
+<h3>Automatic Data Collection Technologies</h3>
+<p>
+  By agreeing to our Privacy Policy, you agree to the use of cookies and similar
+  technologies as described in this policy. Examples include: web beacons,
+  pixels, tags, and device identifiers called "cookies." If you use Christ
+  Fellowship Websites, Mobile apps, and services without changing your browser
+  or device settings to disable cookies, we assume you consent to receive all
+  cookies provided through Christ Fellowship Websites, Mobile apps, and services
+  sites.
+</p>
+<br />
+<p>
+  We use cookies to recognize you and/or your device(s) on, off, and across the
+  different applications of our sites and devices. Cookies help to facilitate
+  the best possible user experience for our sites as they allow us to recognize
+  you and maintain your user preferences from session to session, keep your
+  account safe, and improve the functionality of the products and services
+  offered through Christ Fellowship Websites, Mobile apps, and services. They
+  also help ensure that profile information is associated with the correct
+  profile. We do not use cookies to facilitate interest-based ads from third
+  parties for third-party goods or services.
+</p>
+<br />
+<p>
+  We log usage data when you use Christ Fellowship Websites, Mobile apps, and
+  services, including when you view or click on content, browser type, browser
+  language, perform a search or request, the date and time of your request,
+  install an update, seek new functionality, or use one or more tools offered
+  through our sites. We use cookies to identify you and log your use. When you
+  access or leave our sites, we receive the URL of both the site you came from
+  and the one you go to next. We also get information about your IP address,
+  proxy server, operating system, web browser and add-ons, device identifier and
+  features, and/or ISP or your mobile carrier. Using our sites from a mobile
+  device will send us data about your location based on your phone settings and
+  access you have granted the Christ Fellowship Websites, Mobile apps, and
+  services, as discussed below.
+</p>
+<br />
+<p>
+  We store this information and information about your use of our sites in
+  connection with your profile. We do not share your personally identifiable
+  information, device identification, or location without your explicit
+  permission. We advertise on third-party sites such as Facebook and Google and
+  use third-party software development kits ("SDKs") to attribute a download of
+  a Christ Fellowship application on to the advertisement placed on the
+  third-party site. We do not sell your personal information to any third
+  parties, allow our SDK service providers to sell your personal information to
+  third parties, or use your personal information to solicit the sale of
+  third-party goods or services. We may provide these third parties with
+  aggregate de-identified information concerning ads placed on their sites and
+  downloads that result from those ads.
+</p>
+<br />
+<p>
+  We use this information to provide a more tailored Christ Fellowship site
+  experience and communicate with you more effectively. The information is also
+  collected to determine the aggregate number of unique devices using our sites,
+  track total usage, and analyze usage data to provide you with a better
+  experience and improve the quality of our services. We may combine this
+  information with other information to give you a better experience and improve
+  the quality of our service. If you do not want us to collect this information,
+  you should cease use of our sites.
+</p>
+<br />
+<p>
+  We generally maintain the data we collect from cookies for 21 days but may
+  save it for longer when necessary, such as when required by law or for
+  technical reasons. Although most internet browsers accept cookies by default,
+  you can control cookies through your browser settings and similar tools or
+  agree to refuse all cookies altogether. If you refuse to accept cookies, you
+  may prohibit Christ Fellowship from delivering the full capability of our
+  sites, and you may prevent the use of certain features and services that
+  require these technologies.
+</p>
+<br />
+<p>
+  We cannot regulate other sites, content, or applications of third parties.
+  They may place their cookies or other files on your computer, collect data, or
+  solicit personal information from you. They may use this information to
+  provide you with interest-based, targeted content. We do not control these
+  third parties' tracking technologies or how they may be used. Contact the
+  responsible provider directly if you have any questions about targeted
+  content.
+</p>
+<br />
+<h3>WiFi and GPS</h3>
+<p>
+  Some of our sites use GPS or wireless ("WiFi") information to identify when
+  you are near one of our physical locations. You can provide consent for us to
+  use this information when you first download or begin to use our sites. If you
+  provide consent, we use the information to enable push notifications related
+  to interactions with our Christ Fellowship sites and physical locations.
+</p>
+<br />
+<p>
+  You also can manually initiate a location search to identify whether you are
+  at one of our physical locations. When using specific Christ Fellowship sites,
+  you can provide us with your location through your browser, zip code, or city,
+  which a third-party search engine will process. We do not store GPS and WiFi
+  information outside of your device. Once your particular session of use of the
+  feature ends, we will cease access to your GPS and WiFi location unless you
+  use the feature again.
+</p>
+<br />
+<p>
+  After your first use of this functionality and consent for us to use your GPS
+  or WiFi location, we will assume we have consent unless you revoke it through
+  your mobile device's settings.
+</p>
+<br />
+<h3>Christ Fellowship Church Content</h3>
+<p>
+  We collect how you use the content available through our sites and the
+  language you choose to utilize that content. We process this information to
+  allow you to access and use content through each session of your use of our
+  sites. You can choose whether to download certain Christ Fellowship content to
+  your device. You will have the option to allow Christ Fellowship access to
+  your device's storage to add and modify this downloaded content. Access to the
+  storage of your device is only used by Christ Fellowship for downloading this
+  requested content to your device.
+</p>
+<br />
+<p>
+  It is your choice whether to create, access, or store Christ Fellowship
+  information and content. If you do, we will store it in association with your
+  profile. We may use information about your use of Christ Fellowship and the
+  inferences we make from that use to provide recommendations to you of other
+  Christ Fellowship content. You may opt out of receiving these recommendations
+  by email, as discussed below.
+</p>
+<br />
+<h3>Communication From Us to You</h3>
+<p>
+  We communicate with you through push notification, SMS/Text messages, phone,
+  email, or in-app messages. If we communicate to you through email, you may
+  unsubscribe to these messages via the unsubscribe and or manage preferences
+  link in the emails providing these messages. You can update your push
+  notification settings at any time within the settings menu of the Christ
+  Fellowship App.
+</p>
+<br />
+<p>
+  By subscribing, you have provided Christ Fellowship with consent to send you
+  emails and or SMS/text messages. We may text you about things like events, new
+  content, and requests for volunteer or donation support. The frequency of
+  these messages may vary, and message and data rates may apply. Some of the
+  text messages we send may include links to websites, which will require a web
+  browser and internet access. You may text STOP or REMOVE to opt out or HELP
+  for help at any time to any SMS or MMS message you receive from us or email us
+  at data.privacy@Christfellowship.church. Certain carriers may not be liable
+  for delayed or undeliverable messages.
+</p>
+<br />
+<h3>Recommendations and General Information</h3>
+<p>
+  We use the data about you and inferences we make from that data to recommend
+  certain content and functionality as well as additional products and services
+  offered by Christ Fellowship.
+</p>
+<br />
+<p>
+  We may combine the information you provide with information we collect and the
+  inferences we make for our internal development to improve the overall quality
+  of all services and products provided by Christ Fellowship.
+</p>
+<p>
+  We may make recommendations to you for other Christ Fellowship services and
+  products based on the information you provide, and we infer.
+</p>
+<p>
+  We may also use the data we have about you and inferences we make from that
+  data to contact you regarding other opportunities to engage with Christ
+  Fellowship.
+</p>
+<br />
+<p>
+  We may contact you through push notification, SMS/Text message, phone, email,
+  mail, or in-app messages to discuss these recommendations and opportunities,
+  how to use our sites, and other news.
+</p>
+<br />
+<h3>Security, Legal, and Technical Issues</h3>
+<p>
+  We may use your information to contact you about account security, legal, and
+  other service-related issues. Please be aware that you cannot opt out of
+  receiving such messages from us. We may use your personal information to
+  investigate, respond to, and resolve legal, security, and technical issues and
+  complaints, including, as necessary, security purposes or possible fraud,
+  violations of law or our Terms of Use or this Privacy Policy, or attempts to
+  harm; however, you agree that we have no obligation to prevent or monitor for
+  any of the preceding.
+</p>
+<br />
+<h3>Notice</h3>
+<p>
+  We may use your personal information to provide notice regarding a security
+  incident or data breach by:
+</p>
+<ul>
+  <li>sending a message to the email address you provide, as applicable</li>
+  <li>
+    posting to a publicly facing page of Christ Fellowship sites or through an
+    in-app messages
+  </li>
+  <li>
+    sharing notices through major statewide media and/or telephonic means,
+    including calls and/or text messages, even if sent via automated means,
+    including automated dialers.
+  </li>
+</ul>
+<p>Standard text and data messaging rates may apply from your carrier.</p>
+<br />
+<p>
+  Notices sent by email will be effective when we send the email. Notices we
+  provide by posting will be effective upon posting and by in-app messaging when
+  the message is made. Notices we provide through telephonic means will be
+  effective when transmitted or dialed. You consent to receiving electronic
+  communications from Christ Fellowship relating to your use and access of the
+  services provided by Christ Fellowship. It is your responsibility to keep your
+  email address and any other contact information you provide to us current so
+  that we may provide these communications to you.
+</p>
+<br />
+<h3>Analytics and Performance</h3>
+<p>
+  We internally analyze the personal data available to us, the use of content
+  found on our sites, and the inferences we make from that data to provide and
+  update Christ Fellowship sites, communicate with you, and process information
+  as discussed in this Policy, and for internal analytics such as to observe
+  social, economic, and geographic trends as they pertain to Christ Fellowship
+  content.
+</p>
+<br />
+<p>
+  In some cases, we work with trusted third parties to perform this research
+  under controls that are designed to protect your privacy as outlined below.
+  For example, we may use your data to generate statistics about overall usage
+  of one of our sites worldwide, in specific geographic regions, or at specific
+  events or locations.
+</p>
+<br />
+<p>
+  We also use de-identified and aggregate user data to market our sites,
+  including communications that promote growth. Where we publicly share stats of
+  our growth, we analyze and publish the data in an aggregated form, protecting
+  your privacy and keeping your identity and personal information confidential.
+  We use data, including user-provided personal information, aggregations of
+  user data collected through the use of our sites, public feedback, and
+  information inferred from this data to conduct internal research and
+  development in order to provide a better overall experience on Christ
+  Fellowship sites, measure the performance of our sites and increase use of our
+  sites and their features. This is done by making changes to Christ Fellowship
+  sites that are generally available and by sending messages suggesting
+  functionality and content.
+</p>
+<br />
+<h3>Sensitive Data</h3>
+<p>
+  By using Christ Fellowship Church application and sites, we do not assume that
+  you are of any particular religious affiliation or are expressing to us any
+  particular religious belief. We assume you are interested in the content we
+  provide. We do not require users to provide information about such beliefs or
+  any other sensitive data such as race, ethnicity, philosophical beliefs, or
+  physical or mental health to use Christ Fellowship Church sites or create or
+  maintain a Christ Fellowship Church profile.
+</p>
+<br />
+<p>
+  Some features available through Christ Fellowship Church sites utilize
+  personal information that may reflect your religious or philosophical beliefs,
+  but you are not required to provide such information. In addition to these
+  features, you have control over the content of certain things you create,
+  share, and store through Christ Fellowship Church, and if you provide us with
+  sensitive information with any content you create, share, and store, we will
+  assume we have your consent to process that information.
+</p>
+<br />
+<p>
+  We will not sell your sensitive personal information, but we may need to share
+  it with third-party service providers that enable us to provide the Christ
+  Fellowship Church sites and/or certain app features and those service
+  providers are required to keep your personal information confidential and only
+  use it to provide us with their services. We will process the sensitive
+  information we collect and inferences we make about the same in accordance
+  with our Privacy Policy and for the purpose of allowing and facilitating your
+  use of those specific app features, to personalize your user experience,
+  suggest other content and services, and internally improve our services.
+</p>
+<br />
+<p>
+  If you choose to provide any sensitive information to us, we may use that
+  information with other non-sensitive information you provide to create a more
+  personalized Christ Fellowship Church experience for you and to perform the
+  services and actions you request, such as sharing or storing content you
+  create. In any event, Christ Fellowship Church will only process sensitive
+  data you provide to us for Christ Fellowship Church's legitimate activities on
+  your behalf and solely in accordance with the terms of this policy and any
+  additional requests you make about the information. We will also maintain your
+  information subject to appropriate safeguards discussed in this policy and
+  otherwise provided by Christ Fellowship Church.
+</p>
+<br />
+<p>
+  You have the right to withdraw your consent to our collection and processing
+  of your sensitive personal information by turning off and ceasing to use
+  Christ Fellowship Church features that use this information, or by contacting
+  us via mail at Christ Fellowship Church, Attn.: Data Privacy, 5343 Northlake
+  Blvd, Palm Beach Gardens, FL 33418 or at data.privacy@Christfellowship.church.
+  Withdrawing your consent may hinder our ability to provide certain
+  functionality.
+</p>
+<br />
+<h3>Disclosure of Your Information</h3>
+<p>
+  We do not sell or share your personal data with any third-party advertisers or
+  ad networks for their advertising purposes. We may disclose your personal
+  information to third parties to process information as described above and
+  otherwise enable our ability to provide Christ Fellowship Church, as further
+  discussed below.
+</p>
+<br />
+<h3>Disclosure on Your Behalf</h3>
+<p>
+  We may disclose personal information that we collect, or you provide as
+  described in this Privacy Policy to fulfill our obligations, the purpose for
+  which you provide it, a purpose you request when you provide the information,
+  or any other purpose for which we have your consent.
+</p>
+<br />
+<h3>Disclosure by You</h3>
+<p>
+  If and when you share information through our sites, it is viewable by you and
+  anyone else you choose to share it with. If you give access to your account to
+  other applications and services, based on your approval, those services would
+  have access to your shared information. The use, collection, and protection of
+  your data by such third-party services are subject to those third parties'
+  policies.
+</p>
+<br />
+<h3>Internal Disclosure</h3>
+<p>
+  We will share your personal data internally within Christ Fellowship Church
+  and its affiliates to help combine the personal information covered across the
+  different aspects of Christ Fellowship Church sites and our other products and
+  services to help provide services to you in a manner that is personalized and
+  useful to you and others. For example, we can personalize potential services
+  to recommend to you using cookies or similar technologies that track what
+  functionality you have already opted to receive.
+</p>
+<br />
+<h3>Service Providers</h3>
+<p>
+  We may disclose personal information that we collect or you provide as
+  described in this Privacy Policy to contractors, service providers, and other
+  third parties we use solely to support our sites (such as cloud hosting,
+  cookie providers maintenance, analysis, audit, external marketing, payments,
+  fraud detection, communication, and development), as well as to support our
+  operations (such as communicating with you for potential employment purposes).
+  We may combine the information we have with the information of these service
+  providers to facilitate their support. For example, some of the platforms used
+  to send emails and notifications provided through Christ Fellowship Church are
+  built and managed by third parties, so some of your information is sent
+  securely to those services to provide such functionality. They will have
+  access to your information as reasonably necessary to perform tasks on our
+  behalf and are obligated not to disclose it to others or use it for other
+  purposes. We may also provide aggregate, de-identified information concerning
+  the use of Christ Fellowship Church sites with third parties.
+</p>
+<br />
+<h3>Content Providers</h3>
+<p>
+  We utilize certain third parties to provide content on our sites. We do not
+  share the personal information of users with these third parties. We may
+  provide these third parties with aggregate analytics concerning the use of
+  their content using de-identified and anonymized data.
+</p>
+<br />
+<h3>Legal Process and Subpoena</h3>
+<p>
+  We may need to disclose information about you when required by law, subpoena,
+  or other legal process. We attempt to notify users about legal demands for
+  their personal data when appropriate in our judgment, unless prohibited by law
+  or court order or when the request is an emergency. We may dispute such
+  demands when we believe, in our discretion, that the requests are overbroad,
+  vague, or lack proper authority, but we do not promise to challenge every
+  demand. We may also need to disclose your information if we have a good faith
+  belief that disclosure is reasonably necessary to:
+</p>
+<br />
+<ul>
+  <li>
+    Investigate, prevent, or take action regarding suspected or actual illegal
+    activities or to assist government enforcement agencies;
+  </li>
+  <li>Enforce our agreements with you;</li>
+  <li>
+    Investigate and defend ourselves against any third-party claims or
+    allegations;
+  </li>
+  <li>Protect the security or integrity of our sites or</li>
+  <li>
+    Exercise or protect the rights and safety of Christ Fellowship Church, our
+    users, personnel, you, or others.
+  </li>
+</ul>
+<br />
+<p>
+  We also reserve the right to confidentially disclose personal information we
+  have about you in connection with a potential or actual merger or acquisition
+  such as the sale of all or substantially all our assets.
+</p>
+<br />
+<h3>Deleting, Accessing, and Correcting Your Information</h3>
+<br />
+<h3>How to Make Your Requests</h3>
+<p>For personal data that we have about you, you may request the following:</p>
+<br />
+<p>
+  <b>Deletion:</b> You may ask us to erase or delete all or some of your
+  personal data. Please note that doing so may limit your ability to use certain
+  functionality of Christ Fellowship Church sites. Please note that an email
+  address is required to have an account to ensure we can properly authenticate
+  potential users of that account.
+</p>
+<br />
+<p>
+  <b>Correction/Modification:</b> You may edit some of your personal data
+  through your account or ask us to change, update, or fix your data in certain
+  cases, including if it is inaccurate.
+</p>
+<br />
+<p>
+  <b>Object to, or Limit or Restrict, Use of Data:</b> You can ask us to stop
+  using all or some of your personal data or to limit our use of it.
+</p>
+<br />
+<p>
+  <b>Right to Access and/or Take Your Data: </b>You can ask us for a copy of or
+  disclosure concerning your personal data you provided to us.
+</p>
+<br />
+<p>
+  Certain laws may provide the right to make additional requests concerning your
+  personal information. If you have provided us with personal information and
+  wish to make such a request under a specific region's law, include the phrase
+  "[Your State/Country] Privacy Request" in the subject line of your request and
+  send your request via email to data.privacy@Christfellowship.church or via
+  mail to Christ Fellowship Church, attn.: Data Privacy, 5343 Northlake Blvd,
+  Palm Beach Gardens, FL 33418.
+</p>
+<br />
+<p>
+  We ask that inpiduals making requests identify themselves with at least their
+  name, mailing address, and email address and identify the information
+  requested to be accessed, corrected, or removed before we process the request.
+  We may seek additional information to verify a requestor's identity. We may
+  decline to process requests if we cannot verify the requestor's identity or if
+  we believe the request will jeopardize the privacy of others, violate any law
+  or legal requirement, cause the information to be incorrect, or for a similar
+  legitimate purpose.
+</p>
+<p>
+  We will not discriminate against you for exercising your rights under
+  applicable law. We do not charge a fee to process or respond to a verifiable
+  request concerning your personal information unless it is excessive, unduly
+  burdensome, repetitive, or manifestly unfounded. If we determine that the
+  request warrants a fee, we will tell you why we made that decision and provide
+  a cost estimate before completing your request.
+</p>
+<br />
+<h3>Deleting Your Account</h3>
+<p>
+  You can delete your Christ Fellowship Church account credentials at any time
+  using the settings function in the Christ Fellowship Church application. To
+  request deletion of all account data, you must follow the deletion request
+  instructions above; however, when you delete your account, we will delete the
+  information associated with your account, such as user contributions you have
+  created, received, or shared. If you do not want to delete your account or
+  this information but want to temporarily stop using a Christ Fellowship Church
+  site, you may cease use, and we will maintain your account and the information
+  associated with your account until you resume use or delete your account,
+  whichever comes first.
+</p>
+<br />
+<p>
+  We generally retain and process information and user contributions associated
+  with your account until your account is deleted. You can manage, change, and
+  delete certain information associated with your account using the Christ
+  Fellowship Church application. If you'd like us to delete your account and all
+  the information associated with your account, you may contact us via email to
+  data.privacy@Christfellowship.church or via mail to Christ Fellowship Church,
+  attn.: Data Privacy, 5343 Northlake Blvd, Palm Beach Gardens, FL 33418.
+</p>
+<br />
+<p>
+  If you choose to delete your account or ask that we modify or delete personal
+  information, we will delete and purge personal information we have stored
+  about you in a way that is electronically irreversible; however, we may retain
+  your personal data if we have a legal right or obligation to maintain the
+  information or to meet regulatory requirements, resolve disputes, maintain
+  security, prevent fraud and abuse, enforce our rights, or fulfill any other
+  requests from you (for example, to opt-out of further messages or for a copy
+  of your data). Otherwise, if you request that we delete your account, we will
+  delete your account and all the information we have that is associated with
+  your account, except for aggregated statistics based on de-identified
+  information and inferences we have made (for example, the fact that you
+  downloaded our application, without identifying you or maintaining personal
+  information associated with that account).
+</p>
+<br />
+<p>
+  Our deletion of your information and account will generally take up to 45 days
+  from your request; however, cached information may take up to 30 days to
+  delete. Please note that we have no control of the information you have shared
+  with others through our sites and applications after you close your account,
+  ask to delete information, or attempt to delete your account yourself. Your
+  information and content you have shared may continue to be displayed in the
+  services of others, including search engine results, until their cache
+  refreshes.
+</p>
+<br />
+<h3>Security and Protection</h3>
+<p>
+  We implement security safeguards designed to protect your data. These include
+  using encryption for your data while being transmitted between your device or
+  browser and our servers and while at rest. Data provided to us through our
+  sites is also stored in an ISO 27017-certified infrastructure management
+  system, meaning it has been audited and found in compliance with the
+  requirements of the management system standards ISO 27017, an internationally
+  recognized code of practice for information security controls for cloud
+  services. However, given the nature of communications and information
+  technology and that the use of the internet has inherent risks, although we
+  regularly monitor for possible vulnerabilities and attacks, we cannot warrant
+  or guarantee that information provided to us through our sites or stored in
+  our systems or otherwise will be free from unauthorized intrusion by others,
+  nor can we warrant or guarantee that such data may not be accessed, disclosed,
+  altered, or destroyed by breach of any of our physical, technical, or
+  managerial safeguards.
+</p>
+<br />
+<h3>Children</h3>
+<p>
+  We do not collect personal information from any person we know is under 13
+  without the consent of that minor's parent or legal guardian.
+</p>
+<br />
+<p>
+  A parent or guardian may consent to use our sites or services by a minor.
+  However, we ask that you discuss the risks of sharing personal information on
+  the Internet with your children and require that they refrain from
+  communicating with any third parties or sharing any personal information
+  online or otherwise without the supervision of a parent or guardian. Should
+  you allow your minor child to use our sites or services, you are solely
+  responsible for supervising the minor's use of the same and assume full
+  responsibility for the processing of any information provided to us by that
+  minor.
+</p>
+<br />
+<p>
+  Where you associate your minor child's information with your account, we will
+  assume you consent to our processing of that information in accordance with
+  this policy and other privacy notices and terms we may provide to you from
+  time to time. If you allow your minor child to use our sites, we ask that you
+  discuss the risks of sharing personal information on the Internet with your
+  children and require that they refrain from communicating with any third
+  parties or sharing any personal information with other users. If you believe
+  we might have any information from or about a child under 13, please contact
+  us at data.privacy@Christfellowship.church.
+</p>
+<br />
+<h3>Processing of Data</h3>
+<p>
+  We will only collect and process your personal data where we have lawful
+  bases. Lawful bases include consent where you have given it, contracts, and
+  other legitimate interests. Such legitimate interests include protection to
+  you, us, other users, and third parties, to comply with applicable law, to
+  enable and administer our internal processes, to manage corporate
+  transactions, to generally understand and improve our internal processes and
+  user experience, and to enable us and other users of our sites to connect with
+  you to exchange information, provided that the preceding adequately protects
+  your rights and freedoms. Where we rely on your consent to process personal
+  data, you have the right to withdraw or decline your consent at any time, and
+  where we rely on legitimate interests, you have the right to object. If you
+  have any questions about the lawful bases upon which we collect and use your
+  personal data, please contact us via email at
+  data.privacy@Christfellowship.church or via mail to Christ Fellowship Church,
+  attn.: Data Privacy, 5343 Northlake Blvd, Palm Beach Gardens, FL 33418.
+</p>
+<br />
+<h3>Third-Party Information Collection</h3>
+<p>
+  This Privacy Policy applies only to sites and apps owned and operated by
+  Christ Fellowship Church. Our sites may contain links to other websites or
+  apps. You are responsible for reviewing the privacy statements and policies of
+  those other websites you choose to link to or from one of our sites so that
+  you can understand how those websites collect, use, and store your
+  information. We are not responsible for the privacy statements, policies or
+  content of other websites or apps, including websites you link to or from a
+  Christ Fellowship Church site. Websites containing co-branding (referencing
+  our name and a third party's name) contain content delivered by the third
+  party, not us.
+</p>
+<br />
+<p>
+  If you link to other websites, applications, and services or profiles you have
+  with third-party applications, you will provide the personal data stored on
+  those applications to Christ Fellowship Church. For example, you may link your
+  Facebook account to your profile, providing personal information you have
+  opted to share through Facebook to Christ Fellowship Church. When you do so,
+  we are provided with your Facebook or other applicable social media username.
+  You may revoke the link with such accounts and third-party applications by
+  modifying your settings with those applications. As noted above, third-party
+  sites that link to or are associated with our sites may collect information
+  using automated technologies such as cookies. We have no control over such
+  collection and use, which are subject to the privacy policies of those third
+  parties.
+</p>
+<br />
+<h3>Users Outside the United States</h3>
+<p>
+  We are based in Florida within the United States, and the laws of the U.S. and
+  the State of Florida govern your use of our sites and this Privacy Policy. If
+  you are using one of our sites from outside this state or country, your
+  information may be transferred to, stored, and processed in the U.S. where our
+  servers are located, and our central database is operated. We process data
+  both inside and outside of the U.S. and rely on contractual commitments
+  between us and companies transferring personal data that require the
+  protection and security of such data for your privacy. The data protection and
+  other laws of the State of Florida, the U.S., and other countries might not be
+  as comprehensive and may differ from those in your state or country. By using
+  a Christ Fellowship Church site, you consent to your information being
+  transferred to our facilities and to the facilities of those third parties
+  with whom we share it, as described in this Privacy Policy.
+</p>
+<br />
+<h3>Changes to this Policy</h3>
+<p>
+  This Privacy Policy may change from time to time, and your continued use of
+  Christ Fellowship sites after we make changes is deemed to be acceptance of
+  those changes. So, please check this policy periodically for updates. Our
+  policy is to post any changes we make to our Privacy Policy on this page. If
+  we make material changes to how we treat our users' Personal Information, we
+  will notify you by e-mail (if you have an email address on record with us) and
+  through a notice on the website home pages. The date the Privacy Policy was
+  last revised is identified at the top of the page.
+</p>
+<p>
+  <b><br /></b>
+</p>
+<h3>Disputes; Mediation; Arbitration; Waiver of Class Action</h3>
+<p>
+  This Privacy Policy is subject to our Terms of Use, including Section 9 of our
+  Terms of Use, which includes mediation and binding arbitration (unless you opt
+  out of arbitration within 60 days of the earlier of your first use of the
+  Websites, Mobile App or Services or registration with the Websites, Mobile App
+  or Services) and a waiver of certain class action rights. Please carefully
+  review these terms, as well as the rest of the Terms of Use, before using our
+  Websites, Mobile Apps or Services.
+</p>
+<br />
+<h3>Let Us Know How We Are Doing</h3>
+<p>
+  We have taken great measures to ensure that your visit to our Websites, Mobile
+  Apps, and Services is a positive experience and that your privacy is
+  constantly respected. If you have any questions, comments, or concerns about
+  our privacy practices, please let us know.
+</p>
+<br />
+<h3>Contact Information</h3>
+<p>
+  To ask questions or comment about this Privacy Policy and our privacy
+  practices, you may contact us at: Christ Fellowship Church.Inc., Attn.: Data
+  Privacy, 5343 Northlake Blvd, Palm Beach Gardens, FL 33418, or at
+  data.privacy@Christfellowship.church.
+</p>
+`;
+
+export const termsOfUse = `<div><div>
+</div><h3>Introduction to Our Terms of Use
+</h3><div>Thank you for visiting this website or app, offered by Christ Fellowship Church, Inc. and our affiliated legal entities ("Christ Fellowship", "we", "us" or "our").  These terms of use (the "Terms of Use") govern your access to and use of our websites, including christfellowship.church, gochristfellowship.com, christfellowshipcreative.com, ourheartforthehouse.com, cfspiritualgifts.com, churchunitedfl.com, viveconf.com, christfellowshipconference.com, hopehouseflorida.com, christfellowshipworship.shop, christfellowshipworship.com, cfbelleglade.com, cfseu.com, cfkaleo.com, realityrehab.tv, soallmayknow.com, live.gochristfellowship.com, rock.gocf.org, restorecoffeeroasters.com; (collectively, our "Websites"), Mobile App and the services and tools related to the Websites (including, but not limited to, any mobile and other software applications downloaded from this Websites or obtained elsewhere) (collectively, the "Services").
+</div><div>The Websites, Mobile App and Services are available ONLY TO USERS 13 YEARS OF AGE OR OLDER. Please read these Terms of Use carefully.  We did our best to keep the document simple, but if you have any questions, please contact our Marketing Team. By accessing or using this Website or our Services you are agree to our Terms of Use, which includes our Privacy Policy incorporated herein by reference.
+</div><div>NOTICE REGARDING DISPUTE RESOLUTION:  In keeping with 1 Corinthians 6:1-8, these Terms of Use contain provisions that require all disputes which may arise between you and Christ Fellowship hereunder be resolved by mediation.  The Terms of Use also include an agreement to arbitrate, which will, with limited exception, require you to submit claims you have against us to binding and final arbitration, should mediation be unable to resolve the dispute.  Unless you opt out, you will only be able to pursue claims against Christ Fellowship on an individual basis, not as part of any class or representative action or proceeding, and you will only be permitted to seek relief (including monetary, injunctive, and declaratory relief) on an individual basis.</div><div><br></div><div>
+</div><div>
+</div><h3>1.	Modification of the Terms of Use.
+</h3><div>These Terms of Use may change from time to time and your continued use of this Website, Mobile App or our Services after we make changes is deemed to be acceptance of those changes.  So, please check this policy periodically for updates.  It is our policy to post any changes we make to our Terms of Use on this page.  If we make material changes to the Terms of Use, we will notify you by e-mail (if you have an email address on record with us) and through a notice on the Websites.  The date the Terms of Use was last revised is identified at the top of the page.</div><div><br></div><div>
+</div><div>
+</div><h3>2.	Access, License and Privacy.
+</h3><div>2.1  Access and License.  Provided you are not under the age of thirteen (13), we hereby grant you a personal, non-exclusive, non-transferable, revocable license to access our Websites and use the Services only for your own personal and noncommercial purposes (the "License").
+</div><div>1.	General Use License.  All material found on the Websites, Mobile App and Services  (including visuals, text, icons, displays, databases, recordings (sound, video or otherwise), media, and general information) is owned or licensed by us. You may view, download, and print material from the Websites, Mobile App and Services  only for your personal, noncommercial use unless otherwise stated.
+</div><div>2.	 Exceptions to the General Use License.  Any material that is provided subject to different rights than those set forth in Section 2.1(a) will be governed solely by such separately stated use rights.  Examples of materials that are provided subject to different use rights include material from perrynoble.com, which is subject to the Printing and Reposting use rights published on that site. Other examples include any (i) downloadable material obtained from the Websites, Mobile App or Services , where such material requires acceptance of a separate license agreement that governs the use of the material (e.g. downloading of software code published by us and distributed pursuant to an open source license) or (ii) downloading of materials from the Websites, Mobile App or Services  that include alternative use rights for the material at the location of the download (e.g. social media kit that has on website offering the kit an authorization to use only as a profile picture on Facebook or Twitter).</div><div><br></div><div>
+</div><h3>3.	 Media Rights.</h3><p>Materials may be reproduced by media personnel for use in traditional public news forums unless otherwise stated.
+</p><div><br></div><h3>4.	 Restrictions on Use.</h3><div>You may not post material from the Websites, Mobile App or Services  on another website, service or on a computer network without our permission. You may not transmit or distribute material from the Websites, Mobile App or Services  to other sites or services. You may not use the Websites, Mobile App or Services , or information found at the Websites, Mobile App or Services  (including the names and addresses of those who have submitted information), to sell or promote products or services or to solicit clients or for any other commercial purpose.
+</div><div>In the unlikely event you fail to comply with these Terms of Use, we may terminate the License without notice and you will no longer be permitted to access the Websites or use the Services.  If we become aware of possible violations of these Terms of Use, we may initiate an investigation that may include gathering information from you or any user involved and the examination of other material. We may suspend the provision of our Services temporarily, or we may permanently remove the material involved from our servers, cancel posts, provide warnings to you, or suspend or terminate your access to our Websites. We will determine what action will be taken in response to a violation at our sole discretion. We will fully cooperate with law enforcement authorities in investigating suspected lawbreakers.
+</div><div>2.2   Privacy.  We value your privacy and understand your privacy concerns.  Please review our Privacy Policy, which also governs your access to and use of the Websites, Mobile App and Services, so that you may understand our privacy practices.  All information we collect is subject to our Privacy Policy, and by using the Websites, Mobile App or Services  you consent to all actions taken by us with respect to your information in compliance with the Privacy Policy.  You further understand that any information collected by Christ Fellowship may be transferred to the United States and/or other countries for storage, processing and use by Christ Fellowship and its affiliates.
+</div><div>
+</div><div>3.	Registration Policy and Account Security
+</div><div>To access the Websites, Mobile App or Services, or some of the resources they offer, you may be asked to open a Christ Fellowship Account and provide certain registration details or other information.  Please be sure to (i) provide correct, current and complete information about yourself as prompted by any registration form for the Websites, Mobile App or Services  (such information being the "Registration Data") and (ii) maintain and promptly update the Registration Data to keep it correct, current and complete.  Christ Fellowship will use the email address provided in your Registration Data to provide notices, statements, and other communications to you, so please be sure to keep it current.
+</div><div>If you create, or are provided with, a username, password or any other information as part of our security procedures, please treat such information as confidential and do not disclose such information to any other person or entity.  Your Christ Fellowship Account is personal to you and should not be used to provide any other person access to this Websites or the Services.  To protect your security, as well as our Websites, Mobile App and Services , you must notify us immediately of any unauthorized access to or use of your username or password or any other breach of security. You should use particular caution when accessing your account from a public or shared computer so that others are not able to view or record your password or other personal information.
+</div><div>We have the right to disable any username, password or other identifier, whether chosen by you or provided by us, at any time in our sole discretion for any or no reason, including if, in our opinion, you have violated any provision of these Terms of Use.
+</div><div>
+</div><div>4.	Links to Third Party Sites
+</div><div>The Websites, Mobile App or Services may contain links to third party websites ("Linked Sites").  We do not control these Linked Sites and are not responsible for the content of, stability of, or any transmission to or from any Linked Site.  Christ Fellowship provides these links to you only as a convenience and the inclusion of any link does not imply endorsement by Christ Fellowship or any association with the link's operators or guarantee that the content contains accurate information.  We recommend you review the privacy statements and terms of use posted at any Linked Sites.
+<br><br></div><div>
+</div><h3>5.	Intellectual Property Rights; Content; Copyright Infringement Notification Process
+</h3><div>5.1 Intellectual Property Rights.  The materials, services and content offered on or through the Websites, Mobile App and Services , as well as their selection and arrangement, are protected by intellectual property rights (the "Intellectual Property Rights"), and any unauthorized use of the Websites, Mobile App and Services  may violate such Intellectual Property Rights laws and these Terms of Use.  Christ Fellowship and its licensors own all right, title and interest in and to the Intellectual Property Rights of the materials, services and content offered on or through the Websites, Mobile App and Services. These Terms of Use do not convey or transfer any ownership rights to you. The trademarks, logos and service marks displayed on the Websites, Mobile App or Services, including without limitation "Christ Fellowship Church" are the property of Christ Fellowship or other third parties. You are not permitted to use these marks without the prior written consent of Christ Fellowship or such third party that may own the marks. You may not remove or obscure any copyright notice or other proprietary notices contained on the Websites, Services or any materials, services or content retrieved through the Websites, Mobile App or Services.
+</div><div>5.2 Your Content.  The Websites, Mobile App and Services  may allow or require you to post data, text, pictures, videos, recordings or other materials and information that will be accessible by visitors to the Websites or users of the Services ("Public Content"), or that will only be accessible by you or those designated by you ("Private Content") (Public Content and Private Content, collectively referred to as "Your Content").  As between you and Christ Fellowship you remain the sole owner of and solely responsible for Your Content.  Christ Fellowship does not claim ownership of any of Your Content, but by submitting Your Content, you hereby grant Christ Fellowship a nonexclusive, worldwide, royalty-free, fully paid up, irrevocable, perpetual right and license to link to, reproduce, distribute, adapt, promote, display, and sublicense Your Content, including without limitation using Your Content in marketing materials for Christ Fellowship. (e.g., photos from your Public Group Profile). While we retain these rights, we will do our best to contact you if Your Content will be used for marketing purposes.  Christ Fellowship does not endorse, guarantee, or assume any responsibility, obligation or liability relating to Your Content, including without limitation liability for third-party claims against users of the Websites, Mobile App or Services  for defamation, libel, slander, infringement, invasion of privacy, violation of publicity rights, obscenity, pornography, profanity, fraud or misrepresentation.  Unless required otherwise by law or unable to determine the source of Your Content, Christ Fellowship will attempt to contact you before removing any of Your Content.  However, Christ Fellowship reserves the right to remove any of Your Content at any time, with no obligation to notify you of the removal, where Christ Fellowship believes in good faith that such removal is appropriate.  Publication of any of Your Content is at the sole discretion of Christ Fellowship.
+</div><div>5.3 Prohibited Content.  We want to maintain Websites, Mobile App and Services that are a positive, healthy experience for all.  Therefore, while using the Websites, Mobile App or Services , you agree that you will not upload, post, email, transmit or otherwise make available any Public Content or Private Content that:  (i) is unlawful, harmful, threatening, abusive, harassing, tortious, infringing, defamatory, vulgar, obscene, libelous, invasive of another's privacy, hateful, or is racially, ethnically or otherwise objectionable; (ii) creates a risk of harm, loss, or damage to any person or property or a risk of physical or mental injury, emotional distress, death, disability, disfigurement, or physical or mental illness to yourself, to any other person, or to any animal; (iii) seeks to harm or exploit minors in any way, including, but not limited to, by exposing them to inappropriate content, asking for personally identifiable details or otherwise; (iv) violates, or encourages any conduct that violates laws or regulations or contains any information or content that is illegal; or (v) infringes any third party's intellectual property rights, privacy rights, publicity rights, or other personal or proprietary rights or contains any information or content that you do not have a right to make available under any law or under contractual or fiduciary relationships.
+</div><div>5.4 Prohibited Conduct.  While using the Websites, Mobile App and Services , you agree not to engage in any of the following prohibited activities: (i) use, display, mirror or frame the Websites, Mobile App or Services , any individual element within the Websites, Mobile App or Services , the Christ Fellowship name, trademark, logo or other proprietary information, or the layout and design of any page, without our express written consent; (ii) access the Websites, Mobile App or Services  by any means other than through the interface provided by Christ Fellowship and as otherwise expressly authorized under these Terms of Use; (iii) access, tamper with, or use non-public areas of the Websites, Mobile App or Services , our computer systems, or the technical delivery systems of our providers; (iv) avoid, bypass, remove, deactivate, impair, descramble or otherwise circumvent any technological measure implemented by Christ Fellowship or any of our providers or any other third party (including another user) to protect the Websites, Mobile App or Services ; (v) forge headers or otherwise manipulate identifiers in order to disguise the origin of any of Your Content transmitted through the Websites, Mobile App or Services ; (vi) attempt to access or search the Websites, Mobile App or Services  or scrape or download any user content from the Websites, Mobile App or Services , or otherwise use or upload content to, or create new links, reposts, or referrals in the Websites, Mobile App or Services  through the use of any engine, software, tool, agent, device or mechanism (including automated scripts, spiders, robots, crawlers, data mining tools or the like) other than the software and/or search agents provided by Christ Fellowship or other generally available third party web browsers; (vii) send or post onto the Websites, Mobile App or Services  any unsolicited or unauthorized spam, advertising messages, promotional materials, email, junk mail, chain letters or other form of solicitation; (viii) use any meta tags or other hidden text or metadata utilizing the Websites, Mobile App or Services  or an Christ Fellowship trademark, logo, or URL without Christ Fellowship's express written consent; (ix) attempt to decipher, decompile, disassemble or reverse engineer any of the software used to provide the Websites, Mobile App or Services ; (x) interfere with, or attempt to interfere with, the access of any user, host or network, including, without limitation, sending or posting a virus, overloading, flooding, spamming, or mail-bombing the Websites, Mobile App or Services ; (xi) reproduce, duplicate, copy, sell, trade, resell or exploit for any commercial purpose any portion of the Websites, Mobile App or Services  (including your account) or your access to or use of the Websites, Mobile App or Services ; (xii) collect or store any personally identifiable information from other users of the Websites, Mobile App or Services  without their express permission; (xiii) stalk or otherwise harass another person or entity; (xiv) impersonate or misrepresent your affiliation with any person or entity; (xv) violate any applicable law or regulation; or (xvi) encourage or enable any other individual to do any of the activities prohibited in these Terms of Use.
+</div><div>5.5 Transmission of Your Content.  The term "Your Content" also includes registration information, business and financial information, electronic transmissions and all other data of any kind contained within emails or otherwise submitted by you or entered electronically in the course of your use of the Websites, Mobile App or Services . You understand that the technical processing and transmission of Your Content (including the possible transmission of Your Content outside its country of origin) may be necessary to your use of the materials, services and content offered on or through the Websites, Mobile App or Services  and consent to Christ Fellowship's interception and storage of Your Content. You understand that you or Christ Fellowship may be transmitting Your Content over the Internet, and over various networks, only part of which may be owned and operated by Christ Fellowship. You agree that Christ Fellowship is not responsible for any portions of Your Content that are lost, altered, intercepted or stored without authorization during the transmission of Your Content across networks not owned and operated by Christ Fellowship.
+</div><div>5.6 Copyright Infringement Notification Process. Christ Fellowship abides by the Federal Digital Millennium Copyright Act (the "DMCA"). If you believe that any content included on the Websites, Mobile App or Services  is your proprietary work and has been copied in a way that constitutes an infringement of your copyrights in that work, please immediately notify Christ Fellowship of any such copyright or other Intellectual Property Rights infringement. Similarly, if you believe that </div><div><br></div><div>Your Content has been inappropriately removed, you may send a counter-notification. In either case, your written notice should be sent to our designated agent as follows:
+</div><div>DMCA Complaints
+</div><div>Christ Fellowship Church, Inc.
+</div><div>Attn: Cristian Garcia / Marketing Supervisor
+</div><div>5343 Northlake Blvd., Palm Beach Gardens, FL 33418
+</div><div>Telephone: 561-799-7600
+</div><div>Email: hello@cftoday.org
+<br><br></div><div>Please also note that under the DMCA, any person who knowingly materially misrepresents that material or activity is infringing or was removed or disabled by mistake or misidentification may be subject to liability. All reports and inquiries will be kept confidential, except to the extent necessary to investigate any alleged violation and enforce the terms and conditions of these Terms of Use. Before sending either a copyright infringement notification or counter-notification, you may wish to contact a lawyer to better understand your rights and obligations under the DMCA and other applicable laws. The following notice requirements are intended to comply with Christ Fellowship's rights and obligations under the DMCA and do not constitute legal advice. Christ Fellowship will remove the infringing content, subject to the procedures outlined in the DMCA.
+</div><div>5.6.1 Copyright Infringement Notification. To file a copyright infringement notification with us, you will need to send a written communication that includes substantially the following (please consult your legal counsel or see 17 U.S.C. Section 512(c)(3) to confirm these requirements):
+</div><div>1.	A physical or electronic signature of a person authorized to act on behalf of the owner of an exclusive right that is allegedly infringed.
+</div><div>2.	Identification of the copyrighted work claimed to have been infringed, or, if multiple copyrighted works at a single online site are covered by a single notification, a representative list of such works at that site.
+</div><div>3.	Identification of the material that is claimed to be infringing or to be the subject of infringing activity and that is to be removed or access to which is to be disabled, and information reasonably sufficient to permit the service provider to locate the material. Providing URLs is the best way to help us locate content quickly.
+</div><div>4.	Information reasonably sufficient to permit the service provider to contact the complaining party, such as an address, telephone number, and, if available, an electronic mail address at which the complaining party may be contacted.
+</div><div>5.	A statement that the complaining party has a good faith belief that use of the material in the manner complained of is not authorized by the copyright owner, its agent, or the law.
+</div><div>6.	A statement that the information in the notification is accurate, and under penalty of perjury, that the complaining party is authorized to act on behalf of the owner of an exclusive right that is allegedly infringed.
+</div><div>5.6.2 Counter-Notification. If Your Content has been taken down, you may elect to send us a counter notice. To be effective your counter notice must be a written communication provided to our designated agent that includes substantially the following (please consult your legal counsel or see 17 U.S.C. Section 512(g)(3) to confirm these requirements):
+</div><div>1.	A physical or electronic signature of the subscriber.
+</div><div>2.	Identification of the material that has been removed or to which access has been disabled and the location at which the material appeared before it was removed or access to it was disabled.
+</div><div>3.	A statement under penalty of perjury that the subscriber has a good faith belief that the material was removed or disabled as a result of mistake or misidentification of the material to be removed or disabled.
+</div><div>4.	The subscriber's name, address, and telephone number, and a statement that the subscriber consents to the jurisdiction of Federal District Court for the judicial district in which the address is located, or if the subscriber's address is outside of the United States, for any judicial district in which the service provider may be found, and that the subscriber will accept service of process from the person who provided notification under subsection (c)(1)(C) or an agent of such person.
+</div><div>
+</div><div><br></div><h3><span style="font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;, &quot;Segoe UI Symbol&quot;;">6.	Disclaimer of Warranties/Limitation of Liability</span></h3><div>While we try to provide the Websites, Mobile App and Services  at a standard that we would expect to receive from others providing similar Websites, Mobile App or Services , no one and no thing is perfect. THEREFORE, THE WEBSITES, MOBILE APP AND SERVICES ARE PROVIDED ON AN "AS IS" AND "AS AVAILABLE" BASIS.  TO THE FULL EXTENT PERMISSIBLE BY APPLICABLE LAW, CHRIST FELLOWSHIP AND ITS SUBSIDIARIES, PARTNERS, AFFILIATES, OFFICERS, DIRECTORS, MEMBERS, MANAGERS, EMPLOYEES, AGENTS AND LICENSORS (COLLECTIVELY, THE "CHRIST FELLOWSHIP PARTIES") DISCLAIM ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A  PARTICULAR PURPOSE AND NON-INFRINGEMENT.  THE CHRIST FELLOWSHIP PARTIES DO NOT WARRANT THAT THE WEBSITES, MOBILE APP OR SERVICES  WILL BE UNINTERRUPTED OR ERROR-FREE, THAT DEFECTS WILL BE CORRECTED, THAT THE SERVICE OR SERVERS THAT MAKE THE WEBSITES, MOBILE APP AND SERVICES  AVAILABLE WILL BE FREE OF VIRUSES OR OTHER HARMFUL COMPONENTS, OR THAT ANY DESCRIPTIONS OR DEPICTIONS, OR OTHER CONTENT OFFERED AS PART OF THE WEBSITES, MOBILE APP OR SERVICES , ARE ACCURATE, RELIABLE, CURRENT OR COMPLETE.
+</div><div>YOU EXPRESSLY AGREE THAT YOUR USE OF THE WEBSITES, MOBILE APP AND SERVICES ARE AT YOUR SOLE RISK. IF YOU DOWNLOAD ANY CONTENT FROM THE WEBSITES, MOBILE APP OR SERVICES, YOU DO SO AT YOUR OWN DISCRETION AND RISK. YOU WILL BE SOLELY RESPONSIBLE FOR ANY DAMAGE TO YOUR COMPUTER SYSTEM OR MOBILE DEVICE OR LOSS OF DATA THAT RESULTS FROM THE DOWNLOAD OF ANY CONTENT THROUGH THE WEBSITES, MOBILE APP OR SERVICES. WE RESERVE THE RIGHT TO RESTRICT OR TERMINATE YOUR ACCESS TO THE WEBSITES, MOBILE APP OR SERVICES OR ANY FEATURE OR PART THEREOF AT ANY TIME. THE CHRIST FELLOWSHIP PARTIES ASSUME NO RESPONSIBILITY FOR THE DELETION, MIS-DELIVERY OR FAILURE TO STORE ANY CONTENT OR PERSONALIZATION SETTINGS.
+</div><div>YOU UNDERSTAND AND AGREE THAT THE CHRIST FELLOWSHIP PARTIES WILL NOT BE LIABLE TO YOU FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL OR EXEMPLARY DAMAGES, INCLUDING, BUT NOT LIMITED TO, DAMAGES FOR LOSS OF PROFITS, GOODWILL, USE, DATA OR OTHER INTANGIBLE LOSSES (EVEN IF AN AVIXENA PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES), RESULTING FROM YOUR USE OR ACCESS OF, OR INABILITY TO USE OR ACCESS, THE WEBSITES, MOBILE APP OR SERVICES . IN NO EVENT SHALL OUR TOTAL LIABILITY TO YOU FOR ALL DAMAGES, LOSSES, AND CAUSES OF ACTION EXCEED THE AMOUNT PAID BY YOU, IF ANY, FOR ACCESSING THE WEBSITES, MOBILE APP OR SERVICES.</div><div><br></div><div>
+</div><div>
+</div><h3>7.	Indemnification
+</h3><div>You agree to indemnify, defend and hold harmless the Christ Fellowship Parties from and against all losses, expenses, damages and costs, including reasonable attorneys' fees, resulting from any violation of these Terms of Use by you or any other actions connected with your use of the Websites, Mobile App or Services .  Your indemnification obligations include without limitation claims arising out of any of Your Content, as well as any claims arising out of acts or omissions by your agents, and any other person or entity who gains access to Christ Fellowship's materials, services or content through your name either with your permission or as a result of your failure to use reasonable security measures.</div><div><br></div><div>
+</div><div>
+</div><h3>8.	Injunctive Relief
+</h3><div>Your breach of these Terms of Use may result in immediate and irreparable harm to us, for which there may be no adequate remedy at law, and, therefore, you agree that we are entitled to equitable relief to compel you to cease and desist all unauthorized use, evaluation and disclosure of information obtained through the Websites, Mobile App or Services , which is in addition to any other remedies available at law or in equity.
+</div><div>
+</div><div><br></div><h3>9.	Arbitration Agreement and Waiver of Class Action
+</h3><div>Except as set forth below, ANY DISPUTE OR CLAIM ARISING UNDER THESE TERMS OF USE, INCLUDING THE PRIVACY POLICY INCORPORATED HEREIN BY REFERENCE, OR RELATING IN ANY WAY TO YOUR USE OF THE WEBSITES, MOBILE APP OR SERVICES  WILL BE RESOLVED BY FINAL AND BINDING ARBITRATION, RATHER THAN IN COURT; provided, however, that the following are exceptions to our agreement to arbitrate our disputes:
+</div><div>1.	a) Any claim that qualifies as a small claim in a court of limited subject matter jurisdiction must be brought in such court; and
+</div><div>2.	b) Any claim for injunctive relief may be brought in a court of competent jurisdiction to enjoin intellectual property infringement or misuse.
+</div><div>Any dispute or claim arising under these Terms of Use, including the Privacy Policy incorporated herein by reference or relating in any way to your use of the Websites, Mobile App or Services  will first attempt to be resolved by mediation, and if not resolved by mediation, then you may begin an arbitration proceeding by following the Institute for Christian Conciliation's filing requirements and mailing a request for arbitration and description of your claim to Communications Team, 5343 Northlake Blvd., Palm Beach Gardens, FL 33418.  The Rules of Procedure for Christian Conciliation, Institute for Christian Conciliation will apply (available at http://www.peacemaker.net or by calling 406-256-1583).  The arbitrator will have the power to rule on any challenge to its own jurisdiction or to the validity or enforceability of any portion of this agreement to arbitrate.  Notwithstanding any of the foregoing, THE ARBITRATOR WILL NOT BE EMPOWERED AND DOES NOT HAVE THE AUTHORITY TO HEAR OR DECIDE ANY CLASS, CONSOLIDATED OR REPRESENTATIVE ACTION, TO AWARD PUNITIVE OR EXEMPLARY DAMAGES OR TO AWARD ATTORNEYS' FEES TO THE PREVAILING PARTY.  In the event that the Institute for Christian Conciliation ceases to exist during the course of this Agreement, arbitration under this section shall be conducted according to the Rules of the American Arbitration Association.
+</div><div>You may opt out of this agreement to arbitrate by providing written notice of your intention to do so to Christ Fellowship within 60 days of the earlier of your first use of the Websites, Mobile App or Services  or your creating a Christ Fellowship Account.
+</div><div>By using the Websites, Mobile App or Services , you agree that the Federal Arbitration Act, applicable federal law, and the laws of the state of Florida, without regard to principles of conflict of laws, will govern these Terms of Use (including the Privacy Policy incorporated herein by reference) and any dispute or claim of any sort that might arise between you and Christ Fellowship.
+</div><div>
+</div><div><br></div><h3>10.	No Waiver; Severability
+</h3><div>A waiver of any breach of any provision of these Terms of Use is not a waiver of any repetition of such breach and will not in any manner affect any other terms or conditions of these Terms of Use. We do not waive any rights by the failure to enforce any provision of these Terms of Use in every instance in which it might apply. In the event that any provision of these Terms of Use is held to be unenforceable, it will not affect the validity or enforceability of the remaining provisions and will be replaced by an enforceable provision that is the closest to the intention underlying the unenforceable provision.
+</div><div>
+</div><div><br></div><h3>11.	Assignability
+</h3><div>We may assign our rights and delegate our duties under these Terms of Use either in whole or in part at any time without notice. You may not assign, sublicense or otherwise transfer your rights or obligations, in whole or in part, under these Terms of Use to anyone else without our prior written consent.
+</div><div>
+</div><div><br></div><h3>12.	Relationship
+</h3><div>This Agreement does not establish any relationship of partnership, joint venture, employment, franchise or agency between you and us.
+</div><div>
+</div><div><br></div></div><div class=""></div><div class=""></div></div>`;

--- a/app/routes/privacy-policy/route.tsx
+++ b/app/routes/privacy-policy/route.tsx
@@ -1,0 +1,17 @@
+import { type MetaFunction } from 'react-router';
+import { createMeta } from '~/lib/meta-utils';
+import { LegalHtmlDocument } from '~/components/legal/legal-html-document.component';
+import { privacyPolicy } from '~/lib/legal/privacy-policy-and-terms.data';
+
+export const meta: MetaFunction = () => {
+  return createMeta({
+    title: 'Privacy Policy',
+    description:
+      'Read the Christ Fellowship Church Privacy Policy to understand how we collect, use, and protect your information.',
+    path: '/privacy-policy',
+  });
+};
+
+export default function PrivacyPolicyPage() {
+  return <LegalHtmlDocument title='Privacy Policy' html={privacyPolicy} />;
+}

--- a/app/routes/terms-of-use/route.tsx
+++ b/app/routes/terms-of-use/route.tsx
@@ -1,0 +1,17 @@
+import { type MetaFunction } from 'react-router';
+import { createMeta } from '~/lib/meta-utils';
+import { LegalHtmlDocument } from '~/components/legal/legal-html-document.component';
+import { termsOfUse } from '~/lib/legal/privacy-policy-and-terms.data';
+
+export const meta: MetaFunction = () => {
+  return createMeta({
+    title: 'Terms of Use',
+    description:
+      'Read the Christ Fellowship Church Terms of Use that govern your access to and use of our websites, mobile app, and services.',
+    path: '/terms-of-use',
+  });
+};
+
+export default function TermsOfUsePage() {
+  return <LegalHtmlDocument title='Terms of Use' html={termsOfUse} />;
+}


### PR DESCRIPTION
## Summary

Adds static Privacy Policy and Terms of Use pages to the site. These pages render stored HTML legal content using a shared `LegalHtmlDocument` component with proper meta tags and styling.

## Screenshots

<img width="1155" height="820" alt="image" src="https://github.com/user-attachments/assets/44f1afc9-3655-4821-adae-a1a17084b9c7" />

## Testing

- [x] Navigate to `/privacy-policy` and verify the Privacy Policy content renders correctly
- [x] Navigate to `/terms-of-use` and verify the Terms of Use content renders correctly
- [x] Verify page titles and meta descriptions are correct in browser tab / dev tools
- [x] Was any new linter errors/warnings?

## Tickets

[CFDP-3962](https://christfellowshipchurch.atlassian.net/browse/CFDP-3962)

## Changes Made

### New Components Added

- `app/components/legal/legal-html-document.component.tsx` — Shared component that renders a titled legal page from raw HTML content
- `app/components/legal/legal-html-document.styles.css` — Styles scoped to the legal document layout

### New Utilities

- `app/lib/legal/privacy-policy-and-terms.data.ts` — Stores the raw HTML strings for the Privacy Policy and Terms of Use content

### Route Implementation

- `app/routes/privacy-policy/route.tsx` — New route at `/privacy-policy` rendering the Privacy Policy page
- `app/routes/terms-of-use/route.tsx` — New route at `/terms-of-use` rendering the Terms of Use page

### Key Features

- Privacy Policy and Terms of Use pages accessible at their respective routes
- Each page includes SEO-friendly meta title and description via `createMeta`
- HTML legal content rendered via a reusable `LegalHtmlDocument` component

[CFDP-3962]: https://christfellowshipchurch.atlassian.net/browse/CFDP-3962?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ