### PR TITLE
Devo, SEO & Group Finder Hero Cleanup

### DIFF
--- a/app/routes/daily-devo/loader.tsx
+++ b/app/routes/daily-devo/loader.tsx
@@ -80,6 +80,12 @@ const fetchDailyDevo = async () => {
   return validItems[0]; // Return the most recent valid item
 };
 
+const normalizeDailyDevoContent = (content: string) =>
+  content.replace(
+    'J*esus, search my heart, and show me if I’m treating anyone like my enemy.*',
+    '*Jesus, search my heart, and show me if I’m treating anyone like my enemy.*',
+  );
+
 const avatars = [
   { src: 'https://picsum.photos/id/1011/70/70', alt: 'Avatar 1' },
   { src: 'https://picsum.photos/id/1012/70/70', alt: 'Avatar 2' },
@@ -101,7 +107,7 @@ export const loader: LoaderFunction = async (): Promise<LoaderReturnType> => {
 
   const dailyDevo = {
     title: dailyDevoRockData.title,
-    content: dailyDevoRockData.content,
+    content: normalizeDailyDevoContent(dailyDevoRockData.content),
     startDateTime: dailyDevoRockData.startDateTime,
     wistiaId: dailyDevoRockData.attributeValues.media.value,
     coverImage: await createImageUrlFromGuid(

--- a/app/routes/daily-devo/partials/never-miss-a-daily.tsx
+++ b/app/routes/daily-devo/partials/never-miss-a-daily.tsx
@@ -54,13 +54,13 @@ const floatingCardData: FloatingCardType[] = [
     icon: 'handsPraying',
   },
   {
-    title: 'What are your grateful for?',
+    title: 'What are you grateful for?',
     subtitle: 'Practice Gratitude',
     icon: 'handsClapping',
   },
   {
     title: 'People are journaling',
-    subtitle: 'Ready Scripture',
+    subtitle: 'Read Scripture',
     icon: 'bookOpenText',
   },
 ];

--- a/app/routes/group-finder/group-finder.tsx
+++ b/app/routes/group-finder/group-finder.tsx
@@ -1,6 +1,10 @@
 import { GroupSearch } from './partials/group-search.partial';
 import { FinderHero } from '../../components/finders/hero';
 
+const helpFindGroupUrl = 'https://rock.gocf.org/page/2113';
+const leadGroupUrl =
+  'https://rock.christfellowship.church/dreamteam/locations/opportunities/ministries?AreaId=2030&SetContext=Rock.Model.Campus2&CampusId=2';
+
 export function GroupFinderPage() {
   return (
     <div className='flex flex-col min-h-svh'>
@@ -16,13 +20,13 @@ export function GroupFinderPage() {
             desktopDescription='No matter where you are in life or your journey with God, Groups connect you with people who encourage you, support you, and help you grow. Find a group today that will help you live the full life God intended for you.'
             ctas={[
               {
-                href: '/connect-card',
+                href: helpFindGroupUrl,
                 title: 'Help me find a group',
                 intent: 'secondaryWhite',
                 className: 'text-base font-normal',
               },
               {
-                href: '/group-finder',
+                href: leadGroupUrl,
                 title: 'Lead a group',
                 intent: 'primary',
                 className:
@@ -42,13 +46,13 @@ export function GroupFinderPage() {
             desktopDescription='No matter where you are in life or your journey with God, Groups connect you with people who encourage you, support you, and help you grow. Find a group today that will help you live the full life God intended for you.'
             ctas={[
               {
-                href: '/connect-card',
+                href: helpFindGroupUrl,
                 title: 'Help me find a group',
                 intent: 'white',
                 className: 'text-base font-normal',
               },
               {
-                href: '/group-finder',
+                href: leadGroupUrl,
                 title: 'Lead a group',
                 intent: 'primary',
                 className:

--- a/app/routes/locations/location-single/location-single-data.tsx
+++ b/app/routes/locations/location-single/location-single-data.tsx
@@ -148,7 +148,7 @@ export const englishCampusAmenities: CampusAmenity[] = [
     icon: 'handicap',
   },
   {
-    title: 'Helpful Greeters & Ushers',
+    title: 'Welcoming Team of Volunteers',
     icon: 'happy',
   },
   {
@@ -183,7 +183,7 @@ export const spanishCampusAmenities: CampusAmenity[] = [
     icon: 'handicap',
   },
   {
-    title: 'Anfitriones y Acomodadores Serviciales',
+    title: 'Equipo de Voluntarios Amigables',
     icon: 'happy',
   },
   {

--- a/app/routes/ministry-builder/meta.tsx
+++ b/app/routes/ministry-builder/meta.tsx
@@ -10,13 +10,14 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
     });
   }
   const { title, content } = data;
+  const ministryTitle = title?.includes('Ministry') ? title : `${title} Ministry`;
   const description = content
     ? content
         .replace(/<[^>]*>/g, '')
         .substring(0, 160)
         .trim() + (content.length > 160 ? '...' : '')
-    : `Learn more about ${title}'s Ministry at Christ Fellowship Church`;
-  const metaTitle = title ? `${title}'s Ministry` : 'Ministry';
+    : `Learn more about ${ministryTitle} at Christ Fellowship Church`;
+  const metaTitle = title ? ministryTitle : 'Ministry';
   return createMeta({
     title: metaTitle,
     description,

--- a/app/routes/ministry-builder/meta.tsx
+++ b/app/routes/ministry-builder/meta.tsx
@@ -10,7 +10,9 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
     });
   }
   const { title, content } = data;
-  const ministryTitle = title?.includes('Ministry') ? title : `${title} Ministry`;
+  const ministryTitle = title?.includes('Ministry')
+    ? title
+    : `${title} Ministry`;
   const description = content
     ? content
         .replace(/<[^>]*>/g, '')

--- a/app/routes/yes/components/yes-devotional-hero.component.tsx
+++ b/app/routes/yes/components/yes-devotional-hero.component.tsx
@@ -42,15 +42,15 @@ export const YesHero = ({ isSpanish }: { isSpanish?: boolean }) => {
 
 const heroCardData: { link: string; copy: string }[] = [
   {
-    link: googleLink,
+    link: googleLink, // TODO: Change to the correct link when available
     copy: 'A two-week course to start your relationship with Jesus.',
   },
   {
-    link: googleLink,
+    link: isAppleDevice() ? appleLink : googleLink,
     copy: 'Access resources, submit prayers, & get involved in our app',
   },
   {
-    link: googleLink,
+    link: 'https://www.bible.com/app',
     copy: 'Download the free Bible App from YouVersion',
   },
 ];

--- a/app/routes/yes/components/yes-devotional-hero.component.tsx
+++ b/app/routes/yes/components/yes-devotional-hero.component.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router';
+import { appleLink, googleLink, isAppleDevice } from '~/lib/utils';
 import { Icon } from '~/primitives/icon/icon';
 
 export const YesHero = ({ isSpanish }: { isSpanish?: boolean }) => {
@@ -42,38 +42,44 @@ export const YesHero = ({ isSpanish }: { isSpanish?: boolean }) => {
 
 const heroCardData: { link: string; copy: string }[] = [
   {
-    link: '/app',
+    link: googleLink,
     copy: 'A two-week course to start your relationship with Jesus.',
   },
   {
-    link: '/app',
+    link: googleLink,
     copy: 'Access resources, submit prayers, & get involved in our app',
   },
   {
-    link: '/app',
+    link: googleLink,
     copy: 'Download the free Bible App from YouVersion',
   },
 ];
 
 const spanishHeroCardData: { link: string; copy: string }[] = [
   {
-    link: '/app',
+    link: googleLink,
     copy: 'Un curso de dos semanas para comenzar tu relación con Jesús.',
   },
   {
-    link: '/app',
+    link: googleLink,
     copy: 'Accede a recursos, envía oraciones y participa en nuestra app',
   },
   {
-    link: '/app',
+    link: googleLink,
     copy: 'Descarga la app de la Biblia YouVersion gratis',
   },
 ];
 
 const HeroCard = ({ copy, link }: { copy: string; link: string }) => {
   return (
-    <Link
-      to={link}
+    <a
+      href={link}
+      target='_blank'
+      rel='noopener noreferrer'
+      onClick={(event) => {
+        event.preventDefault();
+        window.open(isAppleDevice() ? appleLink : googleLink, '_blank');
+      }}
       className='bg-white lg:bg-transparent relative flex justify-between items-center lg:justify-center gap-4 border-2 border-white w-full lg:max-w-[200px] pl-4 pr-3 lg:px-2 pt-2 pb-2 lg:pt-8 lg:pb-14 rounded-[36px] group hover:bg-white transition-all duration-400 cursor-pointer'
     >
       <p className='max-w-[85%] md:max-w-[92%] lg:max-w-none lg:text-lg lg:text-center text-text-secondary lg:text-[#FAFAFC] font-semibold group-hover:text-text-secondary transition-all duration-400'>
@@ -83,6 +89,6 @@ const HeroCard = ({ copy, link }: { copy: string; link: string }) => {
         name='arrowRight'
         className='lg:absolute right-auto -bottom-5 text-white bg-navy rounded-full size-10 p-[2px] lg:-rotate-45 group-hover:rotate-0 transition-all duration-400'
       />
-    </Link>
+    </a>
   );
 };


### PR DESCRIPTION
## Summary

Fixes a set of small Devo, SEO, and Group Finder hero cleanup issues.

- Fixed Daily Devo copy typos and normalized one malformed italic prayer line.
- Updated You Said Yes devotional hero cards to link to the app store URLs instead of broken `/app` links.
- Cleaned up Ministry page SEO metadata so dynamic titles use `Kids Ministry` style wording instead of `Kids's Ministry`.
- Updated Group Finder hero CTAs to confirmed Rock destinations.
- Updated Campus Amenities wording to avoid “Greeters & Ushers” language.

## Screenshots

N/A - copy, metadata, and link cleanup only.

## Testing
- [x] Verified Group Finder desktop and mobile hero CTA configs use the same confirmed URLs
- [x] Confirm no more typos in Daily Devo
- [ ] Confirm You Said Yes devotional hero cards are linking to the app store URLs instead of broken `/app` links.
- [x] Confirm Ministry page SEO metadata is cleaned up so dynamic titles use `Kids Ministry` style wording instead of `Kids's Ministry`.
- [x] Confirm Campus Amenities wording have been updated to avoid “Greeters & Ushers” language.
- [x] No new linter errors or warnings

## Tickets
[CFDP-3960](https://christfellowshipchurch.atlassian.net/browse/CFDP-3960)
[CFDP-3961](https://christfellowshipchurch.atlassian.net/browse/CFDP-3961)
[CFDP-3964](https://christfellowshipchurch.atlassian.net/browse/CFDP-3964)

## Changes Made

### New Components Added

- None

### New Utilities

- Added a small `normalizeDailyDevoContent` helper in `app/routes/daily-devo/loader.tsx` to fix the known malformed prayer italic text before rendering.

### New Assets

- None

### Dependencies

- None

### Route Implementation

- `app/routes/daily-devo/partials/never-miss-a-daily.tsx` - fixed Daily Devo floating card typos.
- `app/routes/daily-devo/loader.tsx` - normalized malformed Daily Devo prayer content.
- `app/routes/yes/components/yes-devotional-hero.component.tsx` - updated devotional hero cards to open the correct app store link by device.
- `app/routes/ministry-builder/meta.tsx` - fixed generated ministry SEO title/fallback description wording.
- `app/routes/group-finder/group-finder.tsx` - updated hero CTAs to confirmed destinations.
- `app/routes/locations/location-single/location-single-data.tsx` - updated Campus Amenities volunteer wording.

### Key Features

- Daily Devo and devotional content now avoid visible typos and broken app links.
- Ministry SEO metadata uses cleaner, grammatically correct wording.
- Group Finder hero CTAs now route to the intended external destinations.

[CFDP-3960]: https://christfellowshipchurch.atlassian.net/browse/CFDP-3960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ