### PR TITLE
Give Page FAQ Mobile | Fix Scroll Issue

### DIFF
--- a/app/components/navbar/navbar.component.tsx
+++ b/app/components/navbar/navbar.component.tsx
@@ -35,7 +35,9 @@ export function Navbar() {
 
   // State management
   const [isVisible, setIsVisible] = useState(true);
-  const [lastScrollY, setLastScrollY] = useState(0);
+  /** Last window.scrollY for direction math — ref avoids stale giant deltas when isSmall toggles. */
+  const lastScrollYRef = useRef(0);
+  const prevPathnameRef = useRef<string | null>(null);
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   const [openDropdown, setOpenDropdown] = useState<string | null>(null);
 
@@ -106,25 +108,26 @@ export function Navbar() {
 
       const currentScrollY = window.scrollY;
       const scrollThreshold = 10;
-      const scrollDelta = currentScrollY - lastScrollY;
+      const scrollDelta = currentScrollY - lastScrollYRef.current;
 
       // Reset at top of page
       if (currentScrollY < scrollThreshold) {
         setIsVisible(true);
         setMode(defaultMode);
-        setLastScrollY(currentScrollY);
+        lastScrollYRef.current = currentScrollY;
         return;
       }
 
       // Handle scroll direction
       if (Math.abs(scrollDelta) > scrollThreshold) {
-        setIsVisible(scrollDelta < 0);
+        const nextVisible = scrollDelta < 0;
+        setIsVisible(nextVisible);
         if (currentScrollY > scrollThreshold) {
           setMode(scrollDelta < 0 ? 'light' : 'dark');
         }
       }
 
-      setLastScrollY(currentScrollY);
+      lastScrollYRef.current = currentScrollY;
     };
 
     window.addEventListener('scroll', handleScroll, { passive: true });
@@ -132,14 +135,7 @@ export function Navbar() {
     return () => {
       window.removeEventListener('scroll', handleScroll);
     };
-  }, [
-    lastScrollY,
-    defaultMode,
-    pathname,
-    isSmall,
-    isNavbarHidden,
-    isSearchOpen,
-  ]);
+  }, [defaultMode, isNavbarHidden, isSearchOpen]);
 
   // Initial mode setup
   useEffect(() => {
@@ -150,7 +146,7 @@ export function Navbar() {
     }
   }, [pathname, isSmall]);
 
-  // Route change handling
+  // Route change handling (mode follows pathname + breakpoint; scroll baseline only on real navigation)
   useEffect(() => {
     let newMode: 'light' | 'dark';
     // If on home page, set mode based on screen size
@@ -161,9 +157,14 @@ export function Navbar() {
     }
     setDefaultMode(newMode);
     setMode(newMode);
-    setLastScrollY(0);
-    setIsVisible(true);
     setOpenDropdown(null); // Close menu when navigating to a new page
+
+    if (prevPathnameRef.current !== pathname) {
+      prevPathnameRef.current = pathname;
+      lastScrollYRef.current =
+        typeof window !== 'undefined' ? window.scrollY : 0;
+      setIsVisible(true);
+    }
   }, [pathname, isSmall]);
 
   // Mode sync effect

--- a/app/routes/give/route.tsx
+++ b/app/routes/give/route.tsx
@@ -33,7 +33,7 @@ export default function Give() {
         />
       </div>
 
-      <div className='w-full -my-16'>
+      <div className='w-full py-12 md:py-0'>
         <FAQsComponent data={giveFaqData} />
       </div>
     </div>

--- a/app/routes/page-builder/components/faq/index.tsx
+++ b/app/routes/page-builder/components/faq/index.tsx
@@ -51,7 +51,7 @@ function FAQItem({ question, answer }: { question: string; answer: string }) {
 
   return (
     <div
-      className='rounded-[1rem] text-left flex flex-col py-4 px-5 md:py-5 md:px-6 border border-neutral-default max-w-[768px] lg:max-w-none hover:bg-gray-50 transition-all duration-200 cursor-pointer'
+      className='rounded-2xl text-left flex flex-col py-4 px-5 md:py-5 md:px-6 border border-neutral-default max-w-[768px] lg:max-w-none hover:bg-gray-50 transition-all duration-200 cursor-pointer'
       onClick={() => setIsExpanded(!isExpanded)}
     >
       <div className='flex justify-between gap-2 w-full cursor-pointer'>


### PR DESCRIPTION
## Summary

These changes fix unreliable navbar hide/show behavior when the mobile breakpoint toggles or when scroll listeners were re-bound due to `lastScrollY` living in React state. Scroll position for direction math now lives in a ref so the scroll handler stays stable and avoids stale giant deltas. Route changes reset the scroll baseline and visibility only on real pathname changes (not on `isSmall` alone), which prevents the navbar from jumping incorrectly on resize-driven re-runs.

On the Give page, the FAQ block no longer uses negative vertical margin (`-my-16`); it uses responsive padding so content spacing and scroll behavior feel correct on small screens. The page-builder FAQ item uses `rounded-2xl` instead of an arbitrary `rounded-[1rem]` for consistency with design tokens.

## Screenshots

<img width="523" height="902" alt="image" src="https://github.com/user-attachments/assets/92894914-d735-436b-a0e9-5383c7b28c56" />

## Testing

- [x] Scroll the site on desktop and mobile (or responsive devtools): navbar should show on scroll up and hide on scroll down without erratic jumps when crossing the small breakpoint.
- [x] Navigate between routes (including home) and confirm navbar visibility and light/dark mode still behave as expected.
- [x] Open `/give`, expand/collapse FAQs, and confirm spacing above/below the FAQ section looks correct on mobile vs `md+`.
- [x] Spot-check any route that uses the page-builder FAQ component for unchanged expand/collapse behavior and visual rounding.
- [x] `pnpm lint` (no new linter errors expected).

## Tickets

[CFDP-3963](https://christfellowshipchurch.atlassian.net/browse/CFDP-3963)

## Changes Made

### Route Implementation

- `app/routes/give/route.tsx` — FAQ wrapper spacing: `py-12 md:py-0` instead of `-my-16`.
- `app/routes/page-builder/components/faq/index.tsx` — FAQ item container: `rounded-2xl` instead of `rounded-[1rem]`.

### Key Features

- `app/components/navbar/navbar.component.tsx` — Track last scroll Y in a ref; narrow scroll effect dependencies; reset scroll baseline and visibility on pathname change only (with `prevPathnameRef`).

[CFDP-3963]: https://christfellowshipchurch.atlassian.net/browse/CFDP-3963?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ