### PR TITLE
CFDP-3959 Clean up podcast links and subscription actions

### DIFF
--- a/app/routes/podcasts/all-podcasts/components/podcast-card.tsx
+++ b/app/routes/podcasts/all-podcasts/components/podcast-card.tsx
@@ -15,7 +15,6 @@ export function PodcastHubCard({ podcast, className = '' }: PodcastCardProps) {
     description,
     apple,
     spotify,
-    amazon,
     youtube,
     url,
     coverImage,
@@ -33,16 +32,13 @@ export function PodcastHubCard({ podcast, className = '' }: PodcastCardProps) {
       href: spotify,
     },
     {
-      label: 'Amazon Music',
-      icon: 'amazonMusic',
-      href: amazon,
-    },
-    {
       label: 'YouTube',
       icon: 'youtube',
       href: youtube,
     },
   ];
+
+  const subscriptionLinks = links.filter((link) => !!link.href);
 
   return (
     <div
@@ -72,34 +68,24 @@ export function PodcastHubCard({ podcast, className = '' }: PodcastCardProps) {
             </Button>
 
             <div className='flex gap-2'>
-              {links
-                .filter((link) => !!link.href)
-                .map((link, index) => (
-                  <Link
-                    key={index}
-                    to={link.href}
-                    target='_blank'
-                    className='flex flex-col items-center justify-center gap-1 bg-ocean rounded-lg size-[54px]'
-                  >
-                    <Icon
-                      name={
-                        link.icon as keyof typeof import('~/lib/icons').icons
-                      }
-                      color='white'
-                      size={link.icon === 'amazonMusic' ? 36 : 24}
-                      className={`${
-                        link.icon === 'amazonMusic' ? '-mt-1' : ''
-                      }`}
-                    />
-                    <p
-                      className={`text-[7px] font-extrabold text-white ${
-                        link.icon === 'amazonMusic' ? '-mt-2' : ''
-                      }`}
-                    >
-                      {link.label}
-                    </p>
-                  </Link>
-                ))}
+              {subscriptionLinks.map((link, index) => (
+                <Link
+                  key={index}
+                  to={link.href}
+                  target='_blank'
+                  rel='noopener noreferrer'
+                  className='flex flex-col items-center justify-center gap-1 bg-ocean rounded-lg size-[54px]'
+                >
+                  <Icon
+                    name={link.icon as keyof typeof import('~/lib/icons').icons}
+                    color='white'
+                    size={24}
+                  />
+                  <p className='text-[7px] font-extrabold text-white'>
+                    {link.label}
+                  </p>
+                </Link>
+              ))}
             </div>
           </div>
         </div>
@@ -124,7 +110,6 @@ export function PodcastHubCard({ podcast, className = '' }: PodcastCardProps) {
             <Button
               intent='secondary'
               href={url || ''}
-              target='_blank'
               linkClassName='w-full'
               className='w-full'
             >
@@ -132,24 +117,20 @@ export function PodcastHubCard({ podcast, className = '' }: PodcastCardProps) {
             </Button>
 
             <div className='flex gap-2'>
-              {links.map((link, index) => (
+              {subscriptionLinks.map((link, index) => (
                 <Link
                   key={index}
                   to={link.href}
                   target='_blank'
+                  rel='noopener noreferrer'
                   className='flex flex-col items-center justify-center gap-1 bg-ocean rounded-lg size-[72px]'
                 >
                   <Icon
                     name={link.icon as keyof typeof import('~/lib/icons').icons}
                     color='white'
-                    size={link.icon === 'amazonMusic' ? 50 : 36}
-                    className={`${link.icon === 'amazonMusic' ? '-mt-1' : ''}`}
+                    size={36}
                   />
-                  <p
-                    className={`text-[7px] font-extrabold text-white ${
-                      link.icon === 'amazonMusic' ? '-mt-2' : ''
-                    }`}
-                  >
+                  <p className='text-[7px] font-extrabold text-white'>
                     {link.label}
                   </p>
                 </Link>

--- a/app/routes/podcasts/podcast-show/partials/subscribe-section.partial.tsx
+++ b/app/routes/podcasts/podcast-show/partials/subscribe-section.partial.tsx
@@ -5,13 +5,11 @@ export const SubscribeSection = ({
   title = 'Subscribe and follow',
   apple,
   spotify,
-  amazon,
   youtube,
 }: {
   title?: string;
   apple: string;
   spotify: string;
-  amazon: string;
   youtube: string;
 }) => {
   const links = [
@@ -29,11 +27,6 @@ export const SubscribeSection = ({
       label: 'Spotify',
       icon: 'spotify',
       href: spotify,
-    },
-    {
-      label: 'Amazon Music',
-      icon: 'amazonMusic',
-      href: amazon,
     },
   ];
 
@@ -55,18 +48,12 @@ export const SubscribeSection = ({
                   <a
                     href={link.href}
                     target='_blank'
+                    rel='noopener noreferrer'
                     aria-label={`${link.label} Link`}
                   >
-                    <Icon
-                      name={link.icon as keyof typeof icons}
-                      size={link.icon === 'amazonMusic' ? 62 : 52}
-                    />
+                    <Icon name={link.icon as keyof typeof icons} size={52} />
                   </a>
-                  <p
-                    className={`text-[10px] md:text-xs text-center font-extrabold ${
-                      link.icon === 'amazonMusic' ? '-mt-3' : ''
-                    }`}
-                  >
+                  <p className='text-[10px] md:text-xs text-center font-extrabold'>
                     {link.label}
                   </p>
                 </div>

--- a/app/routes/podcasts/podcast-show/podcasts-show-page.tsx
+++ b/app/routes/podcasts/podcast-show/podcasts-show-page.tsx
@@ -16,7 +16,6 @@ export function PodcastsShowPage() {
       <SubscribeSection
         apple={podcast.apple}
         spotify={podcast.spotify}
-        amazon={podcast.amazon}
         youtube={podcast.youtube}
       />
       {featureBlocks &&


### PR DESCRIPTION
## Summary
- remove Amazon Music from podcast hub and show subscribe sections
- fix mobile podcast cards rendering invalid/empty links
- add noopener noreferrer to external podcast platform links
- clean up unused Amazon props after removing support

## Testing
- verified subscription link rendering now filters empty links on desktop and mobile
- verified podcast show page no longer references Amazon Music
- unable to perform visual QA against Figma or responsive browser testing from connector environment

## Jira
CFDP-3959