### PR TITLE
Update Resource Collections

### DIFF
--- a/app/components/resource-carousel/index.tsx
+++ b/app/components/resource-carousel/index.tsx
@@ -9,6 +9,7 @@ import {
 } from '~/primitives/shadcn-primitives/carousel';
 import { ResourceCard } from '~/primitives/cards/resource-card';
 import { CollectionItem } from '~/routes/page-builder/types';
+import HTMLRenderer from '~/primitives/html-renderer';
 
 interface CardCarouselSectionProps {
   viewMoreStyles?: string;
@@ -68,7 +69,7 @@ export const CardCarouselSection = ({
                   {title}
                 </h2>
                 {description && (
-                  <p className='md:text-lg leading-none'>{description}</p>
+                  <HTMLRenderer html={description} className='md:text-lg' />
                 )}
               </div>
 

--- a/app/primitives/cards/__tests__/index.test.tsx
+++ b/app/primitives/cards/__tests__/index.test.tsx
@@ -77,7 +77,10 @@ describe('ResourceCard', () => {
     });
 
     it('renders a link when REDIRECT_CARD has disableCard undefined', () => {
-      renderCard({ contentType: 'REDIRECT_CARD', pathname: 'https://example.com' });
+      renderCard({
+        contentType: 'REDIRECT_CARD',
+        pathname: 'https://example.com',
+      });
       expect(screen.getByRole('link')).toBeInTheDocument();
     });
 

--- a/app/primitives/cards/__tests__/index.test.tsx
+++ b/app/primitives/cards/__tests__/index.test.tsx
@@ -64,6 +64,39 @@ describe('ResourceCard', () => {
     });
     expect(screen.queryByRole('list')).not.toBeInTheDocument();
   });
+
+  describe('REDIRECT_CARD disableCard', () => {
+    it('renders a link when REDIRECT_CARD has disableCard false', () => {
+      renderCard({
+        contentType: 'REDIRECT_CARD',
+        pathname: 'https://example.com',
+        disableCard: false,
+      });
+      const link = screen.getByRole('link');
+      expect(link).toHaveAttribute('href', 'https://example.com');
+    });
+
+    it('renders a link when REDIRECT_CARD has disableCard undefined', () => {
+      renderCard({ contentType: 'REDIRECT_CARD', pathname: 'https://example.com' });
+      expect(screen.getByRole('link')).toBeInTheDocument();
+    });
+
+    it('renders static content with no link when REDIRECT_CARD has disableCard true', () => {
+      renderCard({
+        contentType: 'REDIRECT_CARD',
+        pathname: 'https://example.com',
+        disableCard: true,
+      });
+      expect(screen.queryByRole('link')).not.toBeInTheDocument();
+      expect(screen.getByText('Test Resource')).toBeInTheDocument();
+      expect(screen.getByAltText('Test Resource')).toBeInTheDocument();
+    });
+
+    it('does not disable the link for non-redirect content types even when disableCard is true', () => {
+      renderCard({ contentType: 'ARTICLES', disableCard: true });
+      expect(screen.getByRole('link')).toBeInTheDocument();
+    });
+  });
 });
 
 describe('MinistryCard', () => {

--- a/app/primitives/cards/resource-card.tsx
+++ b/app/primitives/cards/resource-card.tsx
@@ -14,19 +14,22 @@ export const ResourceCard = ({
   /** Optional state to pass to the Link (e.g. { fromEvents: '/events?q=...' } for back navigation). */
   linkState?: Record<string, unknown>;
 }) => {
-  const { summary, startDate, location, author, image, name, pathname } =
-    resource;
+  const {
+    summary,
+    startDate,
+    location,
+    author,
+    image,
+    name,
+    pathname,
+    contentType,
+    disableCard,
+  } = resource;
 
-  return (
-    <Link
-      to={pathname}
-      state={linkState}
-      className={cn(
-        'flex flex-col w-full h-full overflow-hidden hover:translate-y-[-4px] transition-all duration-300 border border-neutral-lighter rounded-lg',
-        className,
-      )}
-      prefetch='intent'
-    >
+  const isDisabledRedirectCard = contentType === 'REDIRECT_CARD' && disableCard;
+
+  const innerContent = (
+    <>
       <img
         src={image}
         alt={name}
@@ -36,7 +39,7 @@ export const ResourceCard = ({
 
       <div className='flex-1 flex flex-col gap-4 p-6 bg-white h-fit rounded-b-[8px]'>
         {(startDate || location || author) && (
-          <ul className='flex gap-2 md:gap-4 lg:flex-col lg:gap-2 xl:!gap-4 xl:!flex-row'>
+          <ul className='flex gap-2 md:gap-4 lg:flex-col lg:gap-2 xl:gap-4! xl:flex-row!'>
             {startDate && (
               <li className='flex items-center gap-2'>
                 <Icon name='calendarAlt' color='black' />
@@ -66,6 +69,33 @@ export const ResourceCard = ({
           <HtmlRenderer html={summary || ''} className='line-clamp-3' />
         </div>
       </div>
+    </>
+  );
+
+  if (isDisabledRedirectCard) {
+    return (
+      <div
+        className={cn(
+          'flex flex-col w-full h-full overflow-hidden border border-neutral-lighter rounded-lg',
+          className,
+        )}
+      >
+        {innerContent}
+      </div>
+    );
+  }
+
+  return (
+    <Link
+      to={pathname}
+      state={linkState}
+      className={cn(
+        'flex flex-col w-full h-full overflow-hidden hover:translate-y-[-4px] transition-all duration-300 border border-neutral-lighter rounded-lg',
+        className,
+      )}
+      prefetch='intent'
+    >
+      {innerContent}
     </Link>
   );
 };

--- a/app/routes/page-builder/__tests__/loader.test.ts
+++ b/app/routes/page-builder/__tests__/loader.test.ts
@@ -17,7 +17,10 @@ vi.mock('~/lib/.server/fetch-wistia-data', () => ({
   fetchWistiaDataFromRock: vi.fn(),
 }));
 
-import { fetchRockData, isItemInDateRange } from '~/lib/.server/fetch-rock-data';
+import {
+  fetchRockData,
+  isItemInDateRange,
+} from '~/lib/.server/fetch-rock-data';
 import {
   buildPodcastRoutingIndex,
   PODCAST_SHOW_CHANNEL_ID,

--- a/app/routes/page-builder/loader.tsx
+++ b/app/routes/page-builder/loader.tsx
@@ -38,6 +38,15 @@ const getStringValue = (value: string | number | boolean): string => {
   return String(value);
 };
 
+const getBooleanValue = (
+  value: string | number | boolean | null | undefined,
+): boolean => {
+  if (typeof value === 'boolean') return value;
+  if (value == null) return false;
+  const normalized = String(value).toLowerCase();
+  return normalized === 'true' || normalized === 'on' || normalized === '1';
+};
+
 const toArray = <T,>(value: T | T[] | null | undefined): T[] => {
   if (!value) {
     return [];
@@ -198,6 +207,8 @@ export const mapPageBuilderChildItems = async (
                 ),
               );
 
+              console.log({ itemAttributeValues });
+
               if (!contentType) {
                 console.warn(
                   `[page-builder] Skipping unsupported collection item ${item.id} with content channel ID ${item.contentChannelId}`,
@@ -259,7 +270,10 @@ export const mapPageBuilderChildItems = async (
                     ) || '',
                   startDate,
                   pathname,
-                  // attributeValues,
+                  disableCard:
+                    contentType === 'REDIRECT_CARD'
+                      ? getBooleanValue(itemAttributeValues?.disableCard)
+                      : undefined,
                 },
               ];
             },

--- a/app/routes/page-builder/types.ts
+++ b/app/routes/page-builder/types.ts
@@ -83,6 +83,8 @@ export type CollectionItem = {
   startDate?: string; // for Events, Sermons, Articles, Devotionals, Podcasts
   author?: string; // for Sermons, Articles, Devotionals, Podcasts
   location?: string; // for Events
+  /** Redirect Card only (Rock `disableCard`). When true, carousel renders static content without link/card chrome. */
+  disableCard?: boolean;
 };
 
 /**


### PR DESCRIPTION
## Summary

Page builder resource collections now support two CMS-driven behaviors: rich HTML in carousel section descriptions, and optional non-clickable redirect cards when Rock sets `disableCard` on `REDIRECT_CARD` items.

- Carousel descriptions render through `HTMLRenderer` (sanitized) instead of plain text, so markup from Rock displays correctly.
- `REDIRECT_CARD` items with `disableCard: true` render as static cards (no link, no hover lift) while other content types are unchanged.
- The page-builder loader maps `disableCard` from Rock attribute values via a new `getBooleanValue` helper.

## Screenshots

<img width="1407" height="819" alt="image" src="https://github.com/user-attachments/assets/bfc4b056-37fa-4294-bce5-52beb4179e3c" />

## Testing

- [x] Unit tests added/updated for `ResourceCard` `REDIRECT_CARD` + `disableCard` behavior (`app/primitives/cards/__tests__/index.test.tsx`)
- [x] Manual: page with a resource collection whose description includes HTML (links, formatting) — verify carousel header renders markup correctly
- [x] Manual: `REDIRECT_CARD` with `disableCard` false/undefined — card is still a link with hover
- [x] Manual: `REDIRECT_CARD` with `disableCard` true — card shows image/title/summary but is not clickable and has no hover translate
- [x] Manual: non-redirect item with `disableCard` true in Rock — card should still link (attribute ignored outside `REDIRECT_CARD`)
- [ ] `pnpm test` / `pnpm lint` run on branch
- [x] **Review note:** `console.log({ itemAttributeValues })` in `app/routes/page-builder/loader.tsx` looks like debug output — remove before merge unless intentional

### Verification steps
_Can test the new features in `/ministries/leadership#our-leadership-college-team`_
1. Open a page-builder page that uses a resource collection carousel.
2. Confirm collection description HTML (if any) renders with expected formatting.
3. Configure a `REDIRECT_CARD` with `disableCard` enabled in Rock and confirm the carousel card is not a link.
4. Configure a normal redirect card (`disableCard` off) and confirm it still navigates.

## Tickets

[CFDP-3968](https://christfellowshipchurch.atlassian.net/browse/CFDP-3968)
[CFDP-3967](https://christfellowshipchurch.atlassian.net/browse/CFDP-3967)

## Changes Made

### New Utilities

- `getBooleanValue` in `app/routes/page-builder/loader.tsx` — normalizes Rock boolean attribute values (`true` / `on` / `1` strings and booleans)


### Route Implementation

- `app/routes/page-builder/loader.tsx` — maps `disableCard` onto `CollectionItem` for `REDIRECT_CARD` items from `itemAttributeValues`
- `app/routes/page-builder/types.ts` — adds optional `disableCard?: boolean` on `CollectionItem`

### Key Features

- **HTML carousel descriptions:** `CardCarouselSection` uses `HTMLRenderer` for `description` instead of a plain `<p>` (`app/components/resource-carousel/index.tsx`).
- **Disable redirect card links:** `ResourceCard` checks `contentType === 'REDIRECT_CARD' && disableCard` and renders a static `<div>` (no `Link`, no hover animation) vs. the existing linked card (`app/primitives/cards/resource-card.tsx`).
- **Tests:** `REDIRECT_CARD` link vs. static rendering; `disableCard` only applies to redirect cards (`app/primitives/cards/__tests__/index.test.tsx`).

[CFDP-3968]: https://christfellowshipchurch.atlassian.net/browse/CFDP-3968?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ