### PR TITLE
Typo and Small Updates

### DIFF
--- a/app/components/footer/footer-contact.partial.tsx
+++ b/app/components/footer/footer-contact.partial.tsx
@@ -16,9 +16,12 @@ export const ContactInfo = () => {
         </div>
         <div className='flex flex-col h-full justify-center'>
           <p className='text-sm md:text-lg font-medium text-coconut'>Call Us</p>
-          <a className={linkStyle} href='tel:5617997600'>
+          <a className={`${linkStyle} md:hidden`} href='tel:5617997600'>
             (561) 799-7600
           </a>
+          <span className={`${linkStyle} hidden md:inline hover:text-white cursor-default`}>
+            (561) 799-7600
+          </span>
         </div>
       </div>
       <SideDivider />

--- a/app/components/footer/footer-contact.partial.tsx
+++ b/app/components/footer/footer-contact.partial.tsx
@@ -19,7 +19,9 @@ export const ContactInfo = () => {
           <a className={`${linkStyle} md:hidden`} href='tel:5617997600'>
             (561) 799-7600
           </a>
-          <span className={`${linkStyle} hidden md:inline hover:text-white cursor-default`}>
+          <span
+            className={`${linkStyle} hidden md:inline hover:text-white cursor-default`}
+          >
             (561) 799-7600
           </span>
         </div>

--- a/app/lib/faq-data.data.ts
+++ b/app/lib/faq-data.data.ts
@@ -288,7 +288,7 @@ export const faqCfEverywhereData = [
   {
     title: 'What can I expect from a live-streamed service?',
     content:
-      'Every Sunday, we craft a unique livestream experience for our Christ Fellowship Everywhere audience. We have live services at 8:30, 10, and 11:45AM ET every Sunday but we would love to see you for our interactive pre-service segment that begins 6 minutes before services. You never know what’s going to happen, but we promise it’ll always be fun.',
+      'Every Sunday, we craft a unique livestream experience for our Christ Fellowship Everywhere audience. We have live services at 8:15AM, 9:45AM, & 11:30AM ET every Sunday but we would love to see you for our interactive pre-service segment that begins 6 minutes before services. You never know what’s going to happen, but we promise it’ll always be fun.',
   },
   {
     title: 'How can I get campus-specific information?',
@@ -300,7 +300,7 @@ export const faqCfEverywhereData = [
   },
   {
     title: 'How can I get involved?',
-    content: `We are so excited to get you involved with Christ Fellowship Everywhere and want to help you take your next step. <a href=/next-steps> Journey</a> is a great first step that will lay out a variety of ways to get involved. Looking for your next step? <a target="blank" href="mailto:online@christfellowship.church"> Send us an email</a> so we can help you discover your next step!`,
+    content: `We are so excited to get you involved with Christ Fellowship Everywhere and want to help you take your next step. <a href=/events/journey>Journey</a> is a great first step that will lay out a variety of ways to get involved. Looking for your next step? <a target="blank" href="mailto:online@christfellowship.church"> Send us an email</a> so we can help you discover your next step!`,
   },
 ];
 

--- a/app/routes/about/components/history-tabs/history-tabs.component.tsx
+++ b/app/routes/about/components/history-tabs/history-tabs.component.tsx
@@ -30,14 +30,14 @@ const timelineData: TimelineItem[] = [
     image:
       'https://cloudfront.christfellowship.church/GetImage.ashx?id=3068098',
     title: 'Multi-Site Expansion',
-    body: 'Christ Fellowship launched a bold multi-site strategy in 2011 to make it easy for people across South Florida to encounter Jesus. Today, thousands gather each week across multiple campuses—from Boynton Beach to Port St. Lucie—bringing church closer to where people live and work.',
+    body: 'Christ Fellowship launched a bold multi-site strategy in 2011 to make it easy for people across South Florida to encounter Jesus. Today, thousands gather each week across multiple campuses—from Boca Raton to Vero Beach—bringing church closer to where people live and work.',
   },
   {
     year: '1992',
     image:
       'https://cloudfront.christfellowship.church/GetImage.ashx?id=3068099',
     title: 'Building the First Campus',
-    body: 'After years of gathering in schools and temporary spaces, the church’s founding families sacrificed greatly—selling cars, mortgaging homes, and giving generously—to purchase an old horse barn on Northlake Blvd. In 1992, members worked six days a week to transform it into Christ Fellowship’s first permanent campus, a place that quickly filled with life and faith',
+    body: 'After years of gathering in schools and temporary spaces, the church’s founding families sacrificed greatly—selling cars, mortgaging homes, and giving generously—to purchase an old horse barn on Northlake Blvd. In 1992, members worked six days a week to transform it into Christ Fellowship’s first permanent campus, a place that quickly filled with life and faith.',
   },
   {
     year: '1984',

--- a/app/routes/about/partials/beliefs.partial.tsx
+++ b/app/routes/about/partials/beliefs.partial.tsx
@@ -25,7 +25,7 @@ export function BeliefsSection({
           {/* Beliefs Title */}
           <div className='relative flex flex-col gap-6 pb-12 w-full'>
             <SectionTitle
-              sectionTitle={isSpanish ? 'nuestras creencias.' : 'our beliefs.'}
+              sectionTitle={isSpanish ? 'nuestras creencias' : 'our beliefs'}
             />
             <h3 className='font-extrabold text-text-primary text-[28px] md:text-5xl leading-tight'>
               {isSpanish ? 'Lo Que' : 'What We'} <br className='sm:hidden' />{' '}

--- a/app/routes/about/partials/history.partial.tsx
+++ b/app/routes/about/partials/history.partial.tsx
@@ -3,8 +3,8 @@ import { sanitizeCmsHtml } from '~/lib/sanitize';
 import HistoryTabs from '../components/history-tabs/history-tabs.component';
 
 export function HistorySection({
-  sectionTitle = 'our history.',
-  title = 'History of Christ <br /> Fellowship Church',
+  sectionTitle = 'our history',
+  title = 'History of Christ Fellowship Church',
 }: {
   sectionTitle?: string;
   title?: string;

--- a/app/routes/about/partials/impact.partial.tsx
+++ b/app/routes/about/partials/impact.partial.tsx
@@ -35,7 +35,7 @@ export function ImpactSection({ isSpanish = false }: { isSpanish?: boolean }) {
               <div className='flex flex-col gap-8'>
                 <SectionTitle
                   sectionTitle={
-                    isSpanish ? 'nuestro impacto 2025.' : 'our impact 2025.'
+                    isSpanish ? 'nuestro impacto 2025' : 'our impact 2025'
                   }
                 />
                 <h3 className='text-[32px] xl:text-5xl leading-tight font-extrabold mb-6'>

--- a/app/routes/about/partials/leadership.partial.tsx
+++ b/app/routes/about/partials/leadership.partial.tsx
@@ -30,19 +30,19 @@ export function LeadershipSection({
               layout === 'vertical' ? 'flex-col gap-8' : 'gap-24 items-center',
             )}
           >
-            <SectionTitle sectionTitle='our team.' />
+            <SectionTitle sectionTitle='our team' />
             <h3 className='text-5xl font-extrabold leading-none max-w-3xl'>
-              Meet The Passionate Leaders <br />
-              Of Christ Fellowship Church.
+              Meet the Passionate Leaders <br />
+              of Christ Fellowship Church
             </h3>
           </div>
 
           {/* Mobile title */}
           <div className='lg:hidden'>
-            <SectionTitle className='mb-6' sectionTitle='our team.' />
+            <SectionTitle className='mb-6' sectionTitle='our team' />
             <h3 className='text-2xl md:text-4xl font-extrabold leading-tight mb-4 md:mb-8 max-w-3xl'>
-              Meet The Passionate Leaders <br />
-              Of Christ Fellowship Church.
+              Meet the Passionate Leaders <br />
+              of Christ Fellowship Church
             </h3>
           </div>
 

--- a/app/routes/about/partials/mission.partial.tsx
+++ b/app/routes/about/partials/mission.partial.tsx
@@ -12,7 +12,7 @@ export function OurMissionSection({
     ? 'Además de nuestra misión, Dios nos ha dado la visión de liderar una transformación radical para Jesucristo en esta región y más allá. Todos Nosotros, en todo momento, en todo lugar.'
     : ' In addition to our mission, God has given us a vision to lead a radical transformation for Jesus Christ in this region and beyond. Everyone, Everyday, Everywhere.';
 
-  const sectionTitle = isSpanish ? 'nuestra misión.' : 'our mission.';
+  const sectionTitle = isSpanish ? 'nuestra misión' : 'our mission';
 
   return (
     <section id='mission' className='py-2 lg:py-24 content-padding'>

--- a/app/routes/class-finder/class-single/class-single-page.tsx
+++ b/app/routes/class-finder/class-single/class-single-page.tsx
@@ -96,11 +96,7 @@ const ClassSingleContent = ({ hit }: { hit: ClassHitType }) => {
   const handleBack = useCallback(
     (e: ReactMouseEvent<Element>) => {
       e.preventDefault();
-      if (typeof window !== 'undefined' && window.history.length > 1) {
-        navigate(-1);
-      } else {
-        navigate('/class-finder');
-      }
+      navigate('/class-finder');
     },
     [navigate],
   );

--- a/app/routes/class-finder/class-single/components/upcoming-session-card.component.tsx
+++ b/app/routes/class-finder/class-single/components/upcoming-session-card.component.tsx
@@ -81,7 +81,7 @@ const UpcomingSessionCardBody = ({ hit }: { hit: ClassHitType }) => {
 
               <div className='flex items-center gap-2'>
                 <Icon name='timeFive' size={24} />
-                <p className='text-sm'>{schedule} EST</p>
+                <p className='text-sm'>{schedule} ET</p>
               </div>
             </div>
           </div>

--- a/app/routes/events/all-events/components/all-events-content.component.tsx
+++ b/app/routes/events/all-events/components/all-events-content.component.tsx
@@ -299,7 +299,7 @@ export function AllEventsContent() {
             <div className='hidden md:block'>
               <SectionTitle
                 title='Discover Events For You'
-                sectionTitle='all events.'
+                sectionTitle='all events'
               />
             </div>
 

--- a/app/routes/events/event-single/event-single-page.tsx
+++ b/app/routes/events/event-single/event-single-page.tsx
@@ -92,7 +92,11 @@ export const EventSinglePage: React.FC = () => {
         )}
 
         {data.faqItems && data.faqItems.length > 0 && (
-          <EventSingleFAQ title={data.title} items={data.faqItems} />
+          <EventSingleFAQ
+            title={data.title}
+            items={data.faqItems}
+            faqEmail={data.faqEmail}
+          />
         )}
 
         <RegistrationSection />

--- a/app/routes/events/event-single/loader.ts
+++ b/app/routes/events/event-single/loader.ts
@@ -90,9 +90,9 @@ export const loader: LoaderFunction = async ({ params }) => {
       question: item.key,
       answer: item.value,
     })),
-    // FAQEmail attribute key from Rock Events Content Channel.
+    // faqEmail attribute key from Rock Events Content Channel.
     // Optional — falls back to the default contact email when absent.
-    faqEmail: eventData.attributeValues?.fAQEmail?.value || undefined,
+    faqEmail: eventData.attributeValues?.faqEmail?.value || undefined,
     groupType,
     sessionScheduleCards,
   };

--- a/app/routes/events/event-single/loader.ts
+++ b/app/routes/events/event-single/loader.ts
@@ -90,6 +90,9 @@ export const loader: LoaderFunction = async ({ params }) => {
       question: item.key,
       answer: item.value,
     })),
+    // FAQEmail attribute key from Rock Events Content Channel.
+    // Optional — falls back to the default contact email when absent.
+    faqEmail: eventData.attributeValues?.fAQEmail?.value || undefined,
     groupType,
     sessionScheduleCards,
   };

--- a/app/routes/events/event-single/partials/event-faq.partial.tsx
+++ b/app/routes/events/event-single/partials/event-faq.partial.tsx
@@ -1,12 +1,17 @@
 import { StyledAccordion } from '~/components';
 
+const DEFAULT_FAQ_EMAIL = 'hello@christfellowship.church';
+
 export const EventSingleFAQ = ({
   title,
   items,
+  faqEmail,
 }: {
   title: string;
   items?: { question: string; answer: string }[];
+  faqEmail?: string;
 }) => {
+  const contactEmail = faqEmail?.trim() || DEFAULT_FAQ_EMAIL;
   return (
     <section
       className='flex flex-col gap-12 py-12 md:py-24 content-padding'
@@ -39,9 +44,9 @@ export const EventSingleFAQ = ({
               Contact us at{' '}
               <a
                 className='text-[#4D4D4D] hover:text-ocean cursor-pointer'
-                href='mailto:hello@christfellowship.church'
+                href={`mailto:${contactEmail}`}
               >
-                hello@christfellowship.church
+                {contactEmail}
               </a>{' '}
               or call{' '}
               <a

--- a/app/routes/events/event-single/partials/hero.partial.tsx
+++ b/app/routes/events/event-single/partials/hero.partial.tsx
@@ -1,4 +1,5 @@
 import { Fragment } from 'react';
+import { cn } from '~/lib/utils';
 import BulletPoints from '~/primitives/bullet-points';
 import { Button } from '~/primitives/button/button.primitive';
 import HtmlRenderer from '~/primitives/html-renderer';
@@ -25,7 +26,7 @@ export const EventsSingleHero = ({
             {/* Left / Bottom Side (Desktop) */}
             <div className='order-2 md:order-1 flex flex-col gap-10 mb-4 md:mb-0'>
               <div className='flex flex-col gap-3 max-w-[600px]'>
-                <h1 className='font-extrabold heading-h4 md:heading-h3 lg:text-[52px] text-text-primary leading-tight !text-pretty -mb-1'>
+                <h1 className='font-extrabold heading-h4 md:heading-h3 lg:text-[52px] text-text-primary leading-tight text-pretty! -mb-1'>
                   {customTitle}
                 </h1>
 
@@ -37,22 +38,18 @@ export const EventsSingleHero = ({
                 )}
 
                 {/* CTAs */}
-                <div className='flex flex-col md:flex-row gap-2 sm:gap-4'>
+                <div className='flex flex-col md:flex-wrap xl:flex-row gap-2 sm:gap-4'>
                   {ctas?.map((cta, i) => (
                     <Fragment key={i}>
                       <Button
                         href={cta.url}
                         intent={i === 0 ? 'primary' : 'secondary'}
-                        size='md'
-                        className='w-full md:w-auto lg:hidden'
-                      >
-                        {cta.title}
-                      </Button>
-                      <Button
-                        href={cta.url}
-                        intent={i === 0 ? 'primary' : 'secondary'}
-                        size='lg'
-                        className='w-full md:w-auto hidden lg:inline-flex'
+                        className={cn(
+                          'w-full md:w-auto',
+                          'py-2 lg:py-3',
+                          'px-4 lg:px-6',
+                          'text-base lg:text-lg',
+                        )}
                       >
                         {cta.title}
                       </Button>
@@ -76,7 +73,7 @@ export const EventsSingleHero = ({
             <img
               src={imagePath}
               alt={customTitle}
-              className='order-1 md:order-2 w-full max-w-lg md:max-w-[340px] lg:max-w-[480px] xl:!max-w-[638px] aspect-638/478 md:aspect-5/6 lg:aspect-638/478 object-cover rounded-[14px] shadow-xl'
+              className='order-1 md:order-2 w-full max-w-lg md:max-w-[340px] lg:max-w-[480px] xl:max-w-[638px]! aspect-638/478 md:aspect-5/6 lg:aspect-638/478 object-cover rounded-[14px] shadow-xl'
             />
           </div>
         </div>

--- a/app/routes/events/event-single/types.ts
+++ b/app/routes/events/event-single/types.ts
@@ -37,6 +37,7 @@ export type EventSinglePageType = {
   moreInfoText?: string;
   optionalBlurb?: { title: string; description: string }[];
   faqItems?: { question: string; answer: string }[];
+  faqEmail?: string;
   sessionScheduleCards?: SessionRegistrationCardType[];
 };
 

--- a/app/routes/group-finder/components/group-hit.component.tsx
+++ b/app/routes/group-finder/components/group-hit.component.tsx
@@ -26,44 +26,32 @@ export function GroupHit({
   const preference = hit.groupFor?.trim() || 'Anyone';
   const topicTags = splitGroupTopics(hit.topics);
 
-  // Format the time string to show time with AM/PM and timezone
   const formatTime = (timeString: string) => {
-    // If the time string already contains AM/PM, return it as is
+    const normalizedTimeString = timeString.replace(/\bE[SD]T\b/g, 'ET');
+
     if (
-      timeString.toLowerCase().includes('am') ||
-      timeString.toLowerCase().includes('pm')
+      normalizedTimeString.toLowerCase().includes('am') ||
+      normalizedTimeString.toLowerCase().includes('pm')
     ) {
-      return timeString;
+      return normalizedTimeString.includes('ET')
+        ? normalizedTimeString
+        : `${normalizedTimeString.replace(' ', '')} ET`;
     }
 
     try {
-      const [hoursStr, minutesStr] = timeString.split(':');
+      const [hoursStr, minutesStr] = normalizedTimeString.split(':');
       const hours = parseInt(hoursStr, 10);
       const minutes = parseInt(minutesStr || '0', 10);
 
-      if (isNaN(hours) || isNaN(minutes)) return timeString;
+      if (isNaN(hours) || isNaN(minutes)) return normalizedTimeString;
 
       const ampm = hours >= 12 ? 'PM' : 'AM';
       const displayHours = hours % 12 || 12;
       const displayMinutes = minutes.toString().padStart(2, '0');
 
-      // Get current timezone abbreviation
-      const timeZone =
-        new Date()
-          .toLocaleTimeString('en-US', { timeZoneName: 'short' })
-          .split(' ')
-          .pop() || '';
-
-      // Shorten timezone abbreviations
-      const shortTimeZone = timeZone
-        .replace(/E[SD]T/, 'ET')
-        .replace(/C[SD]T/, 'CT')
-        .replace(/M[SD]T/, 'MT')
-        .replace(/P[SD]T/, 'PT');
-
-      return `${displayHours}:${displayMinutes}${ampm} ${shortTimeZone}`;
+      return `${displayHours}:${displayMinutes}${ampm} ET`;
     } catch {
-      return timeString;
+      return normalizedTimeString;
     }
   };
 

--- a/app/routes/group-single/components/faq.component.tsx
+++ b/app/routes/group-single/components/faq.component.tsx
@@ -15,7 +15,7 @@ const faqData = [
   {
     question: 'What Types of Small Groups Are Available?',
     answer:
-      'We offer Bible study, activity, and Freedom groups for men, women, and married couples. Groups are available for all life stages, with both morning and evening options',
+      'We offer Bible study, activity, and Freedom groups for men, women, and married couples. Groups are available for all life stages, with both morning and evening options.',
   },
   {
     question: 'Is Childcare Provided During Group Meetings?',

--- a/app/routes/group-single/components/group-single-banner.component.tsx
+++ b/app/routes/group-single/components/group-single-banner.component.tsx
@@ -1,4 +1,4 @@
-import { Link, useLocation } from 'react-router';
+import { Link } from 'react-router';
 import { GroupConnectModal } from '~/components/modals/group-connect/group-connect-modal';
 import { cn } from '~/lib/utils';
 import { Button } from '~/primitives/button/button.primitive';
@@ -20,11 +20,7 @@ export const GroupSingleBanner = ({
   groupId: string;
 }) => {
   const stickyTopClass = useStickyTopBelowNavbarClass();
-  const location = useLocation();
-  const backToGroupFinderUrl =
-    typeof location.state?.fromGroupFinder === 'string'
-      ? location.state.fromGroupFinder
-      : '/group-finder';
+  const backToGroupFinderUrl = '/group-finder';
 
   const imageStyles = 'size-20 rounded-[10px] object-cover';
 

--- a/app/routes/group-single/partials/group-single-hero.partial.tsx
+++ b/app/routes/group-single/partials/group-single-hero.partial.tsx
@@ -108,7 +108,7 @@ const GroupInfo = ({ hit }: { hit: GroupType }) => {
   } = hit;
   const adultsOnlyBool = adultsOnly === 'True';
 
-  const formattedMeetingTime = meetingTime.replace(' ', '');
+  const formattedMeetingTime = meetingTime.replace(/\s*(EST|EDT|ET)$/i, '').replace(/\s/g, '');
   const campus = (campusName || '').trim();
   const rawLocationType = (meetingLocationType || '').trim();
   const locationType = rawLocationType.toLowerCase();

--- a/app/routes/group-single/partials/group-single-hero.partial.tsx
+++ b/app/routes/group-single/partials/group-single-hero.partial.tsx
@@ -108,7 +108,9 @@ const GroupInfo = ({ hit }: { hit: GroupType }) => {
   } = hit;
   const adultsOnlyBool = adultsOnly === 'True';
 
-  const formattedMeetingTime = meetingTime.replace(/\s*(EST|EDT|ET)$/i, '').replace(/\s/g, '');
+  const formattedMeetingTime = meetingTime
+    .replace(/\s*(EST|EDT|ET)$/i, '')
+    .replace(/\s/g, '');
   const campus = (campusName || '').trim();
   const rawLocationType = (meetingLocationType || '').trim();
   const locationType = rawLocationType.toLowerCase();

--- a/app/routes/home/components/a-chance.data.ts
+++ b/app/routes/home/components/a-chance.data.ts
@@ -16,7 +16,7 @@ export const chanceContent: {
     imageWidth: 1216,
     imageHeight: 1058,
     description:
-      " Looking for community? A place where you can find genuine connection with other people. A place where you're not just a face in the crowd, but someone who belongs. ",
+      " Looking for community? A place where you can find genuine connection with other people? A place where you're not just a face in the crowd, but someone who belongs? ",
     buttonTitle: 'Get Connected',
     buttonLink: '/group-finder',
   },

--- a/app/routes/home/partials/a-chance.partial.tsx
+++ b/app/routes/home/partials/a-chance.partial.tsx
@@ -25,7 +25,7 @@ export function AChanceSection() {
           )}
         />
         <span className='relative z-20'>
-          Think of it less as a chore and more as...{' '}
+          Think of it less as a chore and more as ...{' '}
           <span className='text-ocean'>a chance.</span>
         </span>
       </h2>

--- a/app/routes/home/partials/what-to-expect.partial.tsx
+++ b/app/routes/home/partials/what-to-expect.partial.tsx
@@ -17,7 +17,7 @@ export function WhatToExpectSection() {
               {/* Desktop Title */}
               <div className='flex flex-col gap-12'>
                 <div className='hidden lg:block'>
-                  <SectionTitle sectionTitle='get to know us.' />
+                  <SectionTitle sectionTitle='get to know us' />
                 </div>
                 <h2 className='hidden lg:block lg:text-[52px] font-extrabold'>
                   What to Expect

--- a/app/routes/locations/location-single/components/tabs-component/about-us/campus-pastors-quote.tsx
+++ b/app/routes/locations/location-single/components/tabs-component/about-us/campus-pastors-quote.tsx
@@ -39,7 +39,7 @@ export const CampusPastorsQuote = ({
           />
           <div className='flex flex-col justify-center items-center md:items-start'>
             <h4 className='text-lg text-text-secondary'>
-              {isSpanish ? 'Pastores del Campus' : 'Campus Pastors'}
+              {isSpanish ? 'Pastores del Campus' : 'Campus Pastor'}
             </h4>
             <h3 className='font-semibold text-[22px]'>
               {campusPastor.firstName} {campusPastor.lastName}

--- a/app/routes/locations/location-single/partials/tabs/about-us.tsx
+++ b/app/routes/locations/location-single/partials/tabs/about-us.tsx
@@ -25,7 +25,7 @@ export const AboutUs = ({
     : 'Proud to be your nearest Christ Fellowship location';
   const pastorQuote = isSpanish
     ? 'Nuestros servicios principales de adoración son los domingos, y también nos reunimos como comunidad durante la semana a través de distintos eventos para conectar, crecer y servir juntos. Es un honor ser parte de esta comunidad y nos alegraría que nos acompañes en un servicio este domingo. Si estás buscando una iglesia cerca de ti, será un gusto recibirte, conocerte y caminar contigo.'
-    : 'Our main worship services are on Sundays, and we also gather as a church community throughout the week, through various events, to connect, grow, and serve together. <br /> <br /> We’re honored to be a part of this community and would love for you to join us for a service this Sunday. If you’re looking for a church family nearby, it would be our pleasure to host you and get to know you.';
+    : 'Our main worship services are on Sundays, and we also gather as a church community throughout the week, through various events, to connect, grow, and serve together. <br /> <br /> We’re honored to be a part of this community and would love for you to join us for a service this Sunday. If you’re looking for a church family, it would be our pleasure to host you and get to know you.';
 
   return (
     <div className='flex flex-col w-full'>

--- a/app/routes/messages/all-messages/partials/all-messages.partial.tsx
+++ b/app/routes/messages/all-messages/partials/all-messages.partial.tsx
@@ -108,7 +108,7 @@ export function AllMessages() {
       <div className='relative max-w-screen-content mx-auto'>
         <SectionTitle
           className='mb8'
-          sectionTitle='all messages.'
+          sectionTitle='all messages'
           title='Christ Fellowship Church Messages'
         />
 

--- a/app/routes/messages/message-single/partials/related-messages.partial.tsx
+++ b/app/routes/messages/message-single/partials/related-messages.partial.tsx
@@ -56,7 +56,7 @@ export const RelatedMessages = () => {
             {/* Header */}
             <div className='flex w-full flex-row items-end justify-between gap-4'>
               <div className='flex min-w-0 flex-1 flex-col gap-6 md:gap-8'>
-                <SectionTitle sectionTitle='related messages.' />
+                <SectionTitle sectionTitle='related messages' />
                 <h2 className='text-text font-extrabold text-[28px] lg:text-[32px] leading-tight'>
                   Other Messages On This Topic
                 </h2>

--- a/app/routes/volunteer-form/components/results-progress-bar.component.tsx
+++ b/app/routes/volunteer-form/components/results-progress-bar.component.tsx
@@ -4,7 +4,7 @@ import { StepDotCurrent, StepDotDone, StepDotTodo } from './form-nav.component';
 // Static progress steps for confirmation
 const progressSteps = [
   { label: 'Volunteer Application Complete', state: 'done' },
-  { label: 'Our team is re-viewing', state: 'current' },
+  { label: 'Our team is reviewing', state: 'current' },
   { label: 'One on One Conversation', state: 'todo' },
 ];
 

--- a/app/routes/volunteer-form/partials/form-confirmation.partial.tsx
+++ b/app/routes/volunteer-form/partials/form-confirmation.partial.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import { ResultsProgressBar } from '../components/results-progress-bar.component';
 import { ResultCard } from '../components/result-card.component';
 import { mockResultCards } from '../mock-data';
@@ -11,11 +12,17 @@ export const VolunteerFormConfirmationPartial: React.FC = () => (
       <h2 className='heading-h2 mb-6 text-center'>What Happens Next?</h2>
       <ResultsProgressBar />
       <p className='my-6 text-center max-w-2xl text-text-secondary'>
-        We are thrilled to have you join our team. [Persons Name and title] from
-        your home [Campus] will contact you within [timeframe, e.g., 3-5
-        business days] to discuss potential volunteer opportunities and next
-        steps. In the meantime, you can sign up for the Journey if you haven't
-        taken it yet as it is the first step for volunteering.
+        We're excited to have you join the Dream Team! One of our team members
+        from your home campus will be in touch within the next few days to help
+        you explore volunteer opportunities and share your next steps. In the
+        meantime, if you haven't taken Journey yet, we encourage you to{' '}
+        <Link
+          to='/events/journey'
+          className='text-ocean underline hover:text-navy transition-colors'
+        >
+          sign up
+        </Link>{' '}
+        — it's the first step toward serving on the Dream Team.
       </p>
       <div className='flex items-center gap-4 my-12'>
         <img


### PR DESCRIPTION
## Summary

Addresses QA feedback from Pam Olive (5/21/26) across the site — copy fixes, small bugs, and two feature additions. 26 files touched, no new dependencies.

## Screenshots

N/A — text/logic changes only

## Testing

- [x] Home page: verify ellipsis spacing and question marks on community sentences
- [x] `/about`: verify history title on one line, multi-site location range, building blurb period
- [x] All `SectionTitle` labels site-wide: confirm no trailing periods
- [x] `/locations/cf-everywhere` FAQ: verify service times (8:15AM, 9:45AM, 11:30AM ET) and Journey link goes to `/events/journey`
- [x] Campus About tab: confirm "Campus Pastor" (no s) and "nearby" removed from quote
- [x] `/messages`: confirm "all messages" section label has no period
- [x] Groups detail page: confirm time shows e.g. "2:00PM ET" (no EST)
- [x] Groups FAQ: confirm Small Groups answer ends with a period
- [x] Footer: phone tappable on mobile, plain text on desktop (no hover dim, default cursor)
- [x] `/volunteer-form/confirmation`: confirm updated paragraph copy and "sign up" links to `/events/journey`
- [x] Group single: back arrow (desktop sticky banner) always goes to `/group-finder`
- [x] Class single: back arrow (mobile + desktop) always goes to `/class-finder`
- [x] Event pages with `FAQEmail` set in Rock: confirm custom email shows in FAQ contact line
- [x] Event pages without `FAQEmail`: confirm fallback to `hello@christfellowship.church`

## Tickets

N/A — QA pass from Pam Olive 5/21/26

## Changes Made

### Home page (`/`)
- Added space before ellipsis: `as ... a chance`
- Two community description sentences changed from `.` to `?`

### About page (`/about`)
- `Meet the Passionate Leaders of Christ Fellowship Church` — corrected case, removed period
- History section title: removed `<br />` so "Christ Fellowship Church" stays on one line
- Multi-Site Expansion body: updated location range from "Boynton Beach to Port St. Lucie" → "Boca Raton to Vero Beach"
- Building the First Campus blurb: added missing period

### Section titles (site-wide)
Removed trailing periods from all `sectionTitle` props:
`our history` · `our team` · `our beliefs` / `nuestras creencias` · `our mission` / `nuestra misión` · `our impact 2025` / `nuestro impacto 2025` · `get to know us` · `related messages` · `all events`

### CF Everywhere FAQ (`/locations/cf-everywhere`)
- Service times corrected to 8:15AM, 9:45AM, & 11:30AM ET
- "How can I get involved" Journey link updated to `/events/journey`

### Campus About tab (all campuses)
- "Campus Pastors" → "Campus Pastor"
- Removed "nearby" from the church family welcome quote

### Messages hub (`/messages`)
- "all messages" section title: removed trailing period

### Groups detail pages
- Meeting time display: strips EST/EDT/ET suffix before appending "ET" (fixes "2:00PMEST ET" → "2:00PM ET")
- Small Groups FAQ answer: added missing period

### Footer
- Phone number is a `tel:` link on mobile only; desktop renders a plain `<span>` with no hover effect and `cursor-default`

### Volunteer form confirmation (`/volunteer-form/confirmation`)
- `re-viewing` → `reviewing`
- Replaced placeholder paragraph with final copy; "sign up" linked to `/events/journey`

### Group single — back button
- Desktop sticky banner: removed dynamic `location.state?.fromGroupFinder` lookup; always navigates to `/group-finder`
- Removed now-unused `useLocation` import

### Class single — back button
- `handleBack` no longer calls `navigate(-1)`; always navigates to `/class-finder`
- Applies to both the mobile overlay button and the desktop `FinderHero` back link

### Event FAQ — per-event contact email
- Added optional `FAQEmail` Rock attribute support (`attributeValues.faqEmail`)
- `EventSingleFAQ` accepts `faqEmail?: string` prop
- Falls back to `hello@christfellowship.church` when field is absent (Algolia-safe)
- `EventSinglePageType` updated with `faqEmail?: string`

### New Components Added
None

### New Utilities
None

### New Assets
None

### Dependencies
None

### Route Implementation
No new routes

### Key Features
- Per-event FAQ email: editors can set a ministry-specific contact email per event in Rock (`FAQEmail` attribute on Events Content Channel) without a code deploy
- Back buttons on group/class detail pages now reliably return users to the correct finder regardless of browser history