### PR TITLE
CFDP-3959: Podcasts cleanup — links, Amazon mobile, spacing

### DIFF
--- a/app/lib/__tests__/utils.test.ts
+++ b/app/lib/__tests__/utils.test.ts
@@ -11,6 +11,7 @@ import {
   isValidZip,
   latLonDistance,
   getFirstParagraph,
+  getFirstSentence,
   parseRockKeyValueList,
   parseRockValueList,
   formattedServiceTimes,
@@ -294,6 +295,29 @@ describe('getFirstParagraph', () => {
 
   it('returns empty string for empty input', () => {
     expect(getFirstParagraph('')).toBe('');
+  });
+});
+
+describe('getFirstSentence', () => {
+  it('extracts the first sentence from HTML', () => {
+    const html =
+      '<p>First sentence. Second sentence.</p><p>Third paragraph.</p>';
+    expect(getFirstSentence(html)).toBe('First sentence.');
+  });
+
+  it('strips nested HTML tags within the sentence', () => {
+    const html = '<p>Hello <strong>world</strong>. More text.</p>';
+    expect(getFirstSentence(html)).toBe('Hello world.');
+  });
+
+  it('returns full plain text when no sentence end exists', () => {
+    expect(getFirstSentence('<p>No ending punctuation</p>')).toBe(
+      'No ending punctuation',
+    );
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(getFirstSentence('')).toBe('');
   });
 });
 

--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -1,3 +1,4 @@
+import { trimRemovingInvisibleUnicode } from '~/lib/text-content';
 import { clsx, type ClassValue } from 'clsx';
 import camelCase from 'lodash/camelCase';
 import mapKeys from 'lodash/mapKeys';
@@ -275,6 +276,43 @@ export const getFirstParagraph = (html: string): string => {
   const doc = parser.parseFromString(html, 'text/html');
   const firstParagraph = doc.querySelector('p');
   return firstParagraph?.textContent || '';
+};
+
+const htmlToPlainText = (html: string): string => {
+  if (!html) return '';
+
+  if (typeof window === 'undefined') {
+    return trimRemovingInvisibleUnicode(
+      html
+        .replace(/<script[\s\S]*?<\/script>/gi, '')
+        .replace(/<style[\s\S]*?<\/style>/gi, '')
+        .replace(/<br\s*\/?>/gi, ' ')
+        .replace(/<\/\s*(?:p|div|h[1-6]|li|tr|td|th|blockquote)\s*>/gi, ' ')
+        .replace(/<[^>]+>/g, '')
+        .replace(/&nbsp;/gi, ' ')
+        .replace(/&#(?:160|x0*A0);/gi, ' ')
+        .replace(/\s+/g, ' '),
+    );
+  }
+
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(html, 'text/html');
+  return trimRemovingInvisibleUnicode(
+    (doc.body.textContent || '').replace(/\s+/g, ' '),
+  );
+};
+
+/**
+ * Get the first sentence of plain text extracted from HTML
+ * @param html - The HTML string to parse
+ * @returns The first sentence, or the full plain text if no sentence end is found
+ */
+export const getFirstSentence = (html: string): string => {
+  const text = htmlToPlainText(html);
+  if (!text) return '';
+
+  const match = text.match(/^[^.!?]+[.!?]/);
+  return match ? match[0].trim() : text;
 };
 
 export const parseRockKeyValueList = (

--- a/app/routes/podcasts/all-podcasts/all-podcasts-page.tsx
+++ b/app/routes/podcasts/all-podcasts/all-podcasts-page.tsx
@@ -11,7 +11,7 @@ export function AllPodcastsPage() {
   return (
     <div className='flex flex-col items-center'>
       <DynamicHero imagePath={getImageUrl('3143814')} customTitle='Podcasts' />
-      <div className='py-6 md:py-20 w-full'>
+      <div className='w-full'>
         <div className='flex flex-col'>
           {podcastShows.map((podcast: PodcastShow, index: number) => (
             <PodcastHubCard

--- a/app/routes/podcasts/all-podcasts/all-podcasts-page.tsx
+++ b/app/routes/podcasts/all-podcasts/all-podcasts-page.tsx
@@ -11,7 +11,7 @@ export function AllPodcastsPage() {
   return (
     <div className='flex flex-col items-center'>
       <DynamicHero imagePath={getImageUrl('3143814')} customTitle='Podcasts' />
-      <div className='py-10 md:py-20 w-full'>
+      <div className='py-6 md:py-20 w-full'>
         <div className='flex flex-col'>
           {podcastShows.map((podcast: PodcastShow, index: number) => (
             <PodcastHubCard

--- a/app/routes/podcasts/all-podcasts/components/podcast-card.tsx
+++ b/app/routes/podcasts/all-podcasts/components/podcast-card.tsx
@@ -1,11 +1,8 @@
 import type { PodcastShow } from '../../types';
 import { Button } from '~/primitives/button/button.primitive';
 import Icon from '~/primitives/icon';
-import HtmlRenderer from '~/primitives/html-renderer';
-import {
-  getPodcastShowHref,
-  hasValidHref,
-} from '../../utils/podcast-links';
+import { getPodcastShowHref, hasValidHref } from '../../utils/podcast-links';
+import { cn, getFirstSentence } from '~/lib/utils';
 
 type PodcastCardProps = {
   podcast: PodcastShow;
@@ -17,6 +14,27 @@ type PlatformLink = {
   icon: string;
   href: string;
 };
+
+function PodcastCoverImage({
+  src,
+  alt,
+  className,
+}: {
+  src: string;
+  alt: string;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        'w-full aspect-video shrink-0 self-start overflow-hidden rounded-lg',
+        className,
+      )}
+    >
+      <img src={src} alt={alt} className='h-full w-full object-cover' />
+    </div>
+  );
+}
 
 function PlatformLinkButton({
   link,
@@ -67,6 +85,7 @@ export function PodcastHubCard({ podcast, className = '' }: PodcastCardProps) {
   } = podcast;
 
   const showHref = getPodcastShowHref(url);
+  const descriptionPreview = getFirstSentence(description);
 
   const platformLinks: PlatformLink[] = [
     {
@@ -97,22 +116,20 @@ export function PodcastHubCard({ podcast, className = '' }: PodcastCardProps) {
     >
       {/* Desktop */}
       <div className='hidden relative md:flex flex-col lg:flex-row gap-8 w-full max-w-screen-content mx-auto'>
-        {/* Image */}
-        <img
+        <PodcastCoverImage
           src={coverImage}
           alt={title}
-          className='object-cover bg-cover w-full h-[360px] lg:h-[282px] lg:w-[480px] xl:w-[590px] xl:h-[350px] rounded-lg'
+          className={cn('max-w-[550px]', 'lg:w-[480px]', 'xl:w-[590px]')}
         />
 
         {/* Content */}
         <div className='flex flex-col justify-center gap-4'>
           <h3 className='text-[32px] font-extrabold'>{title}</h3>
-          <p className='text-xl text-[#767676] lg:max-w-[540px]'>
-            <HtmlRenderer
-              html={description}
-              className='text-xl text-[#767676] lg:max-w-[540px]'
-            />
-          </p>
+          {descriptionPreview ? (
+            <p className='text-xl text-[#767676] lg:max-w-[540px]'>
+              {descriptionPreview}
+            </p>
+          ) : null}
           <div className='flex items-center gap-8 w-full'>
             {showHref ? (
               <Button intent='secondary' href={showHref} className='h-full'>
@@ -137,22 +154,13 @@ export function PodcastHubCard({ podcast, className = '' }: PodcastCardProps) {
 
       {/* Mobile */}
       <div className='relative w-full max-w-screen-content mx-auto md:hidden'>
-        <div className='flex flex-col justify-center gap-2'>
+        <div className='flex flex-col justify-center gap-4'>
           <div className='flex flex-col gap-4'>
-            <div className='flex flex-col gap-2'>
-              <h3 className='text-[32px] font-extrabold'>{title}</h3>
-              <p className='text-sm text-[#767676]'>
-                <HtmlRenderer
-                  html={description}
-                  className='text-sm text-[#767676]'
-                />
-              </p>
-            </div>
-            <img
-              src={coverImage}
-              alt={title}
-              className='object-cover bg-cover w-full h-[360px] rounded-lg'
-            />
+            <h3 className='text-[32px] font-extrabold'>{title}</h3>
+            {descriptionPreview ? (
+              <p className='text-[#767676]'>{descriptionPreview}</p>
+            ) : null}
+            <PodcastCoverImage src={coverImage} alt={title} />
           </div>
 
           <div className='flex flex-col items-center gap-6 w-full'>

--- a/app/routes/podcasts/all-podcasts/components/podcast-card.tsx
+++ b/app/routes/podcasts/all-podcasts/components/podcast-card.tsx
@@ -1,13 +1,58 @@
 import type { PodcastShow } from '../../types';
 import { Button } from '~/primitives/button/button.primitive';
 import Icon from '~/primitives/icon';
-import { Link } from 'react-router-dom';
 import HtmlRenderer from '~/primitives/html-renderer';
+import {
+  getPodcastShowHref,
+  hasValidHref,
+} from '../../utils/podcast-links';
 
 type PodcastCardProps = {
   podcast: PodcastShow;
   className?: string;
 };
+
+type PlatformLink = {
+  label: string;
+  icon: string;
+  href: string;
+};
+
+function PlatformLinkButton({
+  link,
+  sizeClass,
+  iconSize,
+  labelClass,
+}: {
+  link: PlatformLink;
+  sizeClass: string;
+  iconSize: number;
+  labelClass: string;
+}) {
+  return (
+    <a
+      href={link.href}
+      target='_blank'
+      rel='noopener noreferrer'
+      aria-label={`${link.label} Link`}
+      className={`flex flex-col items-center justify-center gap-1 bg-ocean rounded-lg ${sizeClass}`}
+    >
+      <Icon
+        name={link.icon as keyof typeof import('~/lib/icons').icons}
+        color='white'
+        size={iconSize}
+        className={link.icon === 'amazonMusic' ? '-mt-1' : ''}
+      />
+      <p
+        className={`text-[7px] font-extrabold text-white ${labelClass} ${
+          link.icon === 'amazonMusic' ? '-mt-2' : ''
+        }`}
+      >
+        {link.label}
+      </p>
+    </a>
+  );
+}
 
 export function PodcastHubCard({ podcast, className = '' }: PodcastCardProps) {
   const {
@@ -21,7 +66,9 @@ export function PodcastHubCard({ podcast, className = '' }: PodcastCardProps) {
     coverImage,
   } = podcast;
 
-  const links = [
+  const showHref = getPodcastShowHref(url);
+
+  const platformLinks: PlatformLink[] = [
     {
       label: 'Apple Music',
       icon: 'appleLogo',
@@ -42,11 +89,11 @@ export function PodcastHubCard({ podcast, className = '' }: PodcastCardProps) {
       icon: 'youtube',
       href: youtube,
     },
-  ];
+  ].filter((link) => hasValidHref(link.href));
 
   return (
     <div
-      className={`flex relative overflow-hidden ${className} py-12 group w-full px-18`}
+      className={`flex relative overflow-hidden ${className} py-8 md:py-12 group w-full px-6 md:px-18`}
     >
       {/* Desktop */}
       <div className='hidden relative md:flex flex-col lg:flex-row gap-8 w-full max-w-screen-content mx-auto'>
@@ -67,39 +114,22 @@ export function PodcastHubCard({ podcast, className = '' }: PodcastCardProps) {
             />
           </p>
           <div className='flex items-center gap-8 w-full'>
-            <Button intent='secondary' href={url || ''} className='h-full'>
-              Episodes and More
-            </Button>
+            {showHref ? (
+              <Button intent='secondary' href={showHref} className='h-full'>
+                Episodes and More
+              </Button>
+            ) : null}
 
             <div className='flex gap-2'>
-              {links
-                .filter((link) => !!link.href)
-                .map((link, index) => (
-                  <Link
-                    key={index}
-                    to={link.href}
-                    target='_blank'
-                    className='flex flex-col items-center justify-center gap-1 bg-ocean rounded-lg size-[54px]'
-                  >
-                    <Icon
-                      name={
-                        link.icon as keyof typeof import('~/lib/icons').icons
-                      }
-                      color='white'
-                      size={link.icon === 'amazonMusic' ? 36 : 24}
-                      className={`${
-                        link.icon === 'amazonMusic' ? '-mt-1' : ''
-                      }`}
-                    />
-                    <p
-                      className={`text-[7px] font-extrabold text-white ${
-                        link.icon === 'amazonMusic' ? '-mt-2' : ''
-                      }`}
-                    >
-                      {link.label}
-                    </p>
-                  </Link>
-                ))}
+              {platformLinks.map((link, index) => (
+                <PlatformLinkButton
+                  key={index}
+                  link={link}
+                  sizeClass='size-[54px]'
+                  iconSize={link.icon === 'amazonMusic' ? 36 : 24}
+                  labelClass=''
+                />
+              ))}
             </div>
           </div>
         </div>
@@ -111,7 +141,12 @@ export function PodcastHubCard({ podcast, className = '' }: PodcastCardProps) {
           <div className='flex flex-col gap-4'>
             <div className='flex flex-col gap-2'>
               <h3 className='text-[32px] font-extrabold'>{title}</h3>
-              <p className='text-sm text-[#767676]'>{description}</p>
+              <p className='text-sm text-[#767676]'>
+                <HtmlRenderer
+                  html={description}
+                  className='text-sm text-[#767676]'
+                />
+              </p>
             </div>
             <img
               src={coverImage}
@@ -120,41 +155,31 @@ export function PodcastHubCard({ podcast, className = '' }: PodcastCardProps) {
             />
           </div>
 
-          <div className='flex flex-col items-center gap-8 w-full'>
-            <Button
-              intent='secondary'
-              href={url || ''}
-              target='_blank'
-              linkClassName='w-full'
-              className='w-full'
-            >
-              Episodes and More
-            </Button>
+          <div className='flex flex-col items-center gap-6 w-full'>
+            {showHref ? (
+              <Button
+                intent='secondary'
+                href={showHref}
+                linkClassName='w-full'
+                className='w-full'
+              >
+                Episodes and More
+              </Button>
+            ) : null}
 
-            <div className='flex gap-2'>
-              {links.map((link, index) => (
-                <Link
-                  key={index}
-                  to={link.href}
-                  target='_blank'
-                  className='flex flex-col items-center justify-center gap-1 bg-ocean rounded-lg size-[72px]'
-                >
-                  <Icon
-                    name={link.icon as keyof typeof import('~/lib/icons').icons}
-                    color='white'
-                    size={link.icon === 'amazonMusic' ? 50 : 36}
-                    className={`${link.icon === 'amazonMusic' ? '-mt-1' : ''}`}
+            {platformLinks.length > 0 ? (
+              <div className='flex gap-2'>
+                {platformLinks.map((link, index) => (
+                  <PlatformLinkButton
+                    key={index}
+                    link={link}
+                    sizeClass='size-[72px]'
+                    iconSize={link.icon === 'amazonMusic' ? 50 : 36}
+                    labelClass=''
                   />
-                  <p
-                    className={`text-[7px] font-extrabold text-white ${
-                      link.icon === 'amazonMusic' ? '-mt-2' : ''
-                    }`}
-                  >
-                    {link.label}
-                  </p>
-                </Link>
-              ))}
-            </div>
+                ))}
+              </div>
+            ) : null}
           </div>
         </div>
       </div>

--- a/app/routes/podcasts/podcast-episode/components/hero-mobile-content.component.tsx
+++ b/app/routes/podcasts/podcast-episode/components/hero-mobile-content.component.tsx
@@ -11,7 +11,7 @@ export const HeroMobileContent = () => {
   return (
     <div className='w-full bg-white content-padding md:hidden'>
       <div className='flex flex-col max-w-screen-content mx-auto'>
-        <div className='flex flex-col gap-8 pt-8 text-text-primary font-medium'>
+        <div className='flex flex-col gap-6 pt-6 text-text-primary font-medium'>
           <div className='flex flex-col gap-1'>
             <h1
               className='max-w-2xl font-extrabold text-2xl text-pretty leading-tight tracking-tight'
@@ -31,7 +31,7 @@ export const HeroMobileContent = () => {
           {/* TODO: Add share functionality */}
           <IconButton withRotatingArrow={true}>Share this episode</IconButton>
         </div>
-        <div className='h-[1px] opacity-10 bg-black/75 mt-12' />
+        <div className='h-[1px] opacity-10 bg-black/75 mt-8' />
       </div>
     </div>
   );

--- a/app/routes/podcasts/podcast-episode/components/more-episodes-search.tsx
+++ b/app/routes/podcasts/podcast-episode/components/more-episodes-search.tsx
@@ -81,7 +81,7 @@ export const MoreEpisodesSearch = ({
       {/* Episodes Section - Only render if there are hits */}
       <HitsWrapper>
         <div className='w-full bg-white content-padding'>
-          <div className='flex flex-col gap-8 md:gap-7 max-w-screen-content mx-auto py-16 md:py-20'>
+          <div className='flex flex-col gap-6 md:gap-7 max-w-screen-content mx-auto py-10 md:py-20'>
             <h2 className='text-[28px] font-extrabold'>More in this season</h2>
 
             <Hits

--- a/app/routes/podcasts/podcast-episode/partials/episode-notes.partial.tsx
+++ b/app/routes/podcasts/podcast-episode/partials/episode-notes.partial.tsx
@@ -11,7 +11,7 @@ export function EpisodeNotes({
 }) {
   return (
     <div className='w-full bg-white content-padding'>
-      <div className='flex flex-col gap-16 max-w-[1150px] mx-auto py-12 md:py-20'>
+      <div className='flex flex-col gap-10 md:gap-16 max-w-[1150px] mx-auto py-8 md:py-20'>
         <div>
           <h2 className='text-[18px] md:text-[32px] font-extrabold'>
             Episode Notes

--- a/app/routes/podcasts/podcast-show/components/hero-content.component.tsx
+++ b/app/routes/podcasts/podcast-show/components/hero-content.component.tsx
@@ -15,7 +15,7 @@ export const HeroContent = ({
   latestEpisode: PodcastEpisode;
 }) => {
   return (
-    <div className='flex px-6 md:px-16 pt-16 pb-6 md:pb-16 md:pt-24'>
+    <div className='flex px-6 md:px-16 pt-10 pb-4 md:pb-16 md:pt-24'>
       <div className='grid grid-cols-1 md:grid-cols-2 gap-8 mx-auto w-full max-w-[1438px]'>
         <div className='flex flex-col justify-center order-2 md:order-1'>
           {title && (

--- a/app/routes/podcasts/podcast-show/partials/all-seasons.partials.tsx
+++ b/app/routes/podcasts/podcast-show/partials/all-seasons.partials.tsx
@@ -8,7 +8,7 @@ export const AllSeasons = () => {
 
   return (
     <div className='w-full bg-[#F5F5FA] content-padding'>
-      <div className='max-w-screen-content mx-auto py-16 md:py-28'>
+      <div className='max-w-screen-content mx-auto py-10 md:py-28'>
         <div className='flex flex-col gap-8'>
           <h2 className='text-[28px] font-extrabold'>All Seasons</h2>
 

--- a/app/routes/podcasts/podcast-show/partials/latests-episodes.partials.tsx
+++ b/app/routes/podcasts/podcast-show/partials/latests-episodes.partials.tsx
@@ -9,7 +9,7 @@ export const LatestEpisodes = () => {
 
   return (
     <div className='w-full bg-white'>
-      <div className='py-16 md:py-28'>
+      <div className='py-10 md:py-28'>
         <CardCarouselSection
           title='Latest Episodes'
           CardComponent={PodcastEpisodeCard}

--- a/app/routes/podcasts/podcast-show/partials/subscribe-section.partial.tsx
+++ b/app/routes/podcasts/podcast-show/partials/subscribe-section.partial.tsx
@@ -39,8 +39,8 @@ export const SubscribeSection = ({
 
   return (
     <div className='w-full bg-linear-to-br from-[#1C3647] to-navy content-padding'>
-      <div className='max-w-screen-content mx-auto py-16'>
-        <div className='flex flex-col items-center gap-8 text-white'>
+      <div className='max-w-screen-content mx-auto py-10 md:py-16'>
+        <div className='flex flex-col items-center gap-6 md:gap-8 text-white'>
           <h2 className='text-[24px] md:text-[28px] font-extrabold leading-none'>
             {title}
           </h2>
@@ -55,6 +55,7 @@ export const SubscribeSection = ({
                   <a
                     href={link.href}
                     target='_blank'
+                    rel='noopener noreferrer'
                     aria-label={`${link.label} Link`}
                   >
                     <Icon

--- a/app/routes/podcasts/utils/podcast-links.ts
+++ b/app/routes/podcasts/utils/podcast-links.ts
@@ -1,0 +1,27 @@
+export function isExternalHref(href: string): boolean {
+  return href.startsWith('http://') || href.startsWith('https://');
+}
+
+export function hasValidHref(href?: string): boolean {
+  return Boolean(href?.trim());
+}
+
+/** Normalizes Rock podcast show URL values to in-app routes. */
+export function getPodcastShowHref(url: string): string {
+  if (!url?.trim()) {
+    return '';
+  }
+
+  const trimmed = url.trim();
+
+  if (isExternalHref(trimmed)) {
+    return trimmed;
+  }
+
+  if (trimmed.startsWith('/podcasts/')) {
+    return trimmed;
+  }
+
+  const slug = trimmed.replace(/^\/+/, '').replace(/^podcasts\/?/, '');
+  return slug ? `/podcasts/${slug}` : '/podcasts';
+}


### PR DESCRIPTION
## Summary

Fixes the All Podcasts hub and related show/episode pages for broken internal links, incorrect new-tab behavior, Amazon Music showing without a URL on mobile, excessive vertical padding on smaller viewports, and hub card copy/layout polish.

## Screenshots

_Manual QA screenshots recommended for All Podcasts (mobile + desktop) and a show page with/without Amazon Music URL._

## Testing

- [x] `pnpm lint` — run locally (requires Node 22+ per project pnpm setup)
- [x] Manual mobile QA on `/podcasts` and representative show/episode pages

**Verification steps:**

1. Open `/podcasts` on mobile width — confirm "Episodes and More" stays in same tab and routes to `/podcasts/{show-slug}`.
2. On a show without Amazon Music in Rock — confirm Amazon icon is hidden on mobile and desktop.
3. On a show with Amazon — confirm icon links out in a new tab.
4. Confirm Apple/Spotify/YouTube still open externally in new tabs.
5. Confirm hub cards show only the first sentence of the show description (plain text, no HTML).
6. Confirm cover images use consistent aspect-video sizing on mobile and desktop.
7. Spot-check reduced spacing on All Podcasts cards, Latest Episodes, All Seasons, Subscribe, and episode notes sections.

## Tickets

CFDP-3959

## Changes Made

### Shared utilities

- `app/routes/podcasts/utils/podcast-links.ts` — `getPodcastShowHref`, `isExternalHref`, `hasValidHref` for normalizing Rock show URLs and filtering platform links
- `app/lib/utils.ts` — `getFirstSentence` to extract plain-text first sentence from HTML descriptions (SSR-safe)
- `app/lib/__tests__/utils.test.ts` — tests for `getFirstSentence`

### All Podcasts hub

- `app/routes/podcasts/all-podcasts/components/podcast-card.tsx` — fixed hub links; platform icons use external `<a>` tags; Amazon only when href exists; first-sentence description preview; `PodcastCoverImage` with aspect-video layout; tighter mobile spacing
- `app/routes/podcasts/all-podcasts/all-podcasts-page.tsx` — removed duplicate list wrapper padding (spacing handled per card)

### Show & episode pages

- `app/routes/podcasts/podcast-show/partials/*` — tighter mobile section spacing (latest episodes, all seasons, subscribe, hero)
- `app/routes/podcasts/podcast-episode/partials/episode-notes.partial.tsx` — tighter mobile spacing
- `app/routes/podcasts/podcast-episode/components/hero-mobile-content.component.tsx` — tighter mobile hero spacing
- `app/routes/podcasts/podcast-episode/components/more-episodes-search.tsx` — tighter mobile spacing

### Key behaviors

- "Episodes and More" uses normalized internal `/podcasts/...` paths (external URLs unchanged)
- Platform subscribe icons use `<a target="_blank" rel="noopener noreferrer">` and only render when href is present
- Mobile Amazon bug fixed by sharing the same `hasValidHref` filter as desktop
- Mobile internal CTA no longer forced to `target="_blank"`
- Reduced `py`/`px`/`gap` on podcast sections for smaller breakpoints (desktop spacing preserved)