### PR TITLE
Events + Navigation Update

### DIFF
--- a/app/components/navbar/desktop/menu-content.component.tsx
+++ b/app/components/navbar/desktop/menu-content.component.tsx
@@ -33,15 +33,9 @@ export const MenuContent: React.FC<
   MenuLink['content'] & { isLoading: boolean; menuType: string }
 > = ({ mainContent, featureCards, isLoading = true, menuType = 'media' }) => {
   return (
-    <div
-      style={{
-        background:
-          'linear-gradient(to right, white 0%, white 80%, #F3F5FA 80%, #F3F5FA 100%)',
-      }}
-      className='w-screen shadow-sm flex items-center justify-center content-padding'
-    >
-      <div className='max-w-screen-content mx-auto w-full flex flex-col lg:flex-row'>
-        <div className='bg-white grid grid-cols-3 xl:gap-8 w-full ml-auto '>
+    <div className='w-screen overflow-hidden bg-white shadow-sm flex items-center justify-center content-padding'>
+      <div className='relative isolate max-w-screen-content mx-auto w-full flex flex-col lg:flex-row'>
+        <div className='bg-white grid grid-cols-3 xl:gap-8 w-full ml-auto'>
           {mainContent.map((section, index) => (
             <div className='w-full px-4 py-8' key={index}>
               <h4 className='font-medium text-link-secondary'>
@@ -80,7 +74,8 @@ export const MenuContent: React.FC<
 
         <div
           className={cn(
-            'py-6 w-1/2 min-w-[340px] max-w-[400px] bg-gray flex flex-col gap-4 items-end',
+            'relative py-6 w-1/2 min-w-[340px] max-w-[400px] bg-gray flex flex-col gap-4 items-end',
+            'before:absolute before:inset-y-0 before:left-0 before:-z-10 before:w-screen before:bg-gray',
             featureCards.length > 1 ? 'pl-4 3xl:pl-6!' : 'pl-0',
             featureCards.length > 1 && 'pb-14',
           )}

--- a/app/components/navbar/desktop/search/content-hit.component.tsx
+++ b/app/components/navbar/desktop/search/content-hit.component.tsx
@@ -66,6 +66,10 @@ export const getPathname = (
     contentTypeLower === 'redirect card' ||
     contentTypeLower === 'page builder'
   ) {
+    if (pathname.startsWith('http')) {
+      return pathname;
+    }
+
     return `/${pathname}`;
   }
 

--- a/app/components/navbar/mobile/search/mobile-content-hit.component.tsx
+++ b/app/components/navbar/mobile/search/mobile-content-hit.component.tsx
@@ -18,12 +18,11 @@ export type MobileContentHitType = {
 
 export function MobileContentHit({ hit }: { hit: MobileContentHitType }) {
   const imageUrl = hit.coverImage?.sources?.[0]?.uri || '';
+  const pathname = hit?.routing?.pathname || '';
+  const to = pathname.startsWith('http') ? pathname : `/${pathname}`;
 
   return (
-    <Link
-      to={`/${hit?.routing?.pathname || ''}`}
-      className='flex gap-2 pb-2 w-full'
-    >
+    <Link to={to} className='flex gap-2 pb-2 w-full'>
       <img
         src={imageUrl}
         alt={hit.title}

--- a/app/components/navbar/mobile/search/search-popup.component.tsx
+++ b/app/components/navbar/mobile/search/search-popup.component.tsx
@@ -140,7 +140,7 @@ export const SearchPopup = ({
     : contentHits;
 
   return (
-    <div className='size-full p-4 !pt-0 md:p-6 md:!pt-6'>
+    <div className='size-full p-4 pt-0! md:p-6 md:pt-6!'>
       {/* Always render content collector to receive search updates */}
       <ContentItemsHitsCollector onHitsChange={setContentHits} />
 

--- a/app/components/navbar/navbar.component.tsx
+++ b/app/components/navbar/navbar.component.tsx
@@ -201,6 +201,7 @@ export function Navbar() {
   const latestMessageFeaturedUrl = getLatestMessageFeaturedUrl(
     watchReadListen?.featureCards,
   );
+  const isTransparentMode = mode === 'dark' && !openDropdown && !isSearchOpen;
 
   // Search handling
   const handleSearchClick = () => {
@@ -408,10 +409,11 @@ export function Navbar() {
                     aria-label='Give'
                     className={cn(
                       'rounded-lg px-4 font-semibold text-sm xl:text-base',
-                      'border border-ocean cursor-pointer',
-                      'text-ocean transition-colors duration-200',
-                      'hover:bg-ocean/20 transition-colors duration-200',
+                      'border cursor-pointer transition-colors duration-200',
                       'flex items-center justify-center',
+                      isTransparentMode
+                        ? 'border-white text-white hover:bg-white/20 group-hover:border-ocean group-hover:text-ocean group-hover:hover:bg-ocean/20'
+                        : 'border-ocean text-ocean hover:bg-ocean/20',
                     )}
                   >
                     Give

--- a/app/components/navbar/navbar.data.tsx
+++ b/app/components/navbar/navbar.data.tsx
@@ -92,7 +92,7 @@ export const ministriesData: MenuLink = {
         title: 'Take the Journey',
         subtitle: 'new classes',
         callToAction: {
-          title: 'Sign up now',
+          title: 'Take the Journey Class',
           url: '/events/journey',
         },
         image: 'https://picsum.photos/282/228',

--- a/app/components/navbar/navbar.data.tsx
+++ b/app/components/navbar/navbar.data.tsx
@@ -30,7 +30,7 @@ export const ministriesData: MenuLink = {
           },
           {
             title: 'Special Needs',
-            description: 'Children and adults',
+            description: 'Children & Adults',
             url: '/ministries/special-needs',
           },
         ],
@@ -41,12 +41,12 @@ export const ministriesData: MenuLink = {
         items: [
           {
             title: 'Men',
-            description: 'Men of all ages',
+            description: 'Men of All Ages',
             url: '/ministries/men',
           },
           {
             title: 'Women',
-            description: 'Girls in every season',
+            description: 'Girls in Every Season',
             url: '/ministries/women',
           },
           {
@@ -56,7 +56,7 @@ export const ministriesData: MenuLink = {
           },
           {
             title: 'Freedom & Care',
-            description: 'Healing and Freedom',
+            description: 'Healing & Freedom',
             url: '/ministries/freedom-and-care',
           },
         ],
@@ -65,12 +65,12 @@ export const ministriesData: MenuLink = {
         title: 'COMMUNITY',
         items: [
           {
-            title: 'Group Finder',
+            title: 'Find a Group',
             description: 'Find community',
             url: '/group-finder',
           },
           {
-            title: 'Class Finder',
+            title: 'Find a Class',
             description: 'Learn together',
             url: '/class-finder',
           },

--- a/app/primitives/cards/ministry-card.tsx
+++ b/app/primitives/cards/ministry-card.tsx
@@ -11,23 +11,39 @@ export function MinistryCard({
   image: string;
   url: string;
 }) {
+  const isExternalLink = url.startsWith('http');
+  const cardClassName =
+    'rounded-lg border border-neutral-lighter overflow-hidden shadow-md cursor-pointer hover:translate-y-[-4px] transition-all duration-300 flex flex-col h-full';
+  const cardContent = (
+    <>
+      <img
+        src={`${image}&quality=20`}
+        alt={title}
+        className='w-full aspect-video object-cover'
+      />
+      <div className='flex flex-col p-6 gap-4 bg-white flex-1'>
+        <h3 className='text-[24px] font-bold leading-none'>{title}</h3>
+        <p className='text-text-secondary flex-1'>{description}</p>
+      </div>
+    </>
+  );
+
   return (
     <div className='h-full pt-1'>
-      <Link
-        to={url}
-        prefetch='intent'
-        className='rounded-lg border border-neutral-lighter overflow-hidden shadow-md cursor-pointer hover:translate-y-[-4px] transition-all duration-300 flex flex-col h-full'
-      >
-        <img
-          src={`${image}&quality=20`}
-          alt={title}
-          className='w-full aspect-video object-cover'
-        />
-        <div className='flex flex-col p-6 gap-4 bg-white flex-1'>
-          <h3 className='text-[24px] font-bold leading-none'>{title}</h3>
-          <p className='text-text-secondary flex-1'>{description}</p>
-        </div>
-      </Link>
+      {isExternalLink ? (
+        <a
+          href={url}
+          target='_blank'
+          rel='noopener noreferrer'
+          className={cardClassName}
+        >
+          {cardContent}
+        </a>
+      ) : (
+        <Link to={url} prefetch='intent' className={cardClassName}>
+          {cardContent}
+        </Link>
+      )}
     </div>
   );
 }

--- a/app/primitives/cards/resource-card.tsx
+++ b/app/primitives/cards/resource-card.tsx
@@ -7,10 +7,12 @@ import { CollectionItem } from '~/routes/page-builder/types';
 export const ResourceCard = ({
   resource,
   className,
+  summaryClassName,
   linkState,
 }: {
   resource: CollectionItem;
   className?: string;
+  summaryClassName?: string;
   /** Optional state to pass to the Link (e.g. { fromEvents: '/events?q=...' } for back navigation). */
   linkState?: Record<string, unknown>;
 }) => {
@@ -66,7 +68,10 @@ export const ResourceCard = ({
             {name}
           </h4>
 
-          <HtmlRenderer html={summary || ''} className='line-clamp-3' />
+          <HtmlRenderer
+            html={summary || ''}
+            className={cn('line-clamp-3', summaryClassName)}
+          />
         </div>
       </div>
     </>

--- a/app/routes/events/all-events/components/all-events-content.component.tsx
+++ b/app/routes/events/all-events/components/all-events-content.component.tsx
@@ -1,4 +1,4 @@
-import { useLoaderData } from 'react-router-dom';
+import { Link, useLoaderData } from 'react-router-dom';
 import { useEffect, useMemo, useState, type RefObject } from 'react';
 import { liteClient as algoliasearch } from 'algoliasearch/lite';
 import {
@@ -47,6 +47,105 @@ const { InstantSearchUrlSync, buildUiState } =
 const AllEventsInstantSearchSync = InstantSearchUrlSync;
 const buildAllEventsInstantSearchUiState = buildUiState;
 
+function formatMobileEventDateParts(isoDate: string) {
+  const date = new Date(isoDate);
+
+  return {
+    month: date
+      .toLocaleDateString('en-US', {
+        timeZone: 'America/New_York',
+        month: 'short',
+      })
+      .toUpperCase(),
+    day: date.toLocaleDateString('en-US', {
+      timeZone: 'America/New_York',
+      day: 'numeric',
+    }),
+    weekday: date
+      .toLocaleDateString('en-US', {
+        timeZone: 'America/New_York',
+        weekday: 'short',
+      })
+      .toUpperCase(),
+  };
+}
+
+function getEventHitLocation(
+  hit: ContentItemHit,
+  multipleLabel = 'Multiple Locations',
+) {
+  return hit.eventLocations && hit.eventLocations.length > 1
+    ? multipleLabel
+    : hit.eventLocations?.[0] ||
+        hit.locations?.[0]?.name ||
+        'Christ Fellowship Church';
+}
+
+function MobileEventHitCard({
+  hit,
+  fromEventsUrl,
+}: {
+  hit: ContentItemHit;
+  fromEventsUrl: string;
+}) {
+  const dateParts = hit.startDateTime
+    ? formatMobileEventDateParts(hit.startDateTime)
+    : null;
+  const location = getEventHitLocation(hit, 'Multiple campuses');
+
+  return (
+    <Link
+      to={`/events/${hit.url}`}
+      state={fromEventsUrl ? { fromEvents: fromEventsUrl } : undefined}
+      className='flex h-[88px] w-full items-start overflow-hidden rounded-xl border border-neutral-lighter bg-white text-text-primary transition-colors duration-200 hover:border-neutral-light md:hidden'
+      prefetch='intent'
+    >
+      <div className='flex h-[88px] w-[74px] shrink-0 flex-col items-center justify-center px-[7px] py-[7px] text-center leading-normal'>
+        {dateParts ? (
+          <time dateTime={hit.startDateTime} className='block'>
+            <span className='block text-xs font-semibold leading-[18px] opacity-70'>
+              {dateParts.month}
+            </span>
+            <span className='block text-2xl font-extrabold leading-9'>
+              {dateParts.day}
+            </span>
+            <span className='block text-xs font-semibold leading-[18px] opacity-70'>
+              {dateParts.weekday}
+            </span>
+          </time>
+        ) : null}
+      </div>
+
+      <div className='flex h-[88px] min-w-0 flex-1 items-center pr-1'>
+        <div className='flex h-full min-w-0 flex-1 flex-col justify-center gap-2 py-2 pl-1 pr-4'>
+          <h4 className='line-clamp-2 w-full text-base font-bold leading-[1.4] text-pretty'>
+            {hit.title}
+          </h4>
+
+          <div className='flex min-w-0 items-center gap-1'>
+            <Icon
+              name='map'
+              color='currentColor'
+              size={18}
+              className='shrink-0'
+            />
+            <p className='truncate text-sm font-semibold leading-normal'>
+              {location}
+            </p>
+          </div>
+        </div>
+
+        <Icon
+          name='chevronRight'
+          color='currentColor'
+          size={24}
+          className='shrink-0 text-neutral-light'
+        />
+      </div>
+    </Link>
+  );
+}
+
 function EventHit({
   hit,
   fromEventsUrl,
@@ -59,27 +158,28 @@ function EventHit({
     : '';
 
   const imageUri = hit.coverImage?.sources?.[0]?.uri ?? '';
+  const location = getEventHitLocation(hit);
 
   return (
-    <ResourceCard
-      resource={{
-        id: hit.objectID,
-        contentChannelId: '78',
-        contentType: 'EVENTS',
-        name: hit.title,
-        summary: hit.summary ?? '',
-        image: imageUri,
-        pathname: `/events/${hit.url}`,
-        startDate: formattedDate,
-        location:
-          hit.eventLocations && hit.eventLocations.length > 1
-            ? 'Multiple Locations'
-            : hit.eventLocations?.[0] ||
-              hit.locations?.[0]?.name ||
-              'Christ Fellowship Church',
-      }}
-      linkState={fromEventsUrl ? { fromEvents: fromEventsUrl } : undefined}
-    />
+    <>
+      <MobileEventHitCard hit={hit} fromEventsUrl={fromEventsUrl} />
+      <div className='hidden h-full md:block'>
+        <ResourceCard
+          resource={{
+            id: hit.objectID,
+            contentChannelId: '78',
+            contentType: 'EVENTS',
+            name: hit.title,
+            summary: hit.summary ?? '',
+            image: imageUri,
+            pathname: `/events/${hit.url}`,
+            startDate: formattedDate,
+            location,
+          }}
+          linkState={fromEventsUrl ? { fromEvents: fromEventsUrl } : undefined}
+        />
+      </div>
+    </>
   );
 }
 
@@ -424,7 +524,7 @@ function AllEventsResultsLayout({
         {eventHits.length === 0 && !isLoading ? null : (
           <ul
             className={cn(
-              'grid w-full list-none grid-cols-1 justify-items-center gap-10 p-0 md:grid-cols-2 lg:grid-cols-3',
+              'grid w-full list-none grid-cols-1 justify-items-center gap-4 p-0 md:grid-cols-2 md:gap-10 lg:grid-cols-3',
               isLoading && 'opacity-60 pointer-events-none',
             )}
             role='list'

--- a/app/routes/events/all-events/components/featured-card.component.tsx
+++ b/app/routes/events/all-events/components/featured-card.component.tsx
@@ -1,3 +1,5 @@
+import { Link } from 'react-router-dom';
+
 import { Button } from '~/primitives/button/button.primitive';
 import Icon from '~/primitives/icon';
 import HtmlRenderer from '~/primitives/html-renderer';
@@ -29,9 +31,9 @@ export const FeaturedEventCard = ({ card }: { card: ContentItemHit }) => {
     locations && locations.length > 1
       ? 'Multiple Locations'
       : locations?.[0]?.name || 'Christ Fellowship Church';
-
-  return (
-    <div className='flex flex-col md:h-[400px] lg:h-[420px] xl:h-[450px] md:flex-row items-center justify-center size-full overflow-hidden rounded-xl border border-neutral-lighter'>
+  const eventPath = `/events/${url}`;
+  const cardContent = (showButton: boolean) => (
+    <>
       <img
         src={image}
         alt={title}
@@ -65,14 +67,28 @@ export const FeaturedEventCard = ({ card }: { card: ContentItemHit }) => {
           )}
         </div>
 
-        <Button
-          intent='secondary'
-          className='font-normal'
-          href={`/events/${url}`}
-        >
-          Save my spot
-        </Button>
+        {showButton ? (
+          <Button intent='secondary' className='font-normal' href={eventPath}>
+            Save my spot
+          </Button>
+        ) : null}
       </div>
-    </div>
+    </>
+  );
+
+  return (
+    <>
+      <Link
+        to={eventPath}
+        className='flex flex-col items-center justify-center size-full overflow-hidden rounded-xl border border-neutral-lighter md:hidden'
+        prefetch='intent'
+      >
+        {cardContent(false)}
+      </Link>
+
+      <div className='hidden md:flex md:h-[400px] lg:h-[420px] xl:h-[450px] md:flex-row items-center justify-center size-full overflow-hidden rounded-xl border border-neutral-lighter'>
+        {cardContent(true)}
+      </div>
+    </>
   );
 };

--- a/app/routes/events/all-events/components/featured-card.component.tsx
+++ b/app/routes/events/all-events/components/featured-card.component.tsx
@@ -1,6 +1,5 @@
 import { Link } from 'react-router-dom';
 
-import { Button } from '~/primitives/button/button.primitive';
 import Icon from '~/primitives/icon';
 import HtmlRenderer from '~/primitives/html-renderer';
 import { ContentItemHit } from '~/routes/search/types';
@@ -14,11 +13,34 @@ export function formatEventCardDate(isoDate: string) {
   });
 }
 
+export function formatFeaturedEventDate(isoDate: string) {
+  const date = new Date(isoDate);
+  const weekday = date.toLocaleDateString('en-US', {
+    timeZone: 'America/New_York',
+    weekday: 'short',
+  });
+  const day = date.toLocaleDateString('en-US', {
+    timeZone: 'America/New_York',
+    day: '2-digit',
+  });
+  const month = date.toLocaleDateString('en-US', {
+    timeZone: 'America/New_York',
+    month: 'short',
+  });
+  const year = date.toLocaleDateString('en-US', {
+    timeZone: 'America/New_York',
+    year: 'numeric',
+  });
+
+  return `${weekday} ${day} ${month} ${year}`;
+}
+
 export const FeaturedEventCard = ({ card }: { card: ContentItemHit }) => {
   const {
     title,
     coverImage,
     startDateTime,
+    eventLocations,
     locations,
     summary,
     url,
@@ -26,69 +48,72 @@ export const FeaturedEventCard = ({ card }: { card: ContentItemHit }) => {
   } = card;
 
   const image = coverImage?.sources[0]?.uri || '';
-  const formattedDate = startDateTime ? formatEventCardDate(startDateTime) : '';
+  const formattedDate = startDateTime
+    ? formatFeaturedEventDate(startDateTime)
+    : '';
   const campus =
-    locations && locations.length > 1
+    eventLocations && eventLocations.length > 1
       ? 'Multiple Locations'
-      : locations?.[0]?.name || 'Christ Fellowship Church';
+      : eventLocations?.[0] ||
+        (locations && locations.length > 1
+          ? 'Multiple Locations'
+          : locations?.[0]?.name) ||
+        'Christ Fellowship Church';
   const eventPath = `/events/${url}`;
-  const cardContent = (showButton: boolean) => (
-    <>
+
+  return (
+    <Link
+      to={eventPath}
+      className='flex flex-col md:h-[400px] lg:h-[420px] xl:h-[450px] md:flex-row items-center justify-center size-full overflow-hidden rounded-2xl md:rounded-xl border border-neutral-lighter'
+      prefetch='intent'
+    >
       <img
         src={image}
         alt={title}
-        className='w-full md:w-1/2 aspect-video md:aspect-auto max-w-[720px] h-full object-cover'
+        className='h-[124px] w-full object-cover md:h-full md:w-1/2 md:aspect-auto md:max-w-[720px]'
       />
 
-      <div className='flex flex-col justify-center gap-4 bg-white p-5 md:p-12 w-full md:h-[400px] lg:h-[420px] xl:h-[450px]'>
+      <div className='flex flex-col justify-center gap-4 bg-white px-5 pb-5 md:p-12 w-full md:h-[400px] lg:h-[420px] xl:h-[450px]'>
         <div className='flex flex-col gap-4'>
-          <ul className='flex gap-4'>
-            <li className='flex items-center gap-1'>
-              {startDateTime && <Icon name='calendarAlt' color='black' />}
-              <p className='text-sm'>{formattedDate}</p>
-            </li>
+          <div className='pt-4 md:hidden'>
+            <p className='text-sm font-extrabold leading-normal text-ocean'>
+              FEATURED EVENT
+            </p>
+          </div>
 
-            <li className='flex items-center gap-1'>
-              {campus && <Icon name='map' color='black' />}
-              <p className='text-sm'>{campus}</p>
-            </li>
-          </ul>
-
-          <h4 className='font-extrabold text-[28px] leading-tight text-pretty'>
+          <h4 className='text-2xl font-extrabold leading-[1.4] text-pretty md:text-[28px] md:leading-tight'>
             {title}
           </h4>
           {summary ? (
-            <p>{summary}</p>
+            <p className='leading-normal'>{summary}</p>
           ) : (
             <HtmlRenderer
               html={htmlContent || ''}
               className={`line-clamp-5  ${htmlContent ? 'block' : 'hidden'}`}
             />
           )}
+
+          <ul className='flex flex-col gap-2 md:flex-row md:gap-4'>
+            <li className='flex items-center gap-1'>
+              {startDateTime && <Icon name='calendarAlt' color='black' />}
+              <p className='text-base font-bold leading-normal md:text-sm md:font-normal'>
+                {formattedDate}
+              </p>
+            </li>
+
+            <li className='flex items-center gap-1'>
+              {campus && <Icon name='map' color='black' />}
+              <p className='text-base font-bold leading-normal md:text-sm md:font-normal'>
+                {campus}
+              </p>
+            </li>
+          </ul>
         </div>
 
-        {showButton ? (
-          <Button intent='secondary' className='font-normal' href={eventPath}>
-            Save my spot
-          </Button>
-        ) : null}
+        <span className='hidden min-h-12 w-fit min-w-24 items-center justify-center rounded-md border border-ocean px-6 py-3 text-center text-lg font-normal text-ocean transition-colors delay-50 hover:bg-ocean hover:text-white md:inline-flex'>
+          Save my spot
+        </span>
       </div>
-    </>
-  );
-
-  return (
-    <>
-      <Link
-        to={eventPath}
-        className='flex flex-col items-center justify-center size-full overflow-hidden rounded-xl border border-neutral-lighter md:hidden'
-        prefetch='intent'
-      >
-        {cardContent(false)}
-      </Link>
-
-      <div className='hidden md:flex md:h-[400px] lg:h-[420px] xl:h-[450px] md:flex-row items-center justify-center size-full overflow-hidden rounded-xl border border-neutral-lighter'>
-        {cardContent(true)}
-      </div>
-    </>
+    </Link>
   );
 };

--- a/app/routes/events/all-events/partials/featured-events.partial.tsx
+++ b/app/routes/events/all-events/partials/featured-events.partial.tsx
@@ -1,16 +1,12 @@
 import type { ReactNode } from 'react';
+import { Link } from 'react-router-dom';
+
+import { Icon } from '~/primitives/icon/icon';
 import { ResourceCard } from '~/primitives/cards/resource-card';
-import {
-  Carousel,
-  CarouselArrows,
-  CarouselContent,
-  CarouselDots,
-  CarouselItem,
-} from '~/primitives/shadcn-primitives/carousel';
 import { ContentItemHit } from '~/routes/search/types';
 import {
   FeaturedEventCard,
-  formatEventCardDate,
+  formatFeaturedEventDate,
 } from '../components/featured-card.component';
 
 export function FeaturedEventsSectionLayout({
@@ -19,7 +15,7 @@ export function FeaturedEventsSectionLayout({
   children: ReactNode;
 }) {
   return (
-    <div className='w-full py-28 content-padding bg-gray'>
+    <div className='w-full py-16 md:py-28 content-padding bg-gray'>
       <div className='flex min-h-88 flex-col max-w-screen-content mx-auto md:min-h-112'>
         {children}
       </div>
@@ -47,50 +43,91 @@ export function FeaturedEventsFromHits({ hits }: { hits: ContentItemHit[] }) {
       </div>
 
       {remainingHits.length > 0 && (
-        <div className='-ml-5 md:ml-0 mt-12 md:hidden'>
-          <Carousel
-            opts={{
-              align: 'start',
-            }}
-            className='w-full'
-          >
-            <CarouselContent className='py-2 gap-4'>
-              {remainingHits.map((hit, index) => (
-                <CarouselItem
-                  key={hit.objectID}
-                  className='w-full basis-[360px] pl-0'
-                  style={{
-                    marginLeft: index === 0 ? '20px' : '0px',
-                    marginRight:
-                      index === remainingHits.length - 1 ? '20px' : '0px',
-                  }}
-                >
-                  <OtherFeatureEventCardHit hit={hit} />
-                </CarouselItem>
-              ))}
-            </CarouselContent>
-
-            <div className='w-full relative mt-4 pb-4'>
-              <div className='absolute h-12 top-7 left-5'>
-                <CarouselDots
-                  activeClassName='bg-ocean'
-                  inactiveClassName='bg-neutral-lighter'
-                />
-              </div>
-
-              <div className='absolute h-12 right-44 lg:right-44 2xl:right-36 3xl:right-28'>
-                <CarouselArrows />
-              </div>
-            </div>
-          </Carousel>
+        <div className='mt-8 flex w-full flex-col gap-2 md:hidden'>
+          {remainingHits.map((hit) => (
+            <OtherFeatureEventMobileCardHit hit={hit} key={hit.objectID} />
+          ))}
         </div>
       )}
     </>
   );
 }
 
+function getFeaturedEventLocation(hit: ContentItemHit) {
+  return hit.eventLocations && hit.eventLocations.length > 1
+    ? 'Multiple Locations'
+    : hit.eventLocations?.[0] ||
+        (hit.locations && hit.locations.length > 1
+          ? 'Multiple Locations'
+          : hit.locations?.[0]?.name) ||
+        'Christ Fellowship Church';
+}
+
+const OtherFeatureEventMobileCardHit = ({ hit }: { hit: ContentItemHit }) => {
+  const image = hit.coverImage?.sources?.[0]?.uri || '';
+  const formattedDate = formatFeaturedEventDate(hit.startDateTime);
+  const campus = getFeaturedEventLocation(hit);
+
+  return (
+    <Link
+      to={`/events/${hit.url}`}
+      className='flex h-[98px] w-full items-start overflow-hidden rounded-xl border border-neutral-lighter bg-white text-text-primary'
+      prefetch='intent'
+    >
+      <div className='flex shrink-0 p-[7px]'>
+        <img
+          src={image}
+          alt={hit.title}
+          className='size-[84px] rounded-[5.5px] object-cover'
+          loading='lazy'
+        />
+      </div>
+
+      <div className='flex h-[98px] min-w-0 flex-1 items-center pr-1'>
+        <div className='flex h-full min-w-0 flex-1 flex-col items-start gap-2 py-2 pl-1 pr-4'>
+          <h4 className='line-clamp-2 w-full text-base font-bold leading-[1.4] text-pretty'>
+            {hit.title}
+          </h4>
+
+          <div className='flex w-full min-w-0 flex-col gap-1'>
+            <div className='flex min-w-0 items-center gap-2'>
+              <Icon
+                name='calendarAlt'
+                color='currentColor'
+                size={18}
+                className='shrink-0'
+              />
+              <p className='truncate text-sm font-semibold leading-normal'>
+                {formattedDate}
+              </p>
+            </div>
+            <div className='flex min-w-0 items-center gap-2'>
+              <Icon
+                name='map'
+                color='currentColor'
+                size={18}
+                className='shrink-0'
+              />
+              <p className='truncate text-sm font-semibold leading-normal'>
+                {campus}
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <Icon
+          name='chevronRight'
+          color='currentColor'
+          size={24}
+          className='shrink-0 text-neutral-light'
+        />
+      </div>
+    </Link>
+  );
+};
+
 const OtherFeatureEventCardHit = ({ hit }: { hit: ContentItemHit }) => {
-  const formattedDate = formatEventCardDate(hit.startDateTime);
+  const formattedDate = formatFeaturedEventDate(hit.startDateTime);
 
   return (
     <ResourceCard
@@ -104,10 +141,7 @@ const OtherFeatureEventCardHit = ({ hit }: { hit: ContentItemHit }) => {
         image: hit.coverImage.sources[0].uri,
         pathname: `/events/${hit.url}`,
         startDate: formattedDate,
-        location:
-          hit.locations && hit.locations.length > 1
-            ? 'Multiple Locations'
-            : hit.locations?.[0]?.name || 'Christ Fellowship Church',
+        location: getFeaturedEventLocation(hit),
       }}
     />
   );

--- a/app/routes/events/all-events/partials/featured-events.partial.tsx
+++ b/app/routes/events/all-events/partials/featured-events.partial.tsx
@@ -15,8 +15,8 @@ export function FeaturedEventsSectionLayout({
   children: ReactNode;
 }) {
   return (
-    <div className='w-full py-16 md:py-28 content-padding bg-gray'>
-      <div className='flex min-h-88 flex-col max-w-screen-content mx-auto md:min-h-112'>
+    <div className='w-full pt-10 pb-16 md:py-28 content-padding bg-gray md:min-h-112'>
+      <div className='flex min-h-88 flex-col max-w-screen-content mx-auto'>
         {children}
       </div>
     </div>
@@ -36,14 +36,14 @@ export function FeaturedEventsFromHits({ hits }: { hits: ContentItemHit[] }) {
     <>
       <FeaturedEventCard card={firstHit} />
 
-      <div className='hidden mt-16 lg:mt-24 md:grid grid-cols-2 lg:grid-cols-3 gap-4 place-items-center md:place-items-start'>
+      <div className='hidden mt-8 lg:mt-12 md:grid grid-cols-2 lg:grid-cols-3 gap-4 place-items-center md:place-items-start'>
         {remainingHits.map((hit) => (
           <OtherFeatureEventCardHit hit={hit} key={hit.objectID} />
         ))}
       </div>
 
       {remainingHits.length > 0 && (
-        <div className='mt-8 flex w-full flex-col gap-2 md:hidden'>
+        <div className='mt-6 flex w-full flex-col gap-2 md:hidden'>
           {remainingHits.map((hit) => (
             <OtherFeatureEventMobileCardHit hit={hit} key={hit.objectID} />
           ))}
@@ -85,7 +85,7 @@ const OtherFeatureEventMobileCardHit = ({ hit }: { hit: ContentItemHit }) => {
 
       <div className='flex h-[98px] min-w-0 flex-1 items-center pr-1'>
         <div className='flex h-full min-w-0 flex-1 flex-col items-start gap-2 py-2 pl-1 pr-4'>
-          <h4 className='line-clamp-2 w-full text-base font-bold leading-[1.4] text-pretty'>
+          <h4 className='line-clamp-1 w-full text-base font-bold leading-[1.4] text-pretty'>
             {hit.title}
           </h4>
 
@@ -132,6 +132,7 @@ const OtherFeatureEventCardHit = ({ hit }: { hit: ContentItemHit }) => {
   return (
     <ResourceCard
       className='min-w-[360px] w-[360px] md:w-full md:min-w-0'
+      summaryClassName='line-clamp-1'
       resource={{
         id: hit.objectID,
         contentChannelId: '78', // EVENT type from builder-utils.ts

--- a/app/routes/events/event-single/partials/hero.partial.tsx
+++ b/app/routes/events/event-single/partials/hero.partial.tsx
@@ -1,6 +1,7 @@
 import { Fragment } from 'react';
 import BulletPoints from '~/primitives/bullet-points';
 import { Button } from '~/primitives/button/button.primitive';
+import HtmlRenderer from '~/primitives/html-renderer';
 import heroBgImgStyles from '~/styles/hero-bg-image-styles';
 
 export const EventsSingleHero = ({
@@ -29,9 +30,10 @@ export const EventsSingleHero = ({
                 </h1>
 
                 {subtitle && (
-                  <p className='font-medium lg:text-lg text-[#717182]'>
-                    {subtitle}
-                  </p>
+                  <HtmlRenderer
+                    html={subtitle}
+                    className='font-medium lg:text-lg text-[#717182]'
+                  />
                 )}
 
                 {/* CTAs */}

--- a/app/routes/ministries/loader.ts
+++ b/app/routes/ministries/loader.ts
@@ -1,7 +1,7 @@
 import { LoaderFunction } from 'react-router-dom';
 import { fetchRockData } from '~/lib/.server/fetch-rock-data';
 import { RockContentChannelItem } from '~/lib/types/rock-types';
-import { createImageUrlFromGuid } from '~/lib/utils';
+import { createImageUrlFromGuid, getImageUrl } from '~/lib/utils';
 
 export type Ministry = {
   title: string;
@@ -24,6 +24,23 @@ const mapMinistryChannelItems = async (
     };
   });
 };
+
+const hardCodedMinistries: Ministry[] = [
+  {
+    title: 'Internships',
+    description:
+      'Gain hands-on ministry experience, intentional mentorship, and leadership development.',
+    image: getImageUrl('3141722'),
+    url: '/internships',
+  },
+  {
+    title: 'CFSEU',
+    description:
+      'Earn your degree through Southeastern University at Christ Fellowship.',
+    image: getImageUrl('2966341'),
+    url: 'https://www.cfseu.com',
+  },
+];
 
 export const loader: LoaderFunction = async (): Promise<{
   ministries: Ministry[];
@@ -53,7 +70,10 @@ export const loader: LoaderFunction = async (): Promise<{
       ministriesArray = ministriesData;
     }
 
-    const ministries = await mapMinistryChannelItems(ministriesArray);
+    const ministries = [
+      ...(await mapMinistryChannelItems(ministriesArray)),
+      ...hardCodedMinistries,
+    ];
 
     return { ministries };
   } catch (error) {

--- a/app/routes/navbar/loader.tsx
+++ b/app/routes/navbar/loader.tsx
@@ -60,7 +60,7 @@ const fetchFeatureCards = async () => {
       title: 'New to our Church?',
       subtitle: 'Learn who we are, what we believe, and how to get connected.',
       callToAction: {
-        title: 'Join the Next Class',
+        title: 'Take the Journey Class',
         url: '/events/journey',
       },
       image: 'https://rock.christfellowship.church/GetImage.ashx?id=3166460',


### PR DESCRIPTION
## Summary

Updates the `/events` page event card experience and navigation menu styling/copy.

These changes bring the mobile Events card layouts closer to the provided Figma designs, improve featured event card behavior across mobile and desktop, and update navbar Journey/Give presentation requirements.

## Screenshots

|Before|After|
|-|-|
|<img width="1536" height="552" alt="Screenshot 2026-05-26 at 12 41 35 PM" src="https://github.com/user-attachments/assets/06ffc655-742c-4c87-b401-32fe40f6bc11" />|<img width="1496" height="538" alt="Screenshot 2026-05-26 at 12 50 46 PM" src="https://github.com/user-attachments/assets/8cb8c045-1e11-4503-a71b-a0fcb93dfbb0" />|



## Testing

- [x] Ran `pnpm run check` with no warnings or errors.
- [x] Verify `/events` mobile all-events cards match the compact Figma card design
- [x] Verify featured events mobile main card matches the Figma card design
- [x] Verify featured events remaining mobile cards render as a vertical list instead of a carousel
- [x] Verify featured events desktop layout still renders correctly
- [x] Verify desktop navbar Give button is white in transparent mode and ocean-colored in normal/light mode
- [x] Verify Journey nav card CTA reads `Take the Journey Class`
- [x] Verify no white bar shows in navbar desktop in very large screens.
- [x] Internships and SEU cards appear correctly on the Ministries Page, ensure cards match existing design patterns on the Ministries Page.
- [x] Ensure SEU, Internships, and Give page are searchable in Site Search.

## Tickets
[CFDP-3973](https://christfellowshipchurch.atlassian.net/browse/CFDP-3973)
[CFDP-3974](https://christfellowshipchurch.atlassian.net/browse/CFDP-3974)
[CFDP-3987](https://christfellowshipchurch.atlassian.net/browse/CFDP-3987)


## Changes Made

### New Components Added

- None

### New Utilities

- `app/routes/events/all-events/components/all-events-content.component.tsx`
  - Added mobile-specific all-events card rendering helpers for compact date/location cards.

- `app/routes/events/all-events/components/featured-card.component.tsx`
  - Added `formatFeaturedEventDate()` for featured event dates in `Fri 09 Feb 2024` format.

- `app/routes/events/all-events/partials/featured-events.partial.tsx`
  - Added helper logic for featured event location display using `eventLocations`.

### New Assets

- None

### Dependencies

- None

### Route Implementation

- `app/routes/events/all-events/components/all-events-content.component.tsx`
  - Updates all-events cards on mobile only to use a compact horizontal card layout.
  - Keeps the existing shared `ResourceCard` layout for tablet/desktop.
  - Uses `eventLocations` for event location display, with `Multiple Locations` when there is more than one location.

- `app/routes/events/all-events/components/featured-card.component.tsx`
  - Makes the main featured event card clickable as a full card.
  - Keeps the desktop `Save my spot` CTA as button-styled UI inside the card.
  - Updates the mobile main featured card to match the Figma styling, including `FEATURED EVENT` label, image height, typography, spacing, and stacked date/location details.
  - Applies the featured date format across featured cards.

- `app/routes/events/all-events/partials/featured-events.partial.tsx`
  - Replaces the mobile featured-events carousel for remaining featured items with a vertical list of cards.
  - Keeps desktop remaining featured cards in the existing grid.
  - Applies the same featured date format and `eventLocations` location behavior to featured event cards.

- `app/components/navbar/navbar.component.tsx`
  - Updates desktop Give button styling so it uses white text and border when the navbar is in transparent mode.
  - Preserves ocean styling for normal/light navbar states.

- `app/components/navbar/navbar.data.tsx`
  - Updates fallback Journey card CTA copy to `Take the Journey Class`.

- `app/routes/navbar/loader.tsx`
  - Updates Journey card CTA copy from loader-provided nav data to `Take the Journey Class`.

### Key Features

- Mobile `/events` all-events cards now match the compact Figma card pattern.
- Featured events mobile section no longer uses a carousel for the remaining featured items.
- Featured events mobile remaining cards now display as a stacked list.
- Featured event dates now use `Fri 09 Feb 2024` formatting across the featured section.
- Featured event locations now prefer `eventLocations`, showing one location or `Multiple Locations`.
- Desktop navbar Give button adapts correctly for transparent mode.
- Journey nav card CTA now reads `Take the Journey Class`.

[CFDP-3973]: https://christfellowshipchurch.atlassian.net/browse/CFDP-3973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ