### PR TITLE
Community Outreach, Events, Podcast Episode, and Location pages bugs

### DIFF
--- a/app/hooks/use-copy-page-path.ts
+++ b/app/hooks/use-copy-page-path.ts
@@ -2,8 +2,7 @@ import { useCallback, useState } from 'react';
 
 function getLocationPathForClipboard(): string {
   if (typeof window === 'undefined') return '';
-  const { pathname, search, hash } = window.location;
-  return `${pathname}${search}${hash}`;
+  return window.location.href;
 }
 
 export function useCopyPagePath() {

--- a/app/routes/events/all-events/partials/featured-events.partial.tsx
+++ b/app/routes/events/all-events/partials/featured-events.partial.tsx
@@ -70,15 +70,15 @@ export function FeaturedEventsFromHits({ hits }: { hits: ContentItemHit[] }) {
               ))}
             </CarouselContent>
 
-            <div className='w-full relative mt-4 pb-4'>
-              <div className='absolute h-12 top-7 left-5'>
+            <div className='mt-8 flex w-full items-center justify-between px-5 pb-4'>
+              <div className='flex min-h-12 items-center'>
                 <CarouselDots
                   activeClassName='bg-ocean'
                   inactiveClassName='bg-neutral-lighter'
                 />
               </div>
 
-              <div className='absolute h-12 right-44 lg:right-44 2xl:right-36 3xl:right-28'>
+              <div className='flex min-h-12 items-center'>
                 <CarouselArrows />
               </div>
             </div>

--- a/app/routes/locations/location-single/components/during-the-week.component.tsx
+++ b/app/routes/locations/location-single/components/during-the-week.component.tsx
@@ -25,7 +25,11 @@ type WeeklyMinistryServiceDisplay = {
 function normalizeWeeklyMinistryService(
   service: WeeklyMinistryService,
 ): WeeklyMinistryServiceDisplay | null {
-  const ministryType = (service.ministryType ?? service.minstryType ?? '').trim();
+  const ministryType = (
+    service.ministryType ??
+    service.minstryType ??
+    ''
+  ).trim();
   const dayOfWeek = (service.daysOfWeek ?? service.dayOfWeek ?? '').trim();
   const serviceTimes = (service.times ?? service.serviceTimes ?? '').trim();
   const learnMoreUrl = (

--- a/app/routes/locations/location-single/components/during-the-week.component.tsx
+++ b/app/routes/locations/location-single/components/during-the-week.component.tsx
@@ -4,8 +4,6 @@ import { weekdaySpanishTranslation } from '../util';
 
 export type WeeklyMinistryService = {
   ministryType?: string;
-  // TOOD: Remove minstryType when fixed in Algolia
-  minstryType?: string;
   dayOfWeek?: string;
   serviceTimes?: string;
   learnMoreUrl?: string;
@@ -56,8 +54,7 @@ function normalizeDaysOfWeek(dayOfWeek: string) {
 function normalizeWeeklyMinistryService(
   service: WeeklyMinistryService,
 ): WeeklyMinistryServiceDisplay[] {
-  // TOOD: Update minstryType to be ministryType when fixed in Algolia
-  const ministryType = (service.minstryType ?? '').trim();
+  const ministryType = (service.ministryType ?? '').trim();
   const daysOfWeek = (service.dayOfWeek ?? '').trim();
   const serviceTimes = (service.serviceTimes ?? '').trim();
   const learnMoreUrl = (service.learnMoreUrl ?? '').trim();

--- a/app/routes/locations/location-single/components/during-the-week.component.tsx
+++ b/app/routes/locations/location-single/components/during-the-week.component.tsx
@@ -4,12 +4,10 @@ import { weekdaySpanishTranslation } from '../util';
 
 export type WeeklyMinistryService = {
   ministryType?: string;
+  // TOOD: Remove minstryType when fixed in Algolia
   minstryType?: string;
-  daysOfWeek?: string;
   dayOfWeek?: string;
-  times?: string;
   serviceTimes?: string;
-  learnMoreLink?: string;
   learnMoreUrl?: string;
   planAVisit?: boolean;
   planMyvisit?: string;
@@ -22,32 +20,58 @@ type WeeklyMinistryServiceDisplay = {
   learnMoreUrl: string;
 };
 
+const dayOrder = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'];
+
+const weekdayDisplayNames = dayOrder.reduce<Record<string, string>>(
+  (acc, day) => {
+    acc[day.toLowerCase()] = day;
+    acc[`${day.toLowerCase()}s`] = day;
+    return acc;
+  },
+  {},
+);
+
+const ministryDisplayNames: Record<string, string> = {
+  'cf-kids': 'Kids',
+  'kids-university': 'Kid U',
+  students: 'Students',
+  'the-mix': 'The Mix',
+  'young-adults': 'Young Adults',
+  'college-nights': 'College Nights',
+  'celebrate-recovery': 'Celebrate Recovery',
+};
+
+function normalizeMinistryType(ministryType: string) {
+  return ministryDisplayNames[ministryType] ?? ministryType;
+}
+
+function normalizeDaysOfWeek(dayOfWeek: string) {
+  return dayOfWeek
+    .split(',')
+    .map((day) => day.trim())
+    .map((day) => weekdayDisplayNames[day.toLowerCase()] ?? day)
+    .filter((day) => dayOrder.includes(day));
+}
+
 function normalizeWeeklyMinistryService(
   service: WeeklyMinistryService,
-): WeeklyMinistryServiceDisplay | null {
-  const ministryType = (
-    service.ministryType ??
-    service.minstryType ??
-    ''
-  ).trim();
-  const dayOfWeek = (service.daysOfWeek ?? service.dayOfWeek ?? '').trim();
-  const serviceTimes = (service.times ?? service.serviceTimes ?? '').trim();
-  const learnMoreUrl = (
-    service.learnMoreLink ??
-    service.learnMoreUrl ??
-    ''
-  ).trim();
+): WeeklyMinistryServiceDisplay[] {
+  // TOOD: Update minstryType to be ministryType when fixed in Algolia
+  const ministryType = (service.minstryType ?? '').trim();
+  const daysOfWeek = (service.dayOfWeek ?? '').trim();
+  const serviceTimes = (service.serviceTimes ?? '').trim();
+  const learnMoreUrl = (service.learnMoreUrl ?? '').trim();
 
-  if (!ministryType || !dayOfWeek || !serviceTimes) {
-    return null;
+  if (!ministryType || !daysOfWeek || !serviceTimes) {
+    return [];
   }
 
-  return {
-    ministryType,
+  return normalizeDaysOfWeek(daysOfWeek).map((dayOfWeek) => ({
+    ministryType: normalizeMinistryType(ministryType),
     dayOfWeek,
     serviceTimes,
     learnMoreUrl,
-  };
+  }));
 }
 
 export const DuringTheWeek = ({
@@ -57,11 +81,9 @@ export const DuringTheWeek = ({
   weeklyMinistryServices: WeeklyMinistryService[];
   isSpanish?: boolean;
 }) => {
-  const displayServices = (weeklyMinistryServices ?? [])
-    .map(normalizeWeeklyMinistryService)
-    .filter((service): service is WeeklyMinistryServiceDisplay =>
-      Boolean(service),
-    );
+  const displayServices = (weeklyMinistryServices ?? []).flatMap(
+    normalizeWeeklyMinistryService,
+  );
 
   const byDay = displayServices.reduce(
     (acc, item) => {
@@ -72,7 +94,6 @@ export const DuringTheWeek = ({
     },
     {} as Record<string, WeeklyMinistryServiceDisplay[]>,
   );
-  const dayOrder = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'];
   const orderedDays = dayOrder.filter((day) => byDay[day]?.length);
 
   return (

--- a/app/routes/locations/location-single/components/during-the-week.component.tsx
+++ b/app/routes/locations/location-single/components/during-the-week.component.tsx
@@ -3,12 +3,48 @@ import { Icon } from '~/primitives/icon/icon';
 import { weekdaySpanishTranslation } from '../util';
 
 export type WeeklyMinistryService = {
-  minstryType: string;
+  ministryType?: string;
+  minstryType?: string;
+  daysOfWeek?: string;
+  dayOfWeek?: string;
+  times?: string;
+  serviceTimes?: string;
+  learnMoreLink?: string;
+  learnMoreUrl?: string;
+  planAVisit?: boolean;
+  planMyvisit?: string;
+};
+
+type WeeklyMinistryServiceDisplay = {
+  ministryType: string;
   dayOfWeek: string;
   serviceTimes: string;
   learnMoreUrl: string;
-  planMyvisit: string;
 };
+
+function normalizeWeeklyMinistryService(
+  service: WeeklyMinistryService,
+): WeeklyMinistryServiceDisplay | null {
+  const ministryType = (service.ministryType ?? service.minstryType ?? '').trim();
+  const dayOfWeek = (service.daysOfWeek ?? service.dayOfWeek ?? '').trim();
+  const serviceTimes = (service.times ?? service.serviceTimes ?? '').trim();
+  const learnMoreUrl = (
+    service.learnMoreLink ??
+    service.learnMoreUrl ??
+    ''
+  ).trim();
+
+  if (!ministryType || !dayOfWeek || !serviceTimes) {
+    return null;
+  }
+
+  return {
+    ministryType,
+    dayOfWeek,
+    serviceTimes,
+    learnMoreUrl,
+  };
+}
 
 export const DuringTheWeek = ({
   weeklyMinistryServices,
@@ -17,14 +53,20 @@ export const DuringTheWeek = ({
   weeklyMinistryServices: WeeklyMinistryService[];
   isSpanish?: boolean;
 }) => {
-  const byDay = (weeklyMinistryServices ?? []).reduce(
+  const displayServices = (weeklyMinistryServices ?? [])
+    .map(normalizeWeeklyMinistryService)
+    .filter((service): service is WeeklyMinistryServiceDisplay =>
+      Boolean(service),
+    );
+
+  const byDay = displayServices.reduce(
     (acc, item) => {
       const day = item.dayOfWeek;
       if (!acc[day]) acc[day] = [];
       acc[day].push(item);
       return acc;
     },
-    {} as Record<string, WeeklyMinistryService[]>,
+    {} as Record<string, WeeklyMinistryServiceDisplay[]>,
   );
   const dayOrder = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'];
   const orderedDays = dayOrder.filter((day) => byDay[day]?.length);
@@ -46,12 +88,12 @@ export const DuringTheWeek = ({
                   key={i}
                   className='font-medium text-neutral-default md:max-w-[260px] lg:max-w-[180px] lg:text-xs'
                 >
-                  {ministry.serviceTimes} | {ministry.minstryType}{' '}
+                  {ministry.serviceTimes} | {ministry.ministryType}{' '}
                   {ministry.learnMoreUrl ? (
                     <Link
                       to={ministry.learnMoreUrl}
                       className='inline align-middle'
-                      aria-label={`${ministry.minstryType} Link`}
+                      aria-label={`${ministry.ministryType} Link`}
                     >
                       <Icon
                         name='linkExternal'

--- a/app/routes/podcasts/podcast-episode/components/__tests__/more-episodes-search.test.tsx
+++ b/app/routes/podcasts/podcast-episode/components/__tests__/more-episodes-search.test.tsx
@@ -1,49 +1,23 @@
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { MoreEpisodesSearch } from '../more-episodes-search';
-
-// Mock react-instantsearch components
-vi.mock('react-instantsearch', () => ({
-  InstantSearch: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid='instant-search'>{children}</div>
-  ),
-  Hits: ({
-    hitComponent: HitComponent,
-    classNames,
-  }: {
-    hitComponent: React.ComponentType<{ hit: unknown }>;
-    classNames: { list: string };
-  }) => (
-    <div data-testid='hits' className={classNames.list}>
-      <HitComponent
-        hit={{
-          title: 'Test Episode',
-          coverImage: { sources: [{ uri: '/test-image.jpg' }] },
-          podcastSeason: 'Season 1',
-          podcastSeasonNumber: 1,
-          podcastEpisodeNumber: 2,
-          routing: { pathname: '/test-episode' },
-        }}
-      />
-    </div>
-  ),
-  Configure: () => <div data-testid='configure' />,
-  useHits: () => ({ items: [{}] }),
-}));
-
-// Mock algoliasearch
-vi.mock('algoliasearch/lite', () => ({
-  liteClient: vi.fn(() => ({})),
-}));
+import type { ContentItemHit } from '~/routes/search/types';
 
 describe('MoreEpisodesSearch', () => {
   const defaultProps = {
-    ALGOLIA_APP_ID: 'test-app-id',
-    ALGOLIA_SEARCH_API_KEY: 'test-api-key',
-    podcastShow: 'Test Show',
-    podcastSeason: 'Season 1',
-    currentEpisodeTitle: 'Current Episode',
+    hits: [
+      {
+        objectID: 'episode-2',
+        title: 'Test Episode',
+        coverImage: { sources: [{ uri: '/test-image.jpg' }] },
+        podcastShow: 'Test Show',
+        podcastSeason: 'Season 1',
+        podcastSeasonNumber: 1,
+        podcastEpisodeNumber: 2,
+        url: 'test-episode',
+      } as ContentItemHit,
+    ],
   };
 
   const renderWithRouter = (component: React.ReactElement) => {
@@ -53,9 +27,7 @@ describe('MoreEpisodesSearch', () => {
   it('renders without crashing', () => {
     renderWithRouter(<MoreEpisodesSearch {...defaultProps} />);
 
-    expect(screen.getByTestId('instant-search')).toBeInTheDocument();
-    expect(screen.getByTestId('hits')).toBeInTheDocument();
-    expect(screen.getByTestId('configure')).toBeInTheDocument();
+    expect(screen.getByText('More in this season')).toBeInTheDocument();
   });
 
   it('renders episode title correctly', () => {
@@ -70,14 +42,9 @@ describe('MoreEpisodesSearch', () => {
     expect(screen.getByText('Season 1 | Episode 2')).toBeInTheDocument();
   });
 
-  it('renders without current episode title', () => {
-    const propsWithoutCurrentEpisode = {
-      ...defaultProps,
-      currentEpisodeTitle: undefined,
-    };
+  it('does not render when there are no loader hits', () => {
+    const { container } = renderWithRouter(<MoreEpisodesSearch hits={[]} />);
 
-    renderWithRouter(<MoreEpisodesSearch {...propsWithoutCurrentEpisode} />);
-
-    expect(screen.getByTestId('instant-search')).toBeInTheDocument();
+    expect(container).toBeEmptyDOMElement();
   });
 });

--- a/app/routes/podcasts/podcast-episode/components/episode-share-button.component.tsx
+++ b/app/routes/podcasts/podcast-episode/components/episode-share-button.component.tsx
@@ -1,0 +1,39 @@
+import { useCopyPagePath } from '~/hooks/use-copy-page-path';
+import { cn } from '~/lib/utils';
+import Icon from '~/primitives/icon';
+
+export function EpisodeShareButton({
+  className,
+  iconClasses,
+}: {
+  className?: string;
+  iconClasses?: string;
+}) {
+  const { copyPath, copied } = useCopyPagePath();
+
+  return (
+    <button
+      type='button'
+      onClick={() => void copyPath()}
+      className='group inline-flex w-fit items-center'
+      aria-label='Share this episode'
+    >
+      <span
+        className={cn(
+          'inline-flex min-h-12 items-center justify-center border border-ocean px-6 py-3 font-semibold text-ocean transition-colors group-hover:bg-current/10',
+          className,
+        )}
+      >
+        {copied ? 'Link copied' : 'Share this episode'}
+      </span>
+      <Icon
+        name='arrowBack'
+        className={cn(
+          'ml-[-0.75rem] size-10 rounded-full bg-ocean p-2 text-white rotate-[135deg] transition-transform duration-300 group-hover:rotate-180',
+          iconClasses,
+        )}
+        size={20}
+      />
+    </button>
+  );
+}

--- a/app/routes/podcasts/podcast-episode/components/hero-mobile-content.component.tsx
+++ b/app/routes/podcasts/podcast-episode/components/hero-mobile-content.component.tsx
@@ -1,7 +1,7 @@
-import { IconButton } from '~/primitives/button/icon-button.primitive';
 import { sanitizeCmsHtml } from '~/lib/sanitize';
 import { useLoaderData } from 'react-router-dom';
 import { LoaderReturnType } from '../loader';
+import { EpisodeShareButton } from './episode-share-button.component';
 
 export const HeroMobileContent = () => {
   const { episode } = useLoaderData<LoaderReturnType>();
@@ -28,8 +28,7 @@ export const HeroMobileContent = () => {
               dangerouslySetInnerHTML={{ __html: sanitizeCmsHtml(summary) }}
             />
           )}
-          {/* TODO: Add share functionality */}
-          <IconButton withRotatingArrow={true}>Share this episode</IconButton>
+          <EpisodeShareButton />
         </div>
         <div className='h-[1px] opacity-10 bg-black/75 mt-8' />
       </div>

--- a/app/routes/podcasts/podcast-episode/components/more-episodes-search.tsx
+++ b/app/routes/podcasts/podcast-episode/components/more-episodes-search.tsx
@@ -1,17 +1,9 @@
-import { useMemo } from 'react';
-import { InstantSearch, Hits, Configure } from 'react-instantsearch';
 import { Icon } from '~/primitives/icon/icon';
 import { Link } from 'react-router-dom';
 import { ContentItemHit } from '~/routes/search/types';
-import { createSearchClient } from '~/lib/create-search-client';
-import { HitsWrapper } from '~/components/hits-wrapper';
 
 interface MoreEpisodesSearchProps {
-  ALGOLIA_APP_ID: string;
-  ALGOLIA_SEARCH_API_KEY: string;
-  podcastShow: string;
-  podcastSeason: string;
-  currentEpisodeTitle?: string;
+  hits: ContentItemHit[];
 }
 
 const MoreEpisodesHitComponent = ({ hit }: { hit: ContentItemHit }) => {
@@ -52,47 +44,23 @@ const MoreEpisodesHitComponent = ({ hit }: { hit: ContentItemHit }) => {
 };
 
 export const MoreEpisodesSearch = ({
-  ALGOLIA_APP_ID,
-  ALGOLIA_SEARCH_API_KEY,
-  podcastShow,
-  podcastSeason,
-  currentEpisodeTitle,
+  hits,
 }: MoreEpisodesSearchProps) => {
-  const searchClient = useMemo(
-    () => createSearchClient(ALGOLIA_APP_ID, ALGOLIA_SEARCH_API_KEY),
-    [ALGOLIA_APP_ID, ALGOLIA_SEARCH_API_KEY],
-  );
-
-  // Filter for episodes from the same show and season, excluding the current episode
-  const filter = `contentType:"Podcast" AND podcastShow:"${podcastShow}" AND podcastSeasonNumber:${podcastSeason}${
-    currentEpisodeTitle ? ` AND NOT title:"${currentEpisodeTitle}"` : ''
-  }`;
+  if (hits.length === 0) {
+    return null;
+  }
 
   return (
-    <InstantSearch
-      indexName='dev_contentItems'
-      searchClient={searchClient}
-      future={{
-        preserveSharedStateOnUnmount: true,
-      }}
-    >
-      <Configure filters={filter} hitsPerPage={8} />
+    <div className='w-full bg-white content-padding'>
+      <div className='flex flex-col gap-6 md:gap-7 max-w-screen-content mx-auto py-10 md:py-20'>
+        <h2 className='text-[28px] font-extrabold'>More in this season</h2>
 
-      {/* Episodes Section - Only render if there are hits */}
-      <HitsWrapper>
-        <div className='w-full bg-white content-padding'>
-          <div className='flex flex-col gap-6 md:gap-7 max-w-screen-content mx-auto py-10 md:py-20'>
-            <h2 className='text-[28px] font-extrabold'>More in this season</h2>
-
-            <Hits
-              hitComponent={MoreEpisodesHitComponent}
-              classNames={{
-                list: 'grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6',
-              }}
-            />
-          </div>
+        <div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6'>
+          {hits.map((hit) => (
+            <MoreEpisodesHitComponent key={hit.objectID} hit={hit} />
+          ))}
         </div>
-      </HitsWrapper>
-    </InstantSearch>
+      </div>
+    </div>
   );
 };

--- a/app/routes/podcasts/podcast-episode/components/more-episodes-search.tsx
+++ b/app/routes/podcasts/podcast-episode/components/more-episodes-search.tsx
@@ -43,9 +43,7 @@ const MoreEpisodesHitComponent = ({ hit }: { hit: ContentItemHit }) => {
   );
 };
 
-export const MoreEpisodesSearch = ({
-  hits,
-}: MoreEpisodesSearchProps) => {
+export const MoreEpisodesSearch = ({ hits }: MoreEpisodesSearchProps) => {
   if (hits.length === 0) {
     return null;
   }

--- a/app/routes/podcasts/podcast-episode/loader.tsx
+++ b/app/routes/podcasts/podcast-episode/loader.tsx
@@ -66,7 +66,9 @@ export const loader = async ({ params }: LoaderFunctionArgs) => {
   const appId = process.env.ALGOLIA_APP_ID;
   const apiKey = process.env.ALGOLIA_SEARCH_API_KEY;
   const moreEpisodesHits =
-    appId && apiKey ? await fetchMoreEpisodesFromAlgolia(episode, appId, apiKey) : [];
+    appId && apiKey
+      ? await fetchMoreEpisodesFromAlgolia(episode, appId, apiKey)
+      : [];
 
   return {
     episode,
@@ -109,7 +111,10 @@ async function fetchMoreEpisodesFromAlgolia(
 
     return (response.hits ?? []).map((hit) => hit as unknown as ContentItemHit);
   } catch (error) {
-    console.error('[podcasts/podcast-episode] Algolia loader fetch failed', error);
+    console.error(
+      '[podcasts/podcast-episode] Algolia loader fetch failed',
+      error,
+    );
     return [];
   }
 }

--- a/app/routes/podcasts/podcast-episode/loader.tsx
+++ b/app/routes/podcasts/podcast-episode/loader.tsx
@@ -1,8 +1,12 @@
 import { LoaderFunctionArgs } from 'react-router-dom';
+import { algoliasearch } from 'algoliasearch';
+
+import { escapeAlgoliaFilterString } from '~/components/finders/finder-algolia.utils';
 import { PodcastEpisode, RockPodcastEpisode, WistiaElement } from '../types';
 import { fetchRockData } from '~/lib/.server/fetch-rock-data';
 import { createImageUrlFromGuid, parseRockKeyValueList } from '~/lib/utils';
 import { PODCAST_SHOW_CHANNEL_ID } from '../podcast-routing.server';
+import type { ContentItemHit } from '~/routes/search/types';
 
 // Error messages
 const ERROR_MESSAGES = {
@@ -16,9 +20,13 @@ const ERROR_MESSAGES = {
 
 export type LoaderReturnType = {
   episode: PodcastEpisode;
+  moreEpisodesHits: ContentItemHit[];
   ALGOLIA_APP_ID: string;
   ALGOLIA_SEARCH_API_KEY: string;
 };
+
+const CONTENT_ITEMS_INDEX_NAME = 'dev_contentItems';
+const MORE_EPISODES_HITS_PER_PAGE = 8;
 
 /**
  * Loader function for podcast episode pages
@@ -57,13 +65,54 @@ export const loader = async ({ params }: LoaderFunctionArgs) => {
   // Get Algolia configuration
   const appId = process.env.ALGOLIA_APP_ID;
   const apiKey = process.env.ALGOLIA_SEARCH_API_KEY;
+  const moreEpisodesHits =
+    appId && apiKey ? await fetchMoreEpisodesFromAlgolia(episode, appId, apiKey) : [];
 
   return {
     episode,
+    moreEpisodesHits,
     ALGOLIA_APP_ID: appId || '',
     ALGOLIA_SEARCH_API_KEY: apiKey || '',
-  };
+  } satisfies LoaderReturnType;
 };
+
+async function fetchMoreEpisodesFromAlgolia(
+  episode: PodcastEpisode,
+  appId: string,
+  apiKey: string,
+): Promise<ContentItemHit[]> {
+  const seasonNumber = Number(episode.season);
+  const rockItemId = Number(episode.id);
+
+  if (!episode.show || !Number.isFinite(seasonNumber)) {
+    return [];
+  }
+
+  const filters = [
+    'contentType:"Podcast"',
+    `podcastShow:"${escapeAlgoliaFilterString(episode.show)}"`,
+    `podcastSeasonNumber:${seasonNumber}`,
+    Number.isFinite(rockItemId) ? `rockItemId != ${rockItemId}` : '',
+  ]
+    .filter(Boolean)
+    .join(' AND ');
+
+  try {
+    const client = algoliasearch(appId, apiKey, {});
+    const response = await client.searchSingleIndex({
+      indexName: CONTENT_ITEMS_INDEX_NAME,
+      searchParams: {
+        filters,
+        hitsPerPage: MORE_EPISODES_HITS_PER_PAGE,
+      },
+    });
+
+    return (response.hits ?? []).map((hit) => hit as unknown as ContentItemHit);
+  } catch (error) {
+    console.error('[podcasts/podcast-episode] Algolia loader fetch failed', error);
+    return [];
+  }
+}
 
 /**
  * Fetches the PodcastShow ContentChannelItem and returns the show ContentChannel containing the episodes

--- a/app/routes/podcasts/podcast-episode/partials/episode-hero.partial.tsx
+++ b/app/routes/podcasts/podcast-episode/partials/episode-hero.partial.tsx
@@ -1,8 +1,8 @@
 import { useLoaderData } from 'react-router-dom';
 import { HeroContent } from '../components/hero-content.component';
 import { Breadcrumbs } from '~/components';
-import { IconButton } from '~/primitives/button/icon-button.primitive';
 import { LoaderReturnType } from '../loader';
+import { EpisodeShareButton } from '../components/episode-share-button.component';
 
 export function EpisodeHero() {
   const { episode } = useLoaderData<LoaderReturnType>();
@@ -21,12 +21,9 @@ export function EpisodeHero() {
             <div>
               <HeroContent />
               <div className='hidden md:block lg:hidden mt-6'>
-                <IconButton
+                <EpisodeShareButton
                   className='text-white border-white'
-                  withRotatingArrow
-                >
-                  Share this episode
-                </IconButton>
+                />
               </div>
             </div>
           </div>
@@ -36,10 +33,7 @@ export function EpisodeHero() {
           <div className='flex flex-col md:flex-row justify-between items-center py-10'>
             <Breadcrumbs mode='light' />
             <div className='mt-5 md:mt-0 flex-wrap justify-between hidden lg:flex'>
-              {/* TODO: Add share functionality */}
-              <IconButton className='text-white border-white' withRotatingArrow>
-                Share this episode
-              </IconButton>
+              <EpisodeShareButton className='text-white border-white' />
             </div>
           </div>
         </div>

--- a/app/routes/podcasts/podcast-episode/partials/episode-hero.partial.tsx
+++ b/app/routes/podcasts/podcast-episode/partials/episode-hero.partial.tsx
@@ -21,9 +21,7 @@ export function EpisodeHero() {
             <div>
               <HeroContent />
               <div className='hidden md:block lg:hidden mt-6'>
-                <EpisodeShareButton
-                  className='text-white border-white'
-                />
+                <EpisodeShareButton className='text-white border-white' />
               </div>
             </div>
           </div>

--- a/app/routes/podcasts/podcast-episode/partials/more-episodes.partial.tsx
+++ b/app/routes/podcasts/podcast-episode/partials/more-episodes.partial.tsx
@@ -3,18 +3,7 @@ import { LoaderReturnType } from '../loader';
 import { MoreEpisodesSearch } from '../components/more-episodes-search';
 
 export function MoreEpisodes() {
-  const { episode, ALGOLIA_APP_ID, ALGOLIA_SEARCH_API_KEY } =
-    useLoaderData<LoaderReturnType>();
+  const { moreEpisodesHits } = useLoaderData<LoaderReturnType>();
 
-  const { show, season } = episode;
-
-  return (
-    <MoreEpisodesSearch
-      ALGOLIA_APP_ID={ALGOLIA_APP_ID}
-      ALGOLIA_SEARCH_API_KEY={ALGOLIA_SEARCH_API_KEY}
-      podcastShow={show}
-      podcastSeason={season}
-      currentEpisodeTitle={episode.title}
-    />
-  );
+  return <MoreEpisodesSearch hits={moreEpisodesHits} />;
 }

--- a/app/routes/podcasts/podcast-show/partials/subscribe-section.partial.tsx
+++ b/app/routes/podcasts/podcast-show/partials/subscribe-section.partial.tsx
@@ -48,21 +48,18 @@ export const SubscribeSection = ({
             {links
               .filter((link) => link.href && link.href !== '')
               .map((link, index) => (
-                <div
+                <a
+                  href={link.href}
+                  target='_blank'
+                  rel='noopener noreferrer'
+                  aria-label={`${link.label} Link`}
                   className='flex flex-col items-center justify-center gap-2 basis-1/3 md:basis-auto bg-[#0092BC] rounded-lg size-[100px] p-2 sm:p-4 sm:size-[120px] hover:scale-105 transition-all duration-300 cursor-pointer'
                   key={index}
                 >
-                  <a
-                    href={link.href}
-                    target='_blank'
-                    rel='noopener noreferrer'
-                    aria-label={`${link.label} Link`}
-                  >
-                    <Icon
-                      name={link.icon as keyof typeof icons}
-                      size={link.icon === 'amazonMusic' ? 62 : 52}
-                    />
-                  </a>
+                  <Icon
+                    name={link.icon as keyof typeof icons}
+                    size={link.icon === 'amazonMusic' ? 62 : 52}
+                  />
                   <p
                     className={`text-[10px] md:text-xs text-center font-extrabold ${
                       link.icon === 'amazonMusic' ? '-mt-3' : ''
@@ -70,7 +67,7 @@ export const SubscribeSection = ({
                   >
                     {link.label}
                   </p>
-                </div>
+                </a>
               ))}
           </div>
         </div>

--- a/app/routes/volunteer/outreach-opportunity/components/outreach-details.component.tsx
+++ b/app/routes/volunteer/outreach-opportunity/components/outreach-details.component.tsx
@@ -1,6 +1,7 @@
+import { icsLink } from '~/lib/utils';
+import { Button } from '~/primitives/button/button.primitive';
 import Icon from '~/primitives/icon';
 import HTMLRenderer from '~/primitives/html-renderer';
-import { icsLink } from '~/lib/utils';
 
 import {
   collapseHtmlToVisibleText,
@@ -66,10 +67,14 @@ function calendarFilename(title: string): string {
   return `${slug || 'community-serving-opportunity'}.ics`;
 }
 
-function AddToCalendarIconButton({
+export function AddToCalendarButton({
   mission,
+  className,
+  showLabel = true,
 }: {
   mission: VolunteerMissionDetail;
+  className?: string;
+  showLabel?: boolean;
 }) {
   if (!mission.calendarStartDateTime) {
     return null;
@@ -108,15 +113,18 @@ function AddToCalendarIconButton({
   };
 
   return (
-    <button
+    <Button
+      intent='secondary'
+      className={className}
       type='button'
       onClick={handleAddToCalendar}
-      className='ml-auto inline-flex size-8 shrink-0 items-center justify-center rounded-full border border-black/12 text-neutral-darker transition-colors hover:border-ocean hover:bg-ocean hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ocean focus-visible:ring-offset-2'
-      aria-label='Add to Calendar'
-      title='Add to Calendar'
+      aria-label={showLabel ? undefined : 'Add to Calendar'}
     >
-      <Icon name='calendarPlus' size={18} />
-    </button>
+      <span className='inline-flex items-center justify-center gap-2'>
+        <Icon name='calendarPlus' size={18} />
+        {showLabel ? 'Add to Calendar' : null}
+      </span>
+    </Button>
   );
 }
 
@@ -131,11 +139,7 @@ export function MissionDetailRows({
 
   const rows = [
     { icon: 'map' as const, label: locationLabel },
-    {
-      icon: 'calendar' as const,
-      label: dateLabel,
-      action: <AddToCalendarIconButton mission={mission} />,
-    },
+    { icon: 'calendar' as const, label: dateLabel },
     { icon: 'time' as const, label: timeLabel },
   ];
 
@@ -149,7 +153,6 @@ export function MissionDetailRows({
           <span className='text-base font-medium leading-snug text-neutral-darker'>
             {row.label}
           </span>
-          {'action' in row ? row.action : null}
         </li>
       ))}
     </ul>

--- a/app/routes/volunteer/outreach-opportunity/components/outreach-details.component.tsx
+++ b/app/routes/volunteer/outreach-opportunity/components/outreach-details.component.tsx
@@ -1,5 +1,6 @@
 import Icon from '~/primitives/icon';
 import HTMLRenderer from '~/primitives/html-renderer';
+import { icsLink } from '~/lib/utils';
 
 import {
   collapseHtmlToVisibleText,
@@ -43,6 +44,82 @@ function formatEventTimeRange(mission: VolunteerMissionDetail): string {
   return start || end || '—';
 }
 
+function plainTextFromHtml(value: string): string {
+  return value
+    .replace(/<script[\s\S]*?<\/script>/gi, '')
+    .replace(/<style[\s\S]*?<\/style>/gi, '')
+    .replace(/<br\s*\/?>/gi, ' ')
+    .replace(/<\/\s*(?:p|div|h[1-6]|li|tr|td|th)\s*>/gi, ' ')
+    .replace(/<[^>]+>/g, '')
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&#(?:160|x0*A0);/gi, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function calendarFilename(title: string): string {
+  const slug = title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+
+  return `${slug || 'community-serving-opportunity'}.ics`;
+}
+
+function AddToCalendarIconButton({
+  mission,
+}: {
+  mission: VolunteerMissionDetail;
+}) {
+  if (!mission.calendarStartDateTime) {
+    return null;
+  }
+
+  const handleAddToCalendar = () => {
+    const startTime = new Date(mission.calendarStartDateTime as string);
+    const fallbackEndTime = new Date(startTime.getTime() + 60 * 60 * 1000);
+    const endTime = mission.calendarEndDateTime
+      ? new Date(mission.calendarEndDateTime)
+      : fallbackEndTime;
+
+    if (Number.isNaN(startTime.getTime())) {
+      return;
+    }
+
+    const calendarUrl = icsLink({
+      title: mission.title,
+      description: plainTextFromHtml(mission.summary),
+      address: mission.checkInLocation || mission.campusName || '',
+      startTime,
+      endTime: Number.isNaN(endTime.getTime()) ? fallbackEndTime : endTime,
+      url:
+        typeof window !== 'undefined'
+          ? window.location.href
+          : mission.missionsUrl,
+    });
+
+    const link = document.createElement('a');
+    link.href = calendarUrl;
+    link.download = calendarFilename(mission.title);
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+    window.setTimeout(() => window.URL.revokeObjectURL(calendarUrl), 0);
+  };
+
+  return (
+    <button
+      type='button'
+      onClick={handleAddToCalendar}
+      className='ml-auto inline-flex size-8 shrink-0 items-center justify-center rounded-full border border-black/12 text-neutral-darker transition-colors hover:border-ocean hover:bg-ocean hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ocean focus-visible:ring-offset-2'
+      aria-label='Add to Calendar'
+      title='Add to Calendar'
+    >
+      <Icon name='calendarPlus' size={18} />
+    </button>
+  );
+}
+
 export function MissionDetailRows({
   mission,
 }: {
@@ -54,7 +131,11 @@ export function MissionDetailRows({
 
   const rows = [
     { icon: 'map' as const, label: locationLabel },
-    { icon: 'calendar' as const, label: dateLabel },
+    {
+      icon: 'calendar' as const,
+      label: dateLabel,
+      action: <AddToCalendarIconButton mission={mission} />,
+    },
     { icon: 'time' as const, label: timeLabel },
   ];
 
@@ -68,6 +149,7 @@ export function MissionDetailRows({
           <span className='text-base font-medium leading-snug text-neutral-darker'>
             {row.label}
           </span>
+          {'action' in row ? row.action : null}
         </li>
       ))}
     </ul>

--- a/app/routes/volunteer/outreach-opportunity/components/outreach-details.component.tsx
+++ b/app/routes/volunteer/outreach-opportunity/components/outreach-details.component.tsx
@@ -92,9 +92,9 @@ export function AddToCalendarButton({
     }
 
     const calendarUrl = icsLink({
-      title: mission.title,
+      title: `CF Missions - ${mission.title}`,
       description: plainTextFromHtml(mission.summary),
-      address: mission.checkInLocation || mission.campusName || '',
+      address: mission.campusName || '',
       startTime,
       endTime: Number.isNaN(endTime.getTime()) ? fallbackEndTime : endTime,
       url:

--- a/app/routes/volunteer/outreach-opportunity/outreach-mission-rock.server.ts
+++ b/app/routes/volunteer/outreach-opportunity/outreach-mission-rock.server.ts
@@ -1,5 +1,5 @@
 import camelCase from 'lodash/camelCase';
-import { format, isValid } from 'date-fns';
+import { addHours, format, isValid, parse } from 'date-fns';
 
 import { fetchRockData, TTL } from '~/lib/.server/fetch-rock-data';
 import { escapeOData } from '~/lib/.server/rock-utils';
@@ -78,6 +78,17 @@ function parseRockDateTime(value: string): Date | null {
   return isValid(d) ? d : null;
 }
 
+function formatEventDateLabel(value: string): string {
+  const trimmed = value.trim();
+  for (const dateFormat of ['M/d/yyyy', 'MM/dd/yyyy', 'yyyy-MM-dd']) {
+    const parsed = parse(trimmed, dateFormat, new Date());
+    if (isValid(parsed)) {
+      return format(parsed, 'EEE d MMM yyyy');
+    }
+  }
+  return trimmed;
+}
+
 /** `HH:mm:ss` or `H:mm:ss` on same calendar day as `base`. */
 function parseTimeOnDate(base: Date, timeHHmmss: string): Date | null {
   const m = timeHHmmss.trim().match(/^(\d{1,2}):(\d{2})(?::(\d{2}))?$/);
@@ -91,6 +102,8 @@ function buildEventSchedule(attrs: AttrBag | undefined): {
   eventDateStr: string;
   eventTimeStr: string;
   eventEndTimeStr: string | undefined;
+  calendarStartDateTime: string | undefined;
+  calendarEndDateTime: string | undefined;
 } {
   const startRaw = readAttr(attrs, ['EventStartDateTime']);
   const startFormatted = readAttrFormatted(attrs, ['EventStartDateTime']);
@@ -98,19 +111,22 @@ function buildEventSchedule(attrs: AttrBag | undefined): {
   let eventDateStr = '—';
   let eventTimeStr = '—';
   let eventEndTimeStr: string | undefined;
+  let calendarStartDateTime: string | undefined;
+  let calendarEndDateTime: string | undefined;
 
   const startDate = startRaw ? parseRockDateTime(startRaw) : null;
 
   if (startDate) {
-    eventDateStr = format(startDate, 'M/d/yyyy');
+    eventDateStr = format(startDate, 'EEE d MMM yyyy');
     eventTimeStr = format(startDate, 'h:mm a');
+    calendarStartDateTime = startDate.toISOString();
   } else if (startFormatted) {
     const m = startFormatted.match(/^(.+?)\s+(\d{1,2}:\d{2}\s*(?:AM|PM))$/i);
     if (m) {
-      eventDateStr = m[1].trim();
+      eventDateStr = formatEventDateLabel(m[1]);
       eventTimeStr = m[2].trim();
     } else {
-      eventDateStr = startFormatted;
+      eventDateStr = formatEventDateLabel(startFormatted);
     }
   }
 
@@ -119,16 +135,33 @@ function buildEventSchedule(attrs: AttrBag | undefined): {
 
   if (endTimeFormatted && !/^\d{1,2}:\d{2}:\d{2}/.test(endTimeFormatted)) {
     eventEndTimeStr = endTimeFormatted;
+    if (startDate) {
+      const endOnStartDay = parse(endTimeFormatted, 'h:mm a', startDate);
+      if (isValid(endOnStartDay)) {
+        calendarEndDateTime = endOnStartDay.toISOString();
+      }
+    }
   } else if (endTimeRaw && /^\d{1,2}:\d{2}/.test(endTimeRaw) && startDate) {
     const endOnStartDay = parseTimeOnDate(startDate, endTimeRaw);
     if (endOnStartDay) {
       eventEndTimeStr = format(endOnStartDay, 'h:mm a');
+      calendarEndDateTime = endOnStartDay.toISOString();
     }
   } else if (endTimeFormatted) {
     eventEndTimeStr = endTimeFormatted;
   }
 
-  return { eventDateStr, eventTimeStr, eventEndTimeStr };
+  if (startDate && !calendarEndDateTime) {
+    calendarEndDateTime = addHours(startDate, 1).toISOString();
+  }
+
+  return {
+    eventDateStr,
+    eventTimeStr,
+    eventEndTimeStr,
+    calendarStartDateTime,
+    calendarEndDateTime,
+  };
 }
 
 function resolveImageUrl(raw: string | undefined): string | undefined {
@@ -288,8 +321,13 @@ export async function fetchVolunteerMissionDetailFromRock(
   const checkInLocation =
     readAttr(attrs, ['CheckInLocation']) || campusName || '—';
 
-  const { eventDateStr, eventTimeStr, eventEndTimeStr } =
-    buildEventSchedule(attrs);
+  const {
+    eventDateStr,
+    eventTimeStr,
+    eventEndTimeStr,
+    calendarStartDateTime,
+    calendarEndDateTime,
+  } = buildEventSchedule(attrs);
 
   const missionsUrl = `https://rock.gocf.org/page/1038?Group=${encodeURIComponent(guid)}`;
 
@@ -308,6 +346,8 @@ export async function fetchVolunteerMissionDetailFromRock(
     eventDateStr,
     eventTimeStr,
     eventEndTimeStr,
+    calendarStartDateTime,
+    calendarEndDateTime,
     missionsUrl,
     contactName: contact.contactName,
     contactEmail: contact.contactEmail,

--- a/app/routes/volunteer/outreach-opportunity/outreach-opportunity-page.tsx
+++ b/app/routes/volunteer/outreach-opportunity/outreach-opportunity-page.tsx
@@ -164,6 +164,7 @@ export function OutreachOpportunityPage() {
 
         <MobileBottomBar
           copied={copied}
+          mission={mission}
           onCopyPath={copyPath}
           onSignUpClick={handleSignupOpen}
         />

--- a/app/routes/volunteer/outreach-opportunity/partials/outreach-partials.partial.tsx
+++ b/app/routes/volunteer/outreach-opportunity/partials/outreach-partials.partial.tsx
@@ -9,6 +9,7 @@ import HTMLRenderer from '~/primitives/html-renderer';
 
 import type { VolunteerMissionDetail } from '../types';
 import {
+  AddToCalendarButton,
   MissionDetailRows,
   normalizeWhatToKnowContent,
   WhatToKnowBody,
@@ -130,6 +131,10 @@ export function Sidebar({
             {copied ? 'Link copied' : 'Share Link'}
           </span>
         </Button>
+        <AddToCalendarButton
+          mission={mission}
+          className='w-full rounded-full border-black/12 hover:border-ocean! text-neutral-darker hover:text-white!'
+        />
       </div>
     </OutreachSidebarShell>
   );
@@ -137,10 +142,12 @@ export function Sidebar({
 
 export function MobileBottomBar({
   copied,
+  mission,
   onCopyPath,
   onSignUpClick,
 }: {
   copied: boolean;
+  mission: VolunteerMissionDetail;
   onCopyPath: () => void;
   onSignUpClick: () => void;
 }) {
@@ -175,6 +182,11 @@ export function MobileBottomBar({
       >
         <Icon name='shareAlt' size={22} />
       </button>
+      <AddToCalendarButton
+        mission={mission}
+        showLabel={false}
+        className='flex size-12 min-w-0 shrink-0 rounded-full border-[0.5px] border-black/12 p-0 text-neutral-darker hover:border-ocean!'
+      />
       <Button
         intent='primary'
         type='button'

--- a/app/routes/volunteer/outreach-opportunity/types.ts
+++ b/app/routes/volunteer/outreach-opportunity/types.ts
@@ -27,6 +27,8 @@ export interface VolunteerMissionDetail {
   eventDateStr: string;
   eventTimeStr: string;
   eventEndTimeStr?: string;
+  calendarStartDateTime?: string;
+  calendarEndDateTime?: string;
   /** External or internal sign-up URL. */
   missionsUrl?: string;
   contactName?: string;


### PR DESCRIPTION
## Summary

Fixes several user-facing bugs and performance issues across Community Outreach, Events, Podcast Episode, and Location pages.

These changes are necessary to improve share/calendar interactions, align mobile carousel controls, ensure Location Page midweek data matches Algolia fields, and move Podcast Episode “More in this season” content to loader-prefetched data for better first paint.

## Screenshots

Screenshot provided in chat for the Events mobile carousel arrow alignment issue.

## Testing

- [x] Run `pnpm run check'
- [x] Run `pnpm test`
- [x] Manual QA recommended for:
  - Community Outreach date display, Add to Calendar, and share behavior
  - Events mobile featured carousel controls
  - Podcast Episode share button and platform tiles
  - Podcast Episode “More in this season” loader-backed rendering
  - Location Page “During the Week” data against Algolia records

## Tickets
[CFDP-3976](https://christfellowshipchurch.atlassian.net/browse/CFDP-3976)
[CFDP-3984](https://christfellowshipchurch.atlassian.net/browse/CFDP-3984)
[CFDP-3986](https://christfellowshipchurch.atlassian.net/browse/CFDP-3986)
[CFDP-3989](https://christfellowshipchurch.atlassian.net/browse/CFDP-3989)

## Changes Made

### New Components Added

- `app/routes/podcasts/podcast-episode/components/episode-share-button.component.tsx`
  - Adds a reusable Podcast Episode share button that copies the current full URL and displays copied-state feedback.

### New Utilities

- Updated `app/hooks/use-copy-page-path.ts`
  - Copies `window.location.href` instead of only the relative path.

- Added normalization helpers in `app/routes/locations/location-single/components/during-the-week.component.tsx`
  - Normalizes weekly ministry service fields from Algolia/canonical data while preserving fallback support for older field names.

- Added calendar helper logic in `app/routes/volunteer/outreach-opportunity/components/outreach-details.component.tsx`
  - Builds `.ics` downloads for Community Outreach opportunities.

### New Assets

- None.

### Dependencies

- None.

### Route Implementation

- `app/routes/volunteer/outreach-opportunity/outreach-mission-rock.server.ts`
  - Formats event dates as weekday-led labels, e.g. `Mon 12 Feb 2024`.
  - Adds calendar start/end datetime values.
  - Falls back to a one-hour calendar event when no valid end time exists.

- `app/routes/volunteer/outreach-opportunity/types.ts`
  - Adds optional `calendarStartDateTime` and `calendarEndDateTime`.

- `app/routes/volunteer/outreach-opportunity/components/outreach-details.component.tsx`
  - Adds an inline Add to Calendar icon button on the date row, aligned to the far right.

- `app/routes/events/all-events/partials/featured-events.partial.tsx`
  - Replaces absolute-positioned mobile carousel controls with an aligned flex control row.

- `app/routes/podcasts/podcast-episode/loader.tsx`
  - Prefetches same-season podcast episodes from Algolia in the loader.
  - Excludes the current episode by `rockItemId`.

- `app/routes/podcasts/podcast-episode/partials/more-episodes.partial.tsx`
  - Passes loader-prefetched hits into “More in this season.”

- `app/routes/podcasts/podcast-episode/components/more-episodes-search.tsx`
  - Removes client-side InstantSearch for this section.
  - Renders loader-backed hits directly and hides the section when empty.

- `app/routes/podcasts/podcast-episode/components/__tests__/more-episodes-search.test.tsx`
  - Updates tests for loader-backed rendering behavior.

- `app/routes/podcasts/podcast-episode/partials/episode-hero.partial.tsx`
  - Wires desktop/tablet Podcast Episode share buttons to the new share component.

- `app/routes/podcasts/podcast-episode/components/hero-mobile-content.component.tsx`
  - Wires mobile Podcast Episode share button to the new share component.

- `app/routes/podcasts/podcast-show/partials/subscribe-section.partial.tsx`
  - Makes the full social platform tile clickable instead of only the icon.

- `app/routes/locations/location-single/components/during-the-week.component.tsx`
  - Corrects Algolia field mapping for weekly ministry services.
  - Keeps “During the Week” limited to Monday through Friday.

### Key Features

- Community Outreach users can save opportunities to their calendar from the date row.
- Share buttons now copy complete absolute URLs.
- Events mobile carousel controls are visually aligned.
- Podcast Episode share buttons now fire correctly.
- Podcast platform tiles use the full button area as the click target.
- Podcast “More in this season” content is available from loader-prefetched Algolia data.
- Location “During the Week” data now reflects Algolia field names and excludes weekend entries.

[CFDP-3976]: https://christfellowshipchurch.atlassian.net/browse/CFDP-3976?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CFDP-3984]: https://christfellowshipchurch.atlassian.net/browse/CFDP-3984?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ