### PR TITLE
Split Todd & Julie byline & HTML Author Bio

### DIFF
--- a/app/routes/articles/article-single/components/__tests__/article-author.component.test.tsx
+++ b/app/routes/articles/article-single/components/__tests__/article-author.component.test.tsx
@@ -1,0 +1,55 @@
+import { MemoryRouter } from 'react-router-dom';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import ArticleAuthor from '../article-author.component';
+import type { AuthorProps } from '../../partials/hero.partial';
+
+const toddAndJulieAuthor: AuthorProps = {
+  fullName: 'Todd and Julie Mullins',
+  authorAttributes: {
+    authorId: '123',
+    pathname: 'todd-julie-mullins',
+  },
+};
+
+function renderArticleAuthor(author: AuthorProps) {
+  return render(
+    <MemoryRouter>
+      <ArticleAuthor
+        author={author}
+        publishDate='January 22, 2025'
+        readTime={4}
+      />
+    </MemoryRouter>,
+  );
+}
+
+describe('ArticleAuthor', () => {
+  it('splits Todd and Julie byline links into individual author pages', () => {
+    renderArticleAuthor(toddAndJulieAuthor);
+
+    expect(screen.getByRole('link', { name: 'Todd' })).toHaveAttribute(
+      'href',
+      '/author/todd-mullins',
+    );
+    expect(screen.getByRole('link', { name: 'Julie' })).toHaveAttribute(
+      'href',
+      '/author/julie-mullins',
+    );
+    expect(screen.getByText(/Authored by/i)).toHaveTextContent(
+      'Authored by Todd and Julie Mullins',
+    );
+  });
+
+  it('does not link Todd and Julie content to the combined author page', () => {
+    renderArticleAuthor(toddAndJulieAuthor);
+
+    const links = screen.getAllByRole('link');
+    expect(
+      links.some(
+        (link) => link.getAttribute('href') === '/author/todd-julie-mullins',
+      ),
+    ).toBe(false);
+  });
+});

--- a/app/routes/articles/article-single/components/article-author.component.tsx
+++ b/app/routes/articles/article-single/components/article-author.component.tsx
@@ -1,7 +1,60 @@
-import * as Avatar from '@radix-ui/react-avatar';
-import { CircleLoader } from '~/primitives/loading-states/circle-loader.primitive';
-import { AuthorProps } from '../partials/hero.partial';
 import { Link } from 'react-router-dom';
+import type { ReactNode } from 'react';
+import * as Avatar from '@radix-ui/react-avatar';
+
+import { CircleLoader } from '~/primitives/loading-states/circle-loader.primitive';
+
+import type { AuthorProps } from '../partials/hero.partial';
+
+const DEFAULT_AUTHOR_PATHNAME = 'christ-fellowship-team';
+const TODD_AND_JULIE_AUTHOR_PATHNAME = 'todd-julie-mullins';
+const TODD_AUTHOR_PATHNAME = 'todd-mullins';
+const JULIE_AUTHOR_PATHNAME = 'julie-mullins';
+
+function getAuthorPathname(author: AuthorProps) {
+  if (
+    author?.authorAttributes?.pathname &&
+    author?.authorAttributes?.pathname !== 'undefined'
+  ) {
+    return author.authorAttributes.pathname;
+  }
+
+  if (
+    author?.authorAttributes?.authorId &&
+    author?.authorAttributes?.authorId !== 'undefined'
+  ) {
+    return author.authorAttributes.authorId;
+  }
+
+  return DEFAULT_AUTHOR_PATHNAME;
+}
+
+function isToddAndJulieAuthor(author: AuthorProps, authorPathname: string) {
+  const normalizedFullName = author.fullName.trim().toLowerCase();
+
+  return (
+    authorPathname === TODD_AND_JULIE_AUTHOR_PATHNAME ||
+    normalizedFullName === 'todd and julie mullins'
+  );
+}
+
+function AuthorNameLink({
+  children,
+  pathname,
+}: {
+  children: ReactNode;
+  pathname: string;
+}) {
+  return (
+    <Link
+      to={`/author/${pathname}`}
+      prefetch='intent'
+      className='underline hover:text-text-secondary'
+    >
+      {children}
+    </Link>
+  );
+}
 
 export default function ArticleAuthor({
   author,
@@ -12,22 +65,15 @@ export default function ArticleAuthor({
   publishDate: string;
   readTime: number;
 }) {
-  let authorPathname = 'christ-fellowship-team';
-  if (
-    author?.authorAttributes?.pathname &&
-    author?.authorAttributes?.pathname !== 'undefined'
-  ) {
-    authorPathname = author?.authorAttributes?.pathname;
-  } else if (
-    author?.authorAttributes?.authorId &&
-    author?.authorAttributes?.authorId !== 'undefined'
-  ) {
-    authorPathname = author?.authorAttributes?.authorId;
-  }
+  const authorPathname = getAuthorPathname(author);
+  const isToddAndJulie = isToddAndJulieAuthor(author, authorPathname);
+  const avatarAuthorPathname = isToddAndJulie
+    ? TODD_AUTHOR_PATHNAME
+    : authorPathname;
 
   return (
     <div className='flex'>
-      <Link prefetch='intent' to={`/author/${authorPathname}`}>
+      <Link prefetch='intent' to={`/author/${avatarAuthorPathname}`}>
         <Avatar.Root className='flex cursor-pointer duration-300 hover:scale-105'>
           <Avatar.Image
             className='size-16 rounded-full'
@@ -46,13 +92,22 @@ export default function ArticleAuthor({
       <div className='ml-4 flex flex-col justify-center'>
         <h2 className='semibold mb-2'>
           Authored by{' '}
-          <Link
-            to={`/author/${authorPathname}`}
-            prefetch='intent'
-            className='underline hover:text-text-secondary'
-          >
-            {author?.fullName || 'Christ Fellowship Church'}
-          </Link>
+          {isToddAndJulie ? (
+            <>
+              <AuthorNameLink pathname={TODD_AUTHOR_PATHNAME}>
+                Todd
+              </AuthorNameLink>{' '}
+              and{' '}
+              <AuthorNameLink pathname={JULIE_AUTHOR_PATHNAME}>
+                Julie
+              </AuthorNameLink>{' '}
+              Mullins
+            </>
+          ) : (
+            <AuthorNameLink pathname={authorPathname}>
+              {author?.fullName || 'Christ Fellowship Church'}
+            </AuthorNameLink>
+          )}
         </h2>
         <div className='flex text-neutral-500 font-normal'>
           {publishDate && (

--- a/app/routes/author/loader.ts
+++ b/app/routes/author/loader.ts
@@ -2,6 +2,13 @@ import { LoaderFunction } from 'react-router-dom';
 import { createImageUrlFromGuid } from '~/lib/utils';
 import { format } from 'date-fns';
 import { Author } from './types';
+import {
+  fetchAuthorData,
+  fetchPersonAliasGuid,
+  fetchAuthorArticles,
+  fetchAuthorId,
+  fetchAuthorByPathname,
+} from '~/lib/.server/author-utils';
 
 interface ArticleData {
   title: string;
@@ -13,13 +20,15 @@ interface ArticleData {
     url?: { value: string };
   };
 }
-import {
-  fetchAuthorData,
-  fetchPersonAliasGuid,
-  fetchAuthorArticles,
-  fetchAuthorId,
-  fetchAuthorByPathname,
-} from '~/lib/.server/author-utils';
+
+interface RockAttributeValue {
+  value?: string | null;
+  valueFormatted?: string | null;
+}
+
+function getHtmlAttributeValue(attribute?: RockAttributeValue) {
+  return attribute?.valueFormatted?.trim() || attribute?.value || '';
+}
 
 // Utility function to check if a string is a GUID
 const isGuid = (str: string): boolean => {
@@ -83,7 +92,7 @@ export const getAuthorDetailsByPathname = async (pathname: string) => {
         uri: createImageUrlFromGuid(authorData.photo?.guid) || null,
       },
       authorAttributes: {
-        bio: authorData?.attributeValues?.authorBio?.value || '',
+        bio: getHtmlAttributeValue(authorData?.attributeValues?.authorBio),
         authorId: authorData.id,
         jobTitle: authorData?.attributeValues?.jobTitle?.value || '',
         socialLinks,
@@ -217,7 +226,7 @@ export const getAuthorDetails = async (personId: string) => {
         uri: createImageUrlFromGuid(authorData.photo?.guid) || null,
       },
       authorAttributes: {
-        bio: authorData?.attributeValues?.authorBio?.value || '',
+        bio: getHtmlAttributeValue(authorData?.attributeValues?.authorBio),
         authorId: personId,
         jobTitle: authorData?.attributeValues?.jobTitle?.value || '',
         socialLinks,

--- a/app/routes/author/meta.ts
+++ b/app/routes/author/meta.ts
@@ -2,6 +2,14 @@ import type { MetaFunction } from 'react-router-dom';
 import { loader } from './loader';
 import { Author } from './types';
 import { createMeta } from '~/lib/meta-utils';
+import { sanitizeCmsHtml } from '~/lib/sanitize';
+
+function htmlToMetaDescription(html: string) {
+  return sanitizeCmsHtml(html)
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
 
 export const meta: MetaFunction<typeof loader> = ({ data }) => {
   if (!data) {
@@ -11,9 +19,10 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
     });
   }
   const author = data as Author;
+  const description = htmlToMetaDescription(author.authorAttributes?.bio ?? '');
+
   return createMeta({
     title: author.fullName,
-    description:
-      author.authorAttributes?.bio ?? 'Author at Christ Fellowship Church',
+    description: description || 'Author at Christ Fellowship Church',
   });
 };

--- a/app/routes/author/partials/author-bio.tsx
+++ b/app/routes/author/partials/author-bio.tsx
@@ -84,11 +84,7 @@ export function AuthorBio({
             {socialLinks && <ShareLinks {...shareLinksProps} />}
           </div>
         )}
-        {bio && (
-          <p>
-            <HTMLRenderer html={bio} />
-          </p>
-        )}
+        {bio && <HTMLRenderer html={bio} />}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Updates article/author handling so Todd and Julie author attribution can link to their individual author pages instead of the combined `todd-julie-mullins` page, and updates author bio rendering to support HTML content.

Important follow-up note: we are waiting on confirmation from Austin that this is the desired direction. If confirmed:

- Pam must update ALL AUTHORS by adding content into the new Author Bio HTML attribute, as well as updating their links.
- The old Author Bio attribute should be deleted once done from [here](https://rock.gocf.org/admin/general/person-attributes).

## Screenshots

N/A

## Testing

- [x] `pnpm test` runs successfully.
- [x] Ran lint: `pnpm run check` and no new warnings or errors are showing.
- [x] Verified Todd and Julie byline renders as natural text with separate links for `Todd` and `Julie`. You can test in `/articles/daily-declarations`
- [x] Verified the combined `/author/todd-julie-mullins` link is no longer used for the Todd and Julie article byline
- [x] Verified author bio renders as HTML (visit `/author/todd-julie-mullins` to see this, only author with this attribute filled out currently)

## Tickets
[CFDP-3995](https://christfellowshipchurch.atlassian.net/browse/CFDP-3995)

## Changes Made

### New Components Added

- None

### New Utilities

- `app/routes/articles/article-single/components/article-author.component.tsx`
  - Added author pathname helper logic.
  - Added Todd and Julie byline detection.
  - Added reusable `AuthorNameLink` helper for author byline links.

- `app/routes/author/loader.ts`
  - Added `getHtmlAttributeValue()` to prefer Rock `valueFormatted` HTML content and fall back to plain `value`.

- `app/routes/author/meta.ts`
  - Added HTML-to-plain-text conversion for author meta descriptions so HTML bios do not leak markup into SEO metadata.

### New Assets

- None

### Dependencies

- None

### Route Implementation

- `app/routes/articles/article-single/components/article-author.component.tsx`
  - Overrides the Todd and Julie article byline so `Todd` links to `/author/todd-mullins` and `Julie` links to `/author/julie-mullins`.
  - Prevents Todd and Julie bylines from using `/author/todd-julie-mullins`.

- `app/routes/author/loader.ts`
  - Author bios now load HTML-capable attribute content via `valueFormatted` when available.

- `app/routes/author/partials/author-bio.tsx`
  - Removes the mobile `<p>` wrapper around `HTMLRenderer` so author bio HTML can render block elements correctly.

- `app/routes/author/meta.ts`
  - Keeps author page meta descriptions plain text even when the rendered bio is HTML.

### Key Features

- Todd and Julie article bylines now display as natural text: `Todd and Julie Mullins`.
- `Todd` and `Julie` are independently clickable links.
- The combined Todd and Julie author page is no longer used for the byline.
- Author bios can render HTML content safely through the existing sanitized HTML renderer.
- Added focused regression tests for the Todd and Julie split-link behavior.

[CFDP-3995]: https://christfellowshipchurch.atlassian.net/browse/CFDP-3995?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ