### PR TITLE
Volunteer + Minor Home Cleanup

### DIFF
--- a/app/components/modals/set-a-reminder/reminder-modal.component.tsx
+++ b/app/components/modals/set-a-reminder/reminder-modal.component.tsx
@@ -9,6 +9,12 @@ import { pushFormEvent } from '~/lib/gtm';
 
 interface SetAReminderModalProps {
   className?: string;
+  /**
+   * When provided, used as the sole className on the trigger button, bypassing
+   * the modal's internal default styles. Use this when the button needs to
+   * match an existing design system style (e.g. inside a CTA card).
+   */
+  buttonClassName?: string;
   intent?: ButtonProps['intent'];
   ModalButton?: React.ComponentType<ButtonProps>;
   /** Merged onto `Modal.Button` (e.g. `w-full mr-0` for full-width triggers). */
@@ -17,6 +23,7 @@ interface SetAReminderModalProps {
 
 export function SetAReminderModal({
   className,
+  buttonClassName,
   intent = 'secondary',
   ModalButton = Button,
   triggerClassName,
@@ -46,10 +53,14 @@ export function SetAReminderModal({
         <ModalButton
           intent={intent}
           type='button'
-          className={cn(
-            'text-white border-[#FAFAFC] rounded-md md:rounded-none border hover:bg-white/10',
-            className,
-          )}
+          className={
+            buttonClassName !== undefined
+              ? buttonClassName
+              : cn(
+                  'text-white border-[#FAFAFC] rounded-md md:rounded-none border hover:bg-white/10',
+                  className,
+                )
+          }
         >
           {buttonLabel}
         </ModalButton>

--- a/app/routes/home/components/hero/desktop-features.component.tsx
+++ b/app/routes/home/components/hero/desktop-features.component.tsx
@@ -46,7 +46,7 @@ const DesktopFeaturedItem = ({
       data-position={position}
       data-item-title={title}
     >
-      <div className='bg-ocean lg:bg-dark-navy group-hover:bg-ocean transition-colors duration-300 rounded-sm lg:rounded-none p-2'>
+      <div className='bg-ocean lg:bg-dark-navy group-hover:bg-ocean transition-colors duration-300 rounded-sm p-2'>
         <Icon name={iconName} color='white' />
       </div>
       <div>

--- a/app/routes/home/components/hero/desktop-features.component.tsx
+++ b/app/routes/home/components/hero/desktop-features.component.tsx
@@ -46,7 +46,7 @@ const DesktopFeaturedItem = ({
       data-position={position}
       data-item-title={title}
     >
-      <div className='bg-ocean lg:bg-dark-navy group-hover:bg-ocean transition-colors duration-300 rounded-sm p-2 '>
+      <div className='bg-ocean lg:bg-dark-navy group-hover:bg-ocean transition-colors duration-300 rounded-sm lg:rounded-none p-2'>
         <Icon name={iconName} color='white' />
       </div>
       <div>

--- a/app/routes/locations/location-single/components/ctas.component.tsx
+++ b/app/routes/locations/location-single/components/ctas.component.tsx
@@ -47,7 +47,12 @@ export const CTAs = ({
     <div className='w-full md:mx-auto md:max-w-md lg:mx-0 lg:max-w-full'>
       <div className='grid w-full grid-cols-3 items-stretch gap-4 lg:gap-6'>
         <div className={ctaSlotClassName}>
-          <CTAButton icon='calendarAlt' title={reminderTitle} isSetAReminder />
+          <CTAButton
+            icon='calendarAlt'
+            title={reminderTitle}
+            href='https://rock.christfellowship.church/CFKidsPlanaVisit'
+            target='_blank'
+          />
         </div>
         <div className={ctaSlotClassName}>
           <CTAButton

--- a/app/routes/page-builder/components/content-block/cta-card-section.tsx
+++ b/app/routes/page-builder/components/content-block/cta-card-section.tsx
@@ -7,7 +7,10 @@ import HTMLRenderer from '~/primitives/html-renderer';
 import { getCtaStyles } from '../builder-utils';
 import { SetAReminderModal } from '~/components/modals/set-a-reminder/reminder-modal.component';
 
-const SET_A_REMINDER_SENTINELS = new Set(['/#set-a-reminder', '#set-a-reminder']);
+const SET_A_REMINDER_SENTINELS = new Set([
+  '/#set-a-reminder',
+  '#set-a-reminder',
+]);
 
 // CTA Card Layout
 export const CtaCardSection: FC<{ data: ContentBlockData }> = ({ data }) => {

--- a/app/routes/page-builder/components/content-block/cta-card-section.tsx
+++ b/app/routes/page-builder/components/content-block/cta-card-section.tsx
@@ -5,6 +5,9 @@ import { Button } from '~/primitives/button/button.primitive';
 import lowerCase from 'lodash/lowerCase';
 import HTMLRenderer from '~/primitives/html-renderer';
 import { getCtaStyles } from '../builder-utils';
+import { SetAReminderModal } from '~/components/modals/set-a-reminder/reminder-modal.component';
+
+const SET_A_REMINDER_SENTINELS = new Set(['/#set-a-reminder', '#set-a-reminder']);
 
 // CTA Card Layout
 export const CtaCardSection: FC<{ data: ContentBlockData }> = ({ data }) => {
@@ -43,16 +46,24 @@ export const CtaCardSection: FC<{ data: ContentBlockData }> = ({ data }) => {
 
         <div className='flex flex-col lg:flex-row gap-2'>
           {/* Limit to 2 CTA buttons */}
-          {ctas.slice(0, 2).map((cta, idx) => (
-            <Button
-              key={cta.url}
-              className={cn(getButtonClassName(idx), 'font-normal')}
-              intent={getButtonIntent(idx)}
-              href={cta.url}
-            >
-              {cta.title}
-            </Button>
-          ))}
+          {ctas.slice(0, 2).map((cta, idx) =>
+            SET_A_REMINDER_SENTINELS.has(cta.url) ? (
+              <SetAReminderModal
+                key={cta.url}
+                intent={getButtonIntent(idx)}
+                buttonClassName={cn(getButtonClassName(idx), 'font-normal')}
+              />
+            ) : (
+              <Button
+                key={cta.url}
+                className={cn(getButtonClassName(idx), 'font-normal')}
+                intent={getButtonIntent(idx)}
+                href={cta.url}
+              >
+                {cta.title}
+              </Button>
+            ),
+          )}
         </div>
       </div>
     </section>

--- a/app/routes/page-builder/loader.tsx
+++ b/app/routes/page-builder/loader.tsx
@@ -213,7 +213,7 @@ export const mapPageBuilderChildItems = async (
           ...baseChild,
           collection: visibleItems.flatMap(
             (item: RockContentItem): CollectionItem[] => {
-              const channelId = item.contentChannelId;
+              const channelId = String(item.contentChannelId);
 
               // Flatten attribute values (needed for all routing paths)
               const itemAttributeValues = Object.fromEntries(

--- a/app/routes/volunteer/components/volunteer-testimonial-carousel.component.tsx
+++ b/app/routes/volunteer/components/volunteer-testimonial-carousel.component.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { useCallback, useLayoutEffect, useRef, useState } from 'react';
 import type { PointerEvent } from 'react';
 
 import { cn } from '~/lib/utils';
@@ -95,30 +95,6 @@ export function VolunteerTestimonialCarousel() {
 
   const desktopViewportRef = useRef<HTMLDivElement>(null);
   const [desktopViewportWidth, setDesktopViewportWidth] = useState(0);
-  const wheelCooldownRef = useRef(false);
-
-  useEffect(() => {
-    const el = desktopViewportRef.current;
-    if (!el) return;
-
-    const onWheel = (e: WheelEvent) => {
-      if (Math.abs(e.deltaX) <= Math.abs(e.deltaY)) return;
-      if (wheelCooldownRef.current) return;
-      e.preventDefault();
-      wheelCooldownRef.current = true;
-      setTimeout(() => {
-        wheelCooldownRef.current = false;
-      }, 500);
-      if (e.deltaX > 0) {
-        setActiveIndex((i) => Math.min(lastIndex, i + 1));
-      } else {
-        setActiveIndex((i) => Math.max(0, i - 1));
-      }
-    };
-
-    el.addEventListener('wheel', onWheel, { passive: false });
-    return () => el.removeEventListener('wheel', onWheel);
-  }, [lastIndex]);
 
   useLayoutEffect(() => {
     const el = desktopViewportRef.current;

--- a/app/routes/volunteer/components/volunteer-testimonial-carousel.component.tsx
+++ b/app/routes/volunteer/components/volunteer-testimonial-carousel.component.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useLayoutEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import type { PointerEvent } from 'react';
 
 import { cn } from '~/lib/utils';
@@ -95,6 +95,30 @@ export function VolunteerTestimonialCarousel() {
 
   const desktopViewportRef = useRef<HTMLDivElement>(null);
   const [desktopViewportWidth, setDesktopViewportWidth] = useState(0);
+  const wheelCooldownRef = useRef(false);
+
+  useEffect(() => {
+    const el = desktopViewportRef.current;
+    if (!el) return;
+
+    const onWheel = (e: WheelEvent) => {
+      if (Math.abs(e.deltaX) <= Math.abs(e.deltaY)) return;
+      if (wheelCooldownRef.current) return;
+      e.preventDefault();
+      wheelCooldownRef.current = true;
+      setTimeout(() => {
+        wheelCooldownRef.current = false;
+      }, 500);
+      if (e.deltaX > 0) {
+        setActiveIndex((i) => Math.min(lastIndex, i + 1));
+      } else {
+        setActiveIndex((i) => Math.max(0, i - 1));
+      }
+    };
+
+    el.addEventListener('wheel', onWheel, { passive: false });
+    return () => el.removeEventListener('wheel', onWheel);
+  }, [lastIndex]);
 
   useLayoutEffect(() => {
     const el = desktopViewportRef.current;

--- a/app/routes/volunteer/partials/volunteer-globe.partial.tsx
+++ b/app/routes/volunteer/partials/volunteer-globe.partial.tsx
@@ -16,7 +16,7 @@ export function VolunteerGlobe() {
       className='w-full bg-dark-navy text-white py-28 content-padding'
     >
       <div className='max-w-screen-content mx-auto'>
-        <SectionTitle sectionTitle='Go Further' color='#56c6f2' />
+        <SectionTitle sectionTitle='Go further' color='#56c6f2' />
         <div className='flex flex-col gap-4 mt-3 mb-12'>
           <h2 className='heading-h2 text-[40px] md:text-6xl text-white'>
             Volunteer Around The Globe

--- a/app/routes/volunteer/partials/volunteer-hero.partial.tsx
+++ b/app/routes/volunteer/partials/volunteer-hero.partial.tsx
@@ -36,7 +36,7 @@ export const VolunteerHero = () => {
 
           {/* Body */}
           <p className='text-[#3F484C] text-lg lg:text-xl max-w-[520px]'>
-            We want every volunteer&apos;s experience at Church to be a
+            We want every volunteer&apos;s experience at church to be a
             fulfilling journey where they feel welcomed and can share the love
             of Jesus. Our hope is that every volunteer understands the impact
             they have, knowing they are making a difference in the lives of

--- a/app/routes/volunteer/partials/volunteer-hero.partial.tsx
+++ b/app/routes/volunteer/partials/volunteer-hero.partial.tsx
@@ -24,7 +24,7 @@ export const VolunteerHero = () => {
               Home
             </a>
             <Icon name='chevronRight' size={16} className='text-navy' />
-            <a href='/volunteer'>Volunteer</a>
+            <span>Volunteer</span>
           </div>
 
           {/* Heading */}

--- a/app/routes/volunteer/partials/volunteer-stats.partial.tsx
+++ b/app/routes/volunteer/partials/volunteer-stats.partial.tsx
@@ -10,23 +10,23 @@ type ImpactStat = {
 const IMPACT_STATS_ROW1: ImpactStat[] = [
   {
     value: '695k+',
-    label: 'People impacted through our mission efforts.',
+    label: 'People impacted through our mission efforts',
   },
   { value: '13k+', label: 'Volunteers served' },
   {
     value: '8,010',
-    label: 'People said “yes” to Jesus.',
+    label: 'People said “yes” to Jesus',
   },
   {
     value: '639k+',
-    label: 'Kids received hot meals in 39 different countries.',
+    label: 'Kids received hot meals in 39 different countries',
   },
 ];
 
 const IMPACT_STATS_ROW2: ImpactStat[] = [
   {
     value: '42k+',
-    label: 'People served by the food truck in our community.',
+    label: 'People served by the food truck in our community',
   },
   {
     value: '41',
@@ -34,11 +34,11 @@ const IMPACT_STATS_ROW2: ImpactStat[] = [
   },
   {
     value: '427k',
-    label: 'Food distributed to the Missions Center.',
+    label: 'Food distributed to the Missions Center',
   },
   {
     value: '2,794',
-    label: 'People were baptized, declaring their faith.',
+    label: 'People were baptized, declaring their faith',
   },
 ];
 

--- a/app/routes/volunteer/volunteer-testimonials.data.ts
+++ b/app/routes/volunteer/volunteer-testimonials.data.ts
@@ -25,7 +25,7 @@ export const volunteerTestimonialsData: VolunteerTestimonialCardType[] = [
   },
   {
     title: 'Addi’s Story',
-    heading: 'A Place Of Belonging',
+    heading: 'A place of belonging',
     description:
       'After a lonely start to her college experience, Addi’s path began to change when someone suggested Southeastern University at Christ Fellowship (CFSEU).',
     shortContent:
@@ -37,7 +37,7 @@ export const volunteerTestimonialsData: VolunteerTestimonialCardType[] = [
   },
   {
     title: 'Markaveus’ Story',
-    heading: 'When Jesus Steps In, Freedom Begins',
+    heading: 'When Jesus steps in, freedom begins',
     description:
       'As Markaveus’ mom watched her son fall into a life of violence, gangs, and drugs, she prayed diligently that he would remember the values she tried to instill in him.',
     shortContent: '\u201cI Walked Out A Free Man In More Ways Than One.\u201d',
@@ -74,7 +74,7 @@ export const volunteerTestimonialsData: VolunteerTestimonialCardType[] = [
     title: 'Ruth’s Story',
     heading: 'The Message of Jesus',
     description:
-      'How the Gospel Reached This 17-Year-Old From Liberia Who Grew Up in a Devout Muslim Home...',
+      'How the gospel reached this 17-year-old from Liberia who grew up in a devout Muslim home...',
     shortContent: '\u201cI Believe Jesus Is The Son Of God.\u201d',
     longDescription:
       'Ruth is a 17-year-old from Liberia who grew up in a devout Muslim home. When she joined a Beyond Success table, she was drawn to the values being taught, but hesitant about the message of Jesus. During a session called \u201cMy Most Important Relationship,\u201d Ruth quietly prayed to accept Christ. Though nervous to share her decision, she later told her facilitator, \u201cI believe Jesus is the Son of God.\u201d Her faith is now growing, and her heart is open to all God has for her.',
@@ -83,7 +83,7 @@ export const volunteerTestimonialsData: VolunteerTestimonialCardType[] = [
   },
   {
     title: 'Donnie & Maria',
-    heading: 'When The City Called, The Church Responded',
+    heading: 'When the city called, the church responded',
     description:
       'When Palm Beach Gardens Police and city officials discovered a local couple, Maria and Donnie, living in horrific conditions after their home was taken over by drug dealers, they didn’t know where to turn—so they called the church.',
     shortContent: '\u201cStunned And Grateful Beyond Words\u201d',


### PR DESCRIPTION
## Summary
General cleanup and bug fixes across the volunteer and home pages, plus a breadcrumb
semantic fix. Additionally fixes a podcast episode routing bug in Resource Collections
and wires up the Set a Reminder modal in the For Families tab CTA card.
These changes address items from CFDP-4001, CFDP-4002, and CFDP-4005.

## Screenshots
N/A — copy/casing, CSS fixes, and bug fixes only.

## Testing
- [x] Volunteer page: confirm "church" and "further" are lowercase in hero/globe sections
- [x] Volunteer page: confirm stat blurbs have no trailing periods
- [x] Volunteer page: confirm story headings use sentence case (Addi, Markaveus, Ruth, Donnie & Maria)
- [x] Volunteer page: confirm "Volunteer" breadcrumb is non-clickable (rendered as <span>)
- [x] Volunteer page: confirm desktop carousel advances via trackpad horizontal scroll
- [x] Verify So Good Sisterhood S7E5 appears on the Christine Caine Resource Collection in the [/hear-more-from-christine-caine](https://deploy-preview-276--cf-web-v3.netlify.app/hear-more-from-christine-caine) page
- [x] Verify "Plan your first Visit" button in the For Families tab opens the Set a Reminder modal (not navigating to homepage)

## Tickets
[CFDP-4001](https://christfellowshipchurch.atlassian.net/browse/CFDP-4001) — Volunteer page
[CFDP-4002](https://christfellowshipchurch.atlassian.net/browse/CFDP-4002) — Home hero
[CFDP-4005](https://christfellowshipchurch.atlassian.net/browse/CFDP-4005) — CFSEU Redirect Card / Resource Collection

## Changes Made

### Volunteer Page (CFDP-4001)
- `volunteer-hero.partial.tsx` — "at Church" → "at church"; breadcrumb last item changed from `<a>` to `<span>`
- `volunteer-globe.partial.tsx` — "Go Further" → "Go further"
- `volunteer-stats.partial.tsx` — removed trailing periods from all stat blurbs for consistency
- `volunteer-testimonials.data.ts` — sentence-cased headings for Addi, Markaveus, Ruth (description), Donnie & Maria
- `volunteer-testimonial-carousel.component.tsx` — added non-passive wheel event listener on desktop viewport for trackpad horizontal scroll navigation

### Home Page (CFDP-4002)
- `desktop-features.component.tsx` — added `lg:rounded-none` to featured item icon boxes to remove unintended 4px rounding at desktop breakpoint

### Podcast Episode Routing Fix (CFDP-4005)
- `app/routes/page-builder/loader.tsx` — coerce `item.contentChannelId` to `String()` before Map lookup; Rock's API returns `ContentChannelId` as a number at runtime but the podcast routing index stores Map keys as strings, causing `Map.get(188)` to never match key `'188'` and silently dropping all podcast episodes from Resource Collections

### Set a Reminder Modal — For Families Tab
- `app/routes/page-builder/components/content-block/cta-card-section.tsx` — detect `/#set-a-reminder` sentinel in CTA URLs and render `<SetAReminderModal>` instead of a plain link, so the "Plan your first Visit" card button correctly opens the modal
- `app/components/modals/set-a-reminder/reminder-modal.component.tsx` — added `buttonClassName` prop to allow callers to fully override internal button styles; used by `CtaCardSection` to match the card's existing button appearance exactly

### Broader Cleanup (various pages)
- Copy and formatting cleanup across about, events, group-finder, locations, messages, and volunteer-form pages

[CFDP-4001]: https://christfellowshipchurch.atlassian.net/browse/CFDP-4001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CFDP-4002]: https://christfellowshipchurch.atlassian.net/browse/CFDP-4002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ