### PR TITLE
Carousel Padding/Content Block Header Fixes

### DIFF
--- a/app/components/resource-carousel/index.tsx
+++ b/app/components/resource-carousel/index.tsx
@@ -175,7 +175,8 @@ export const CardCarousel = ({
           /* Reserve space for absolutely positioned dots/arrows (parent had ~0 in-flow height on mobile → clipped by overflow-hidden). */
           'min-h-[4.5rem]',
           {
-            'flex md:hidden': resources.length < 4,
+            'flex md:hidden': resources.length < 4 && resources.length > 1,
+            hidden: resources.length < 2,
           },
         )}
       >

--- a/app/components/resource-carousel/index.tsx
+++ b/app/components/resource-carousel/index.tsx
@@ -55,7 +55,7 @@ export const CardCarouselSection = ({
     >
       <div className='flex flex-col max-w-screen-content mx-auto'>
         <div className='w-full flex justify-center'>
-          <div className='w-full flex flex-col items-center gap-12 lg:gap-20 py-16 md:py-24 lg:py-28'>
+          <div className='w-full flex flex-col items-center gap-12 lg:gap-20 py-16 md:py-24'>
             {/* Header */}
             <div className='w-full flex items-end justify-between pr-5 md:pr-12 lg:pr-18 2xl:pr-8! 3xl:pr-0!'>
               <div

--- a/app/components/resource-carousel/index.tsx
+++ b/app/components/resource-carousel/index.tsx
@@ -171,11 +171,11 @@ export const CardCarousel = ({
 
       <div
         className={cn(
-          'relative w-full flex justify-between items-center mt-8 sm:mt-12 md:mt-16',
+          'relative w-full flex justify-between items-center mt-8 sm:mt-12 md:mt-14 px-4',
           /* Reserve space for absolutely positioned dots/arrows (parent had ~0 in-flow height on mobile → clipped by overflow-hidden). */
           'min-h-[4.5rem]',
           {
-            'lg:mt-0 lg:min-h-0 lg:pb-0': resources.length < 4,
+            'flex md:hidden': resources.length < 4,
           },
         )}
       >

--- a/app/routes/locations/location-single/partials/tabs/families.tsx
+++ b/app/routes/locations/location-single/partials/tabs/families.tsx
@@ -1,15 +1,21 @@
 import { renderSection } from '~/routes/page-builder/page-builder-page';
+import { getCarouselCollectionBackgrounds } from '~/routes/page-builder/components/builder-utils';
 import {
   familiesMappedChildren,
   spanishFamiliesMappedChildren,
 } from './tabs.data';
 
 export const ForFamilies = ({ isSpanish }: { isSpanish?: boolean }) => {
+  const children = isSpanish ? spanishFamiliesMappedChildren : familiesMappedChildren;
+  const backgrounds = getCarouselCollectionBackgrounds(children);
+
   return (
     <div className='flex flex-col w-full rounded-t-[24px] md:rounded-none bg-gray pt-20 md:pt-24'>
-      {isSpanish
-        ? spanishFamiliesMappedChildren.map((section) => renderSection(section))
-        : familiesMappedChildren.map((section) => renderSection(section))}
+      {children.map((section) =>
+        renderSection(section, {
+          collectionBackground: backgrounds.get(section.id),
+        }),
+      )}
     </div>
   );
 };

--- a/app/routes/locations/location-single/partials/tabs/families.tsx
+++ b/app/routes/locations/location-single/partials/tabs/families.tsx
@@ -6,7 +6,9 @@ import {
 } from './tabs.data';
 
 export const ForFamilies = ({ isSpanish }: { isSpanish?: boolean }) => {
-  const children = isSpanish ? spanishFamiliesMappedChildren : familiesMappedChildren;
+  const children = isSpanish
+    ? spanishFamiliesMappedChildren
+    : familiesMappedChildren;
   const backgrounds = getCarouselCollectionBackgrounds(children);
 
   return (

--- a/app/routes/ministry-builder/ministry-builder-page.tsx
+++ b/app/routes/ministry-builder/ministry-builder-page.tsx
@@ -2,6 +2,7 @@ import { useLoaderData, useLocation } from 'react-router-dom';
 import { DynamicHero } from '~/components';
 import { PageBuilderLoader } from '../page-builder/types';
 import { renderSection } from '../page-builder/page-builder-page';
+import { getCarouselCollectionBackgrounds } from '../page-builder/components/builder-utils';
 import { MinistryServiceTimes } from './components/ministry-service-times.component';
 import { displayServiceTimes } from './utils';
 
@@ -17,6 +18,8 @@ export function MinistryBuilderRoute() {
     cleanPathname,
   );
 
+  const backgrounds = getCarouselCollectionBackgrounds(sections);
+
   return (
     <div className='bg-white'>
       <DynamicHero
@@ -28,7 +31,11 @@ export function MinistryBuilderRoute() {
         }))}
       />
 
-      {sections.map(renderSection)}
+      {sections.map((section) =>
+        renderSection(section, {
+          collectionBackground: backgrounds.get(section.id),
+        }),
+      )}
 
       {shouldDisplayServiceTimes && (
         <MinistryServiceTimes services={services} />

--- a/app/routes/page-builder/__tests__/collection-backgrounds.test.ts
+++ b/app/routes/page-builder/__tests__/collection-backgrounds.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import { getCarouselCollectionBackgrounds } from '../components/builder-utils';
+import { PageBuilderSection } from '../types';
+
+function makeSection(
+  id: string,
+  type: PageBuilderSection['type'],
+): PageBuilderSection {
+  return { id, name: id, content: '', type };
+}
+
+describe('getCarouselCollectionBackgrounds', () => {
+  it('returns an empty map when there are no sections', () => {
+    const result = getCarouselCollectionBackgrounds([]);
+    expect(result.size).toBe(0);
+  });
+
+  it('returns an empty map when there are no carousel collection sections', () => {
+    const sections = [
+      makeSection('a', 'CONTENT_BLOCK'),
+      makeSection('b', 'FAQs'),
+    ];
+    const result = getCarouselCollectionBackgrounds(sections);
+    expect(result.size).toBe(0);
+  });
+
+  it('assigns white to a single isolated collection section', () => {
+    const sections = [makeSection('a', 'RESOURCE_COLLECTION')];
+    const result = getCarouselCollectionBackgrounds(sections);
+    expect(result.get('a')).toBe('white');
+  });
+
+  it('assigns white to an isolated EVENT_COLLECTION', () => {
+    const sections = [makeSection('a', 'EVENT_COLLECTION')];
+    const result = getCarouselCollectionBackgrounds(sections);
+    expect(result.get('a')).toBe('white');
+  });
+
+  it('alternates white then gray for an adjacent pair', () => {
+    const sections = [
+      makeSection('a', 'RESOURCE_COLLECTION'),
+      makeSection('b', 'EVENT_COLLECTION'),
+    ];
+    const result = getCarouselCollectionBackgrounds(sections);
+    expect(result.get('a')).toBe('white');
+    expect(result.get('b')).toBe('gray');
+  });
+
+  it('alternates white, gray, white for a run of three', () => {
+    const sections = [
+      makeSection('a', 'RESOURCE_COLLECTION'),
+      makeSection('b', 'EVENT_COLLECTION'),
+      makeSection('c', 'RESOURCE_COLLECTION'),
+    ];
+    const result = getCarouselCollectionBackgrounds(sections);
+    expect(result.get('a')).toBe('white');
+    expect(result.get('b')).toBe('gray');
+    expect(result.get('c')).toBe('white');
+  });
+
+  it('resets to white after a non-collection section breaks the run', () => {
+    const sections = [
+      makeSection('a', 'RESOURCE_COLLECTION'),
+      makeSection('b', 'EVENT_COLLECTION'),
+      makeSection('x', 'CONTENT_BLOCK'),
+      makeSection('c', 'RESOURCE_COLLECTION'),
+    ];
+    const result = getCarouselCollectionBackgrounds(sections);
+    expect(result.get('a')).toBe('white');
+    expect(result.get('b')).toBe('gray');
+    expect(result.has('x')).toBe(false);
+    expect(result.get('c')).toBe('white');
+  });
+
+  it('treats mixed RESOURCE_COLLECTION and EVENT_COLLECTION as one alternating run', () => {
+    const sections = [
+      makeSection('a', 'RESOURCE_COLLECTION'),
+      makeSection('b', 'EVENT_COLLECTION'),
+      makeSection('c', 'RESOURCE_COLLECTION'),
+      makeSection('d', 'EVENT_COLLECTION'),
+    ];
+    const result = getCarouselCollectionBackgrounds(sections);
+    expect(result.get('a')).toBe('white');
+    expect(result.get('b')).toBe('gray');
+    expect(result.get('c')).toBe('white');
+    expect(result.get('d')).toBe('gray');
+  });
+
+  it('does not include CTA_COLLECTION in the alternating pattern', () => {
+    const sections = [
+      makeSection('a', 'RESOURCE_COLLECTION'),
+      makeSection('b', 'CTA_COLLECTION'),
+      makeSection('c', 'EVENT_COLLECTION'),
+    ];
+    const result = getCarouselCollectionBackgrounds(sections);
+    // CTA breaks the run → 'a' is alone (white), 'c' starts a new run (white)
+    expect(result.get('a')).toBe('white');
+    expect(result.has('b')).toBe(false);
+    expect(result.get('c')).toBe('white');
+  });
+});

--- a/app/routes/page-builder/components/builder-utils.ts
+++ b/app/routes/page-builder/components/builder-utils.ts
@@ -1,6 +1,11 @@
 import { cn } from '~/lib/utils';
 import { parseRockKeyValueList } from '~/lib/utils';
-import { ContentBlockData, ContentType, PageBuilderSection, SectionType } from '../types';
+import {
+  ContentBlockData,
+  ContentType,
+  PageBuilderSection,
+  SectionType,
+} from '../types';
 
 /**
  * Maps content channel IDs to their corresponding content types

--- a/app/routes/page-builder/components/builder-utils.ts
+++ b/app/routes/page-builder/components/builder-utils.ts
@@ -1,6 +1,6 @@
 import { cn } from '~/lib/utils';
 import { parseRockKeyValueList } from '~/lib/utils';
-import { ContentBlockData, ContentType, SectionType } from '../types';
+import { ContentBlockData, ContentType, PageBuilderSection, SectionType } from '../types';
 
 /**
  * Maps content channel IDs to their corresponding content types
@@ -36,6 +36,52 @@ const COLLECTION_TYPES_MAP = [
   'RESOURCE_COLLECTION',
   'CTA_COLLECTION',
 ] as const;
+
+/**
+ * Section types that participate in the carousel background alternation logic
+ */
+const CAROUSEL_COLLECTION_TYPES = [
+  'EVENT_COLLECTION',
+  'RESOURCE_COLLECTION',
+] as const;
+
+type CarouselCollectionType = (typeof CAROUSEL_COLLECTION_TYPES)[number];
+
+/**
+ * Computes alternating 'white' | 'gray' backgrounds for consecutive runs of
+ * EVENT_COLLECTION / RESOURCE_COLLECTION sections. A single isolated section
+ * stays 'white'; consecutive sections within a run alternate white → gray → …
+ * Any other section type between two collections breaks the run, restarting the
+ * alternation from 'white'.
+ */
+export function getCarouselCollectionBackgrounds(
+  sections: PageBuilderSection[],
+): Map<string, 'white' | 'gray'> {
+  const result = new Map<string, 'white' | 'gray'>();
+
+  const isCarouselType = (type: SectionType): type is CarouselCollectionType =>
+    (CAROUSEL_COLLECTION_TYPES as readonly string[]).includes(type);
+
+  let runIndex = 0;
+  let inRun = false;
+
+  for (let i = 0; i < sections.length; i++) {
+    const section = sections[i];
+
+    if (isCarouselType(section.type)) {
+      result.set(section.id, runIndex % 2 === 0 ? 'white' : 'gray');
+      runIndex++;
+      inRun = true;
+    } else {
+      if (inRun) {
+        runIndex = 0;
+        inRun = false;
+      }
+    }
+  }
+
+  return result;
+}
 
 type CollectionTypes = (typeof COLLECTION_TYPES_MAP)[number];
 

--- a/app/routes/page-builder/components/content-block/feature-section.tsx
+++ b/app/routes/page-builder/components/content-block/feature-section.tsx
@@ -87,12 +87,12 @@ export const FeatureSection: FC<{
         {(data.coverImage || data.featureVideo) &&
           data.imageLayout === 'LEFT' && <FeatureImage data={data} />}
         <div className={`flex-1 flex flex-col gap-5`}>
-          <h2 className='text-text-primary heading-h4 md:heading-h2'>
+          <h2 className='text-text-primary text-2xl md:text-4xl lg:text-[52px] font-extrabold'>
             {data.name}
           </h2>
           {data.subtitle && (
             <h4
-              className={`text-text-secondary text-lg font-bold uppercase mb-2 tracking-widest -mt-2 md:mt-0`}
+              className={`text-text-secondary text-base md:text-lg font-bold uppercase mb-2 tracking-widest -mt-2 md:mt-0`}
             >
               {data.subtitle}
             </h4>

--- a/app/routes/page-builder/page-builder-page.tsx
+++ b/app/routes/page-builder/page-builder-page.tsx
@@ -7,8 +7,12 @@ import { ContentBlock } from './components/content-block';
 import { ContentBlockData } from './types';
 import { ImageGallerySection } from './components/image-gallery';
 import { FAQsComponent } from './components/faq';
+import { getCarouselCollectionBackgrounds } from './components/builder-utils';
 
-export function renderSection(section: PageBuilderSection) {
+export function renderSection(
+  section: PageBuilderSection,
+  options?: { collectionBackground?: 'white' | 'gray' },
+) {
   const sectionName =
     section.titleOverride !== '' ? section.titleOverride : section.name;
 
@@ -24,6 +28,9 @@ export function renderSection(section: PageBuilderSection) {
             description={section.content}
             resources={section.collection || []}
             viewMoreLink={section.viewMoreLink || undefined}
+            className={
+              options?.collectionBackground === 'gray' ? 'bg-gray' : 'bg-white'
+            }
           />
         </div>
       );
@@ -84,9 +91,16 @@ export function renderSection(section: PageBuilderSection) {
 
 export function PageBuilderRoute() {
   const { sections } = useLoaderData<PageBuilderLoader>();
+  const backgrounds = getCarouselCollectionBackgrounds(sections);
 
   return (
-    <div className='w-full flex flex-col'>{sections.map(renderSection)}</div>
+    <div className='w-full flex flex-col'>
+      {sections.map((section) =>
+        renderSection(section, {
+          collectionBackground: backgrounds.get(section.id),
+        }),
+      )}
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary

Fixes carousel and feature content block presentation on page-builder-driven pages. Carousel navigation controls are corrected on small viewports when there are fewer than four items, consecutive resource/event collection sections alternate `white` / `gray` backgrounds for visual separation, and feature block headings use explicit responsive typography instead of heading utility classes that were sizing incorrectly.

## Screenshots

<img width="975" height="1023" alt="image" src="https://github.com/user-attachments/assets/aa7c4f01-d31e-465d-9d48-763e50c66f81" />

## Testing

You can use the following pages to test the updates:
* `/ministries/freedom-and-care` - Ministry Page example
* `/ministries/test` - Adjacent and different sized Collections example(can delete after testing)
- [x] Open a page builder page with two or more consecutive resource/event collection blocks — confirm backgrounds alternate white → gray → white within a run, and reset to white after a non-collection section (e.g. content block) between collections.
- [x] Open a page with a resource carousel and fewer than four items — confirm prev/next controls are visible on mobile/tablet and not clipped.
- [x] Open a page with a feature content block — confirm title scales (`text-2xl` → `text-4xl` → `text-[52px]`) and subtitle is `text-base` on mobile, `text-lg` on `md+`.
- [ ] No new linter errors/warnings. `pnpm check` and `pnpm test`

## Tickets

[CFDP-3952](https://christfellowshipchurch.atlassian.net/browse/CFDP-3952)
[CFDP-3953](https://christfellowshipchurch.atlassian.net/browse/CFDP-3953)

## Changes Made

### New Utilities

- `getCarouselCollectionBackgrounds` — `app/routes/page-builder/components/builder-utils.ts`  
  Computes alternating `'white' | 'gray'` backgrounds for consecutive runs of `EVENT_COLLECTION` and `RESOURCE_COLLECTION` sections; non-collection sections break the run and restart alternation from white. `CTA_COLLECTION` and other types do not participate.

### Route Implementation

- `app/routes/page-builder/page-builder-page.tsx` — `renderSection` accepts optional `collectionBackground`; page builder route passes computed backgrounds into resource collections.
- `app/routes/ministry-builder/ministry-builder-page.tsx` — applies carousel background alternation when rendering sections.
- `app/routes/locations/location-single/partials/tabs/families.tsx` — applies carousel background alternation for English and Spanish families content.

### Key Features

- **Carousel collection backgrounds:** Adjacent `RESOURCE_COLLECTION` / `EVENT_COLLECTION` blocks alternate white and gray; isolated collections stay white; gaps from other section types reset the pattern.
- **Carousel controls:** Nav row uses consistent spacing (`md:mt-14`, `px-4`); when fewer than four resources, controls stay visible on mobile/tablet (`flex md:hidden`) instead of being hidden on large breakpoints only.
- **Carousel section padding:** Removed extra large-breakpoint vertical padding (`lg:py-28`) on the carousel header container.
- **Feature content block typography:** Title and subtitle use explicit responsive font sizes for correct hierarchy across breakpoints.
- **Test coverage:** Nine unit tests document alternation rules, run breaks, and exclusion of `CTA_COLLECTION` from the pattern.

[CFDP-3952]: https://christfellowshipchurch.atlassian.net/browse/CFDP-3952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ