### PR TITLE
Native Prayer Request Form

### DIFF
--- a/app/components/footer/footer-column.component.tsx
+++ b/app/components/footer/footer-column.component.tsx
@@ -1,5 +1,5 @@
 import type { FooterColumn } from './footer-data';
-import { ConnectCardModal } from '~/components';
+import { ConnectCardModal, PrayerRequestModal } from '~/components';
 
 interface FooterColumnProps {
   column: FooterColumn;
@@ -18,6 +18,12 @@ export const FooterColumnComponent = ({ column }: FooterColumnProps) => {
       {column.links.map((link) =>
         link.url === '#connect-card' ? (
           <ConnectCardModal
+            key={link.title}
+            triggerStyles='text-lg font-light text-coconut m-0 p-0 border-0 rounded-none bg-transparent items-start justify-start min-h-0 min-w-0 hover:enabled:bg-transparent hover:cursor-pointer hover:text-white/50'
+            buttonTitle={link.title}
+          />
+        ) : link.url === '#prayer-request' ? (
+          <PrayerRequestModal
             key={link.title}
             triggerStyles='text-lg font-light text-coconut m-0 p-0 border-0 rounded-none bg-transparent items-start justify-start min-h-0 min-w-0 hover:enabled:bg-transparent hover:cursor-pointer hover:text-white/50'
             buttonTitle={link.title}

--- a/app/components/footer/footer-data.ts
+++ b/app/components/footer/footer-data.ts
@@ -23,10 +23,7 @@ export const footerColumns: FooterColumn[] = [
     title: 'Connect',
     links: [
       { title: 'Connect Card', url: '#connect-card' },
-      {
-        title: 'Request Prayer',
-        url: `${ROCK_PUBLIC_SITE_ORIGIN}/RequestPrayer`,
-      },
+      { title: 'Request Prayer', url: '#prayer-request' },
       {
         title: 'Subscribe to Updates',
         url: `${ROCK_PUBLIC_SITE_ORIGIN}/page/4344`,

--- a/app/components/modals/index.ts
+++ b/app/components/modals/index.ts
@@ -1,5 +1,6 @@
 export { AuthModal } from './auth';
 export { ConnectCardModal } from './connect-card';
 export { GroupConnectModal } from './group-connect';
+export { PrayerRequestModal } from './prayer-request';
 export { SetAReminderModal } from './set-a-reminder';
 export { VideoModal } from './video-modal';

--- a/app/components/modals/prayer-request/__tests__/prayer-request-form.test.tsx
+++ b/app/components/modals/prayer-request/__tests__/prayer-request-form.test.tsx
@@ -1,0 +1,188 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { pushFormEvent } from '~/lib/gtm';
+import PrayerRequestForm from '../prayer-request-form.component';
+
+vi.mock('~/lib/gtm', () => ({ pushFormEvent: vi.fn() }));
+
+let mockFetcherState = {
+  state: 'idle' as 'idle' | 'submitting' | 'loading',
+  data: undefined as unknown,
+};
+const mockLoad = vi.fn();
+const mockSubmit = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual =
+    await vi.importActual<typeof import('react-router-dom')>(
+      'react-router-dom',
+    );
+  return {
+    ...actual,
+    useFetcher: () => ({
+      state: mockFetcherState.state,
+      data: mockFetcherState.data,
+      load: mockLoad,
+      submit: mockSubmit,
+    }),
+  };
+});
+
+function renderForm(onSuccess = vi.fn()) {
+  return render(
+    <MemoryRouter>
+      <PrayerRequestForm onSuccess={onSuccess} />
+    </MemoryRouter>,
+  );
+}
+
+function fillRequiredFields() {
+  fireEvent.change(screen.getByLabelText('First Name'), {
+    target: { value: 'Ada' },
+  });
+  fireEvent.change(screen.getByLabelText('Last Name'), {
+    target: { value: 'Lovelace' },
+  });
+  fireEvent.change(screen.getByLabelText('Email'), {
+    target: { value: 'ada@example.com' },
+  });
+  fireEvent.change(screen.getByLabelText('Mobile Phone'), {
+    target: { value: '5615551234' },
+  });
+  fireEvent.change(screen.getByLabelText('Campus'), {
+    target: { value: 'guid-1' },
+  });
+  fireEvent.change(screen.getByLabelText('How can we pray for you?'), {
+    target: { value: 'Please pray for my family.' },
+  });
+}
+
+describe('PrayerRequestForm', () => {
+  beforeEach(() => {
+    mockFetcherState = { state: 'idle', data: undefined };
+    vi.clearAllMocks();
+  });
+
+  it('renders prayer request fields', () => {
+    renderForm();
+
+    expect(screen.getByText('Prayer Request')).toBeInTheDocument();
+    expect(screen.getByText('First Name')).toBeInTheDocument();
+    expect(screen.getByText('Last Name')).toBeInTheDocument();
+    expect(screen.getByText('Email')).toBeInTheDocument();
+    expect(screen.getByText('Mobile Phone')).toBeInTheDocument();
+    expect(screen.getByText('Campus')).toBeInTheDocument();
+    expect(screen.getByText('How can we pray for you?')).toBeInTheDocument();
+    expect(
+      screen.getByText('Would you like our team to follow up with you?'),
+    ).toBeInTheDocument();
+  });
+
+  it('renders follow up options with a blank default option', () => {
+    renderForm();
+
+    expect(screen.getByText('Select one...')).toBeInTheDocument();
+    expect(screen.getByText('Yes - Text Message')).toBeInTheDocument();
+    expect(screen.getByText('Yes - Phone Call')).toBeInTheDocument();
+    expect(screen.getByText('Yes - Email')).toBeInTheDocument();
+    expect(screen.getByText('No Thank You')).toBeInTheDocument();
+  });
+
+  it('shows campuses in select when fetcher data loads', () => {
+    mockFetcherState = {
+      state: 'idle',
+      data: {
+        campuses: [
+          { guid: 'guid-1', name: 'Palm Beach Gardens' },
+          { guid: 'guid-2', name: 'Stuart' },
+        ],
+      },
+    };
+
+    renderForm();
+
+    expect(screen.getByText('Palm Beach Gardens')).toBeInTheDocument();
+    expect(screen.getByText('Stuart')).toBeInTheDocument();
+  });
+
+  it('shows Loading... on submit button when submitting', () => {
+    mockFetcherState = { state: 'submitting', data: undefined };
+
+    renderForm();
+
+    const button = screen.getByRole('button', { name: /loading/i });
+    expect(button).toBeInTheDocument();
+    expect(button).toBeDisabled();
+  });
+
+  it('shows error message from fetcher data', () => {
+    mockFetcherState = {
+      state: 'idle',
+      data: { error: 'Something went wrong' },
+    };
+
+    renderForm();
+
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+  });
+
+  it("calls fetcher.load('/prayer-request') on mount", () => {
+    renderForm();
+
+    expect(mockLoad).toHaveBeenCalledWith('/prayer-request');
+  });
+
+  it('submits to the prayer request route', () => {
+    mockFetcherState = {
+      state: 'idle',
+      data: {
+        campuses: [{ guid: 'guid-1', name: 'Palm Beach Gardens' }],
+      },
+    };
+    renderForm();
+
+    fillRequiredFields();
+    fireEvent.click(screen.getByRole('button', { name: /submit/i }));
+
+    expect(mockSubmit).toHaveBeenCalledWith(expect.any(FormData), {
+      method: 'post',
+      action: '/prayer-request',
+    });
+  });
+
+  it('fires GTM event before onSuccess and passes submitted first name', () => {
+    const onSuccess = vi.fn();
+    mockFetcherState = {
+      state: 'idle',
+      data: {
+        campuses: [{ guid: 'guid-1', name: 'Palm Beach Gardens' }],
+      },
+    };
+    const { rerender } = renderForm(onSuccess);
+
+    fillRequiredFields();
+    fireEvent.click(screen.getByRole('button', { name: /submit/i }));
+
+    mockFetcherState = {
+      state: 'idle',
+      data: { success: true },
+    };
+
+    rerender(
+      <MemoryRouter>
+        <PrayerRequestForm onSuccess={onSuccess} />
+      </MemoryRouter>,
+    );
+
+    expect(pushFormEvent).toHaveBeenCalledWith(
+      'form_complete',
+      'prayer_request',
+      'Prayer Request',
+    );
+    expect(onSuccess).toHaveBeenCalledWith('Ada');
+    expect(vi.mocked(pushFormEvent).mock.invocationCallOrder[0]).toBeLessThan(
+      onSuccess.mock.invocationCallOrder[0],
+    );
+  });
+});

--- a/app/components/modals/prayer-request/confirmation.component.tsx
+++ b/app/components/modals/prayer-request/confirmation.component.tsx
@@ -19,11 +19,11 @@ const PrayerRequestConfirmation: React.FC<PrayerRequestConfirmationProps> = ({
         Thank you {firstName} for allowing us to pray with you.
       </h1>
       <Button
-        intent='primary'
-        className='rounded-xl w-64'
+        intent='secondary'
+        className='rounded-xl w-auto whitespace-nowrap'
         onClick={onAddAnother}
       >
-        Add Another Prayer Request
+        Add another prayer request
       </Button>
       <Button intent='primary' className='rounded-xl w-52' onClick={onSuccess}>
         Continue

--- a/app/components/modals/prayer-request/confirmation.component.tsx
+++ b/app/components/modals/prayer-request/confirmation.component.tsx
@@ -1,0 +1,35 @@
+import { Button } from '~/primitives/button/button.primitive';
+import Icon from '~/primitives/icon';
+
+interface PrayerRequestConfirmationProps {
+  firstName: string;
+  onAddAnother: () => void;
+  onSuccess: () => void;
+}
+
+const PrayerRequestConfirmation: React.FC<PrayerRequestConfirmationProps> = ({
+  firstName,
+  onAddAnother,
+  onSuccess,
+}) => {
+  return (
+    <div className='flex flex-col items-center gap-4 p-8'>
+      <Icon name='check' size={64} color='#1ec27f' />
+      <h1 className='font-bold text-2xl text-navy'>
+        Thank you {firstName} for allowing us to pray with you.
+      </h1>
+      <Button
+        intent='primary'
+        className='rounded-xl w-64'
+        onClick={onAddAnother}
+      >
+        Add Another Prayer Request
+      </Button>
+      <Button intent='primary' className='rounded-xl w-52' onClick={onSuccess}>
+        Continue
+      </Button>
+    </div>
+  );
+};
+
+export default PrayerRequestConfirmation;

--- a/app/components/modals/prayer-request/confirmation.component.tsx
+++ b/app/components/modals/prayer-request/confirmation.component.tsx
@@ -14,18 +14,24 @@ const PrayerRequestConfirmation: React.FC<PrayerRequestConfirmationProps> = ({
 }) => {
   return (
     <div className='flex flex-col items-center gap-4 p-8'>
-      <Icon name='check' size={64} color='#1ec27f' />
-      <h1 className='font-bold text-2xl text-navy'>
+      <Icon name='handsPraying' size={64} color='#0092bc' />
+      <h1 className='my-4 font-bold text-2xl text-navy'>
         Thank you {firstName} for allowing us to pray with you.
       </h1>
       <Button
         intent='secondary'
+        size='md'
         className='rounded-xl w-auto whitespace-nowrap'
         onClick={onAddAnother}
       >
         Add another prayer request
       </Button>
-      <Button intent='primary' className='rounded-xl w-52' onClick={onSuccess}>
+      <Button
+        intent='primary'
+        size='md'
+        className='rounded-xl w-52'
+        onClick={onSuccess}
+      >
         Continue
       </Button>
     </div>

--- a/app/components/modals/prayer-request/index.ts
+++ b/app/components/modals/prayer-request/index.ts
@@ -1,0 +1,3 @@
+import { PrayerRequestModal } from './prayer-request-modal';
+
+export { PrayerRequestModal };

--- a/app/components/modals/prayer-request/prayer-request-flow.component.tsx
+++ b/app/components/modals/prayer-request/prayer-request-flow.component.tsx
@@ -1,0 +1,52 @@
+import { useState } from 'react';
+import PrayerRequestConfirmation from './confirmation.component';
+import PrayerRequestForm from './prayer-request-form.component';
+
+enum PrayerRequestStep {
+  FORM,
+  CONFIRMATION,
+}
+
+const PrayerRequestFlow = ({
+  setOpenModal,
+}: {
+  setOpenModal: (open: boolean) => void;
+}) => {
+  const [step, setStep] = useState<PrayerRequestStep>(PrayerRequestStep.FORM);
+  const [firstName, setFirstName] = useState('');
+
+  const renderStep = () => {
+    switch (step) {
+      case PrayerRequestStep.FORM:
+        return (
+          <PrayerRequestForm
+            onSuccess={(submittedFirstName) => {
+              setFirstName(submittedFirstName);
+              setStep(PrayerRequestStep.CONFIRMATION);
+            }}
+          />
+        );
+      case PrayerRequestStep.CONFIRMATION:
+        return (
+          <PrayerRequestConfirmation
+            firstName={firstName}
+            onAddAnother={() => {
+              setFirstName('');
+              setStep(PrayerRequestStep.FORM);
+            }}
+            onSuccess={() => setOpenModal(false)}
+          />
+        );
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <div className='pt-10 text-center text-text_primary p-6 w-[90vw] max-w-sm md:max-w-xl lg:max-w-3xl overflow-y-scroll max-h-[85vh] md:max-h-[90vh]'>
+      {renderStep()}
+    </div>
+  );
+};
+
+export default PrayerRequestFlow;

--- a/app/components/modals/prayer-request/prayer-request-form.component.tsx
+++ b/app/components/modals/prayer-request/prayer-request-form.component.tsx
@@ -1,0 +1,210 @@
+import * as Form from '@radix-ui/react-form';
+import { useEffect, useRef, useState } from 'react';
+import { useFetcher } from 'react-router-dom';
+import { pushFormEvent } from '~/lib/gtm';
+import { Button } from '~/primitives/button/button.primitive';
+import { defaultTextInputStyles } from '~/primitives/inputs/text-field/text-field.primitive';
+import { PrayerRequestLoaderReturnType } from '~/routes/prayer-request/types';
+
+interface PrayerRequestFormProps {
+  onSuccess: (firstName: string) => void;
+}
+
+const followUpOptions = [
+  { value: '1', label: 'Yes - Text Message' },
+  { value: '2', label: 'Yes - Phone Call' },
+  { value: '3', label: 'Yes - Email' },
+  { value: '4', label: 'No Thank You' },
+];
+
+const renderInputField = (
+  name: string,
+  label: string,
+  type: string,
+  requiredMessage: string,
+) => (
+  <Form.Field name={name} className='flex flex-col mb-4'>
+    <Form.Label className='font-bold text-sm mb-2'>{label}</Form.Label>
+    <Form.Control asChild>
+      <input type={type} required className={defaultTextInputStyles} />
+    </Form.Control>
+    <Form.Message className='text-sm text-alert' match='valueMissing'>
+      {requiredMessage}
+    </Form.Message>
+    {type === 'email' && (
+      <Form.Message className='text-sm text-alert' match='typeMismatch'>
+        Please enter a valid email address
+      </Form.Message>
+    )}
+  </Form.Field>
+);
+
+const PrayerRequestForm: React.FC<PrayerRequestFormProps> = ({ onSuccess }) => {
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [campuses, setCampuses] = useState<
+    PrayerRequestLoaderReturnType['campuses']
+  >([]);
+  const submittedFirstName = useRef('');
+  const fetcher = useFetcher();
+
+  useEffect(() => {
+    fetcher.load('/prayer-request');
+  }, []);
+
+  useEffect(() => {
+    if (fetcher.state === 'idle' && fetcher.data) {
+      setLoading(false);
+
+      if ('campuses' in fetcher.data) {
+        setCampuses((fetcher.data as PrayerRequestLoaderReturnType).campuses);
+      } else if ('error' in fetcher.data) {
+        setError(fetcher.data.error || 'An unexpected error occurred');
+      } else {
+        setError(null);
+        pushFormEvent('form_complete', 'prayer_request', 'Prayer Request');
+        onSuccess(submittedFirstName.current);
+      }
+    }
+
+    if (fetcher.state === 'submitting') {
+      setLoading(true);
+      setError(null);
+    }
+  }, [fetcher.state, fetcher.data, onSuccess]);
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+    submittedFirstName.current = String(formData.get('FirstName') || '');
+
+    try {
+      fetcher.submit(formData, {
+        method: 'post',
+        action: '/prayer-request',
+      });
+    } catch {
+      setError(
+        'An error occurred while submitting the form. Please try again.',
+      );
+      setLoading(false);
+    }
+  };
+
+  return (
+    <>
+      <h2 className='mb-6 text-3xl text-navy font-bold'>Prayer Request</h2>
+      <Form.Root
+        onSubmit={handleSubmit}
+        className='flex flex-col md:grid text-left grid-cols-1 gap-y-3 gap-x-6 md:grid-cols-2'
+      >
+        {renderInputField(
+          'FirstName',
+          'First Name',
+          'text',
+          'Please enter your first name',
+        )}
+        {renderInputField(
+          'LastName',
+          'Last Name',
+          'text',
+          'Please enter your last name',
+        )}
+        {renderInputField(
+          'Email',
+          'Email',
+          'email',
+          'Please enter your email address',
+        )}
+        {renderInputField(
+          'MobilePhone',
+          'Mobile Phone',
+          'tel',
+          'Please enter your phone number',
+        )}
+
+        <Form.Field name='Campus' className='flex flex-col mb-4 md:col-span-2'>
+          <Form.Label className='font-bold text-sm mb-2'>Campus</Form.Label>
+          <Form.Control asChild>
+            {campuses && (
+              <select
+                className={`appearance-none ${defaultTextInputStyles}`}
+                required
+                style={{
+                  backgroundImage: `url('/assets/icons/chevron-down.svg')`,
+                  backgroundSize: '24px',
+                  backgroundPosition: 'calc(100% - 2%) center',
+                  backgroundRepeat: 'no-repeat',
+                }}
+              >
+                <option value=''>Select a Campus</option>
+                {campuses.map(({ guid, name }, index) => (
+                  <option key={index} value={guid}>
+                    {name}
+                  </option>
+                ))}
+              </select>
+            )}
+          </Form.Control>
+          <Form.Message className='text-sm text-alert' match='valueMissing'>
+            Please select a campus
+          </Form.Message>
+        </Form.Field>
+
+        <Form.Field name='Request' className='flex flex-col mb-4 md:col-span-2'>
+          <Form.Label className='font-bold text-sm mb-2'>
+            How can we pray for you?
+          </Form.Label>
+          <Form.Control asChild>
+            <textarea required rows={5} className={defaultTextInputStyles} />
+          </Form.Control>
+          <Form.Message className='text-sm text-alert' match='valueMissing'>
+            Please enter your prayer request
+          </Form.Message>
+        </Form.Field>
+
+        <Form.Field
+          name='FollowUp'
+          className='flex flex-col mb-4 md:col-span-2'
+        >
+          <Form.Label className='font-bold text-sm mb-2'>
+            Would you like our team to follow up with you?
+          </Form.Label>
+          <Form.Control asChild>
+            <select
+              className={`appearance-none ${defaultTextInputStyles}`}
+              style={{
+                backgroundImage: `url('/assets/icons/chevron-down.svg')`,
+                backgroundSize: '24px',
+                backgroundPosition: 'calc(100% - 2%) center',
+                backgroundRepeat: 'no-repeat',
+              }}
+            >
+              <option value=''>Select one...</option>
+              {followUpOptions.map(({ value, label }) => (
+                <option key={value} value={value}>
+                  {label}
+                </option>
+              ))}
+            </select>
+          </Form.Control>
+        </Form.Field>
+
+        {error && <p className='text-alert col-span-2 text-center'>{error}</p>}
+
+        <Form.Submit className='mt-6 mx-auto col-span-1 md:col-span-2' asChild>
+          <Button
+            className='w-40 h-12'
+            size='md'
+            type='submit'
+            disabled={loading}
+          >
+            {loading ? 'Loading...' : 'Submit'}
+          </Button>
+        </Form.Submit>
+      </Form.Root>
+    </>
+  );
+};
+
+export default PrayerRequestForm;

--- a/app/components/modals/prayer-request/prayer-request-modal.tsx
+++ b/app/components/modals/prayer-request/prayer-request-modal.tsx
@@ -1,0 +1,47 @@
+import { useState } from 'react';
+import { pushFormEvent } from '~/lib/gtm';
+import Modal from '~/primitives/Modal';
+import { Button } from '~/primitives/button/button.primitive';
+import { ButtonProps } from '~/primitives/button/button.primitive';
+import type { ReactNode } from 'react';
+import PrayerRequestFlow from './prayer-request-flow.component';
+
+interface PrayerRequestModalProps {
+  buttonTitle?: string;
+  triggerStyles?: string;
+  TriggerButton?: React.ComponentType<ButtonProps>;
+  children?: ReactNode;
+}
+
+export function PrayerRequestModal({
+  buttonTitle,
+  triggerStyles,
+  TriggerButton = Button,
+  children,
+}: PrayerRequestModalProps) {
+  const [openModal, setOpenModal] = useState(false);
+
+  const handleOpenChange = (open: boolean) => {
+    setOpenModal(open);
+    if (open) {
+      pushFormEvent('form_start', 'prayer_request', 'Prayer Request');
+    }
+  };
+
+  return (
+    <Modal open={openModal} onOpenChange={handleOpenChange}>
+      {children ? (
+        <Modal.Button asChild>{children}</Modal.Button>
+      ) : (
+        <Modal.Button asChild className='mr-2'>
+          <TriggerButton intent='white' className={triggerStyles}>
+            {buttonTitle ? buttonTitle : 'Prayer Request'}
+          </TriggerButton>
+        </Modal.Button>
+      )}
+      <Modal.Content>
+        <PrayerRequestFlow setOpenModal={setOpenModal} />
+      </Modal.Content>
+    </Modal>
+  );
+}

--- a/app/routes/prayer-request/action.test.ts
+++ b/app/routes/prayer-request/action.test.ts
@@ -1,0 +1,67 @@
+import type { ActionFunctionArgs } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { postRockWorkflowLaunchWithApiInitiator } from '~/lib/.server/rock-workflow';
+import { action } from './action';
+
+vi.mock('~/lib/.server/rock-workflow', () => ({
+  postRockWorkflowLaunchWithApiInitiator: vi.fn(),
+}));
+
+const createRequest = (includeFollowUp = false) => {
+  const formData = new FormData();
+  formData.set('FirstName', 'Test');
+  formData.set('LastName', 'Person');
+  formData.set('Email', 'test@example.com');
+  formData.set('MobilePhone', '5555555555');
+  formData.set('Campus', 'campus-guid-123');
+  formData.set('Request', 'Please pray for us');
+  if (includeFollowUp) {
+    formData.set('FollowUp', '1');
+  }
+
+  return new Request('http://localhost/prayer-request', {
+    method: 'POST',
+    body: formData,
+  });
+};
+
+describe('prayer request action', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(postRockWorkflowLaunchWithApiInitiator).mockResolvedValue(
+      undefined,
+    );
+  });
+
+  it('launches prayer workflow with API initiator', async () => {
+    await action({ request: createRequest() } as ActionFunctionArgs);
+
+    expect(postRockWorkflowLaunchWithApiInitiator).toHaveBeenCalledWith({
+      workflowTypeId: '348',
+      workflowName: 'CFDP App Prayer Request',
+      body: {
+        FirstName: 'Test',
+        LastName: 'Person',
+        Email: 'test@example.com',
+        MobilePhone: '5555555555',
+        Campus: 'campus-guid-123',
+        Request: 'Please pray for us',
+        LaunchSource: 'app',
+        SendingFormName: 'CFDP App Prayer Request',
+      },
+      instanceName: 'Test Person',
+    });
+  });
+
+  it('includes FollowUp when provided', async () => {
+    await action({
+      request: createRequest(true),
+    } as ActionFunctionArgs);
+
+    expect(postRockWorkflowLaunchWithApiInitiator).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({ FollowUp: '1' }),
+      }),
+    );
+  });
+});

--- a/app/routes/prayer-request/action.ts
+++ b/app/routes/prayer-request/action.ts
@@ -1,0 +1,52 @@
+import { ActionFunction, data } from 'react-router-dom';
+import { PrayerRequestFormType } from './types';
+import { postRockData } from '~/lib/.server/fetch-rock-data';
+
+export const action: ActionFunction = async ({ request }) => {
+  try {
+    const formData = Object.fromEntries(await request.formData());
+
+    const {
+      FirstName,
+      LastName,
+      Email,
+      MobilePhone,
+      Campus,
+      Request,
+      FollowUp,
+    } = formData;
+
+    const prayerRequestSubmission: PrayerRequestFormType = {
+      FirstName: FirstName as string,
+      LastName: LastName as string,
+      Email: Email as string,
+      MobilePhone: MobilePhone as string,
+      Campus: Campus as string,
+      Request: Request as string,
+      LaunchSource: 'app',
+      SendingFormName: 'CFDP App Prayer Request',
+    };
+
+    if (FollowUp) {
+      prayerRequestSubmission.FollowUp = FollowUp as string;
+    }
+
+    await postRockData({
+      endpoint:
+        'Workflows/LaunchWorkflow/0?workflowTypeId=348&workflowName=CFDP%20App%20Prayer%20Request',
+      body: prayerRequestSubmission,
+    });
+
+    return new Response(JSON.stringify({ success: true }), {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+  } catch (error) {
+    if (error instanceof Error) {
+      return data({ error: error.message }, { status: 400 });
+    }
+    return data({ error: 'Network error please try again' }, { status: 400 });
+  }
+};

--- a/app/routes/prayer-request/action.ts
+++ b/app/routes/prayer-request/action.ts
@@ -1,6 +1,6 @@
 import { ActionFunction, data } from 'react-router-dom';
 import { PrayerRequestFormType } from './types';
-import { postRockData } from '~/lib/.server/fetch-rock-data';
+import { postRockWorkflowLaunchWithApiInitiator } from '~/lib/.server/rock-workflow';
 
 export const action: ActionFunction = async ({ request }) => {
   try {
@@ -31,10 +31,14 @@ export const action: ActionFunction = async ({ request }) => {
       prayerRequestSubmission.FollowUp = FollowUp as string;
     }
 
-    await postRockData({
-      endpoint:
-        'Workflows/LaunchWorkflow/0?workflowTypeId=348&workflowName=CFDP%20App%20Prayer%20Request',
+    const firstName = FirstName as string;
+    const lastName = LastName as string;
+
+    await postRockWorkflowLaunchWithApiInitiator({
+      workflowTypeId: '348',
+      workflowName: 'CFDP App Prayer Request',
       body: prayerRequestSubmission,
+      instanceName: `${firstName} ${lastName}`.trim(),
     });
 
     return new Response(JSON.stringify({ success: true }), {

--- a/app/routes/prayer-request/loader.ts
+++ b/app/routes/prayer-request/loader.ts
@@ -1,0 +1,18 @@
+import { LoaderFunction } from 'react-router-dom';
+import { fetchRockData } from '~/lib/.server/fetch-rock-data';
+import { PrayerRequestLoaderReturnType } from './types';
+
+export const loader: LoaderFunction = async () => {
+  const campuses = await fetchRockData({
+    endpoint: 'Campuses',
+    queryParams: {
+      $filter: 'IsActive eq true',
+      $orderby: 'Order',
+      $select: 'Name, Guid',
+    },
+  });
+
+  const data: PrayerRequestLoaderReturnType = { campuses };
+
+  return <PrayerRequestLoaderReturnType>data;
+};

--- a/app/routes/prayer-request/route.tsx
+++ b/app/routes/prayer-request/route.tsx
@@ -1,0 +1,6 @@
+export { action } from './action';
+export { loader } from './loader';
+
+export default function PrayerRequestRoute() {
+  return null;
+}

--- a/app/routes/prayer-request/types.ts
+++ b/app/routes/prayer-request/types.ts
@@ -1,0 +1,15 @@
+export type PrayerRequestFormType = {
+  FirstName: string;
+  LastName: string;
+  Email: string;
+  MobilePhone: string;
+  Campus: string; // campus guid
+  Request: string;
+  FollowUp?: string;
+  LaunchSource: 'app';
+  SendingFormName: 'CFDP App Prayer Request';
+};
+
+export type PrayerRequestLoaderReturnType = {
+  campuses: { guid: string; name: string }[];
+};


### PR DESCRIPTION
## Summary

Adds native Rock Prayer Request form to website with a new prayer-request modal and fetcher-backed route that submits to Rock RMS via `LaunchWorkflow` workflow type `348`. The form follows the existing connect-card modal pattern and includes the REST remediation fields required by Rock.

## Screenshots

<img width="1178" height="967" alt="image" src="https://github.com/user-attachments/assets/1e5f60bb-1d95-4762-a74f-5a3dd1cc37bb" />

## Testing

Manual verification steps:

- [x] Scroll to the footer and click `Request Prayer` under the `Connect` column.
- [x] Confirm the Prayer Request modal opens instead of navigating to the old Rock-hosted prayer page.
- [x] Confirm the form shows all the correct fields
- [x] Submit the form with valid test data and confirm the personalized confirmation screen appears.
- [x] Click `Add Another Prayer Request` and confirm the form step is shown again.

Rock verification checklist:

- [x] Workflow type ID 348 verified in Rock admin.
- [ ] Test submission fires successfully and a workflow instance appears in Rock Manage Workflows with all filters cleared.

## Tickets

[CFDP-3980](https://christfellowshipchurch.atlassian.net/browse/CFDP-3980)

## Changes Made

### New Components Added

- `app/components/modals/prayer-request/prayer-request-modal.tsx` - modal wrapper that fires the prayer request form-start GTM event.
- `app/components/modals/prayer-request/prayer-request-flow.component.tsx` - form/confirmation step flow with submitted first name state.
- `app/components/modals/prayer-request/prayer-request-form.component.tsx` - Radix form using `useFetcher` to load campuses and submit prayer requests.
- `app/components/modals/prayer-request/confirmation.component.tsx` - personalized confirmation view with add-another and continue actions.

### Route Implementation

- `app/routes/prayer-request/route.tsx` - fetcher-only route exporting action and loader.
- `app/routes/prayer-request/action.ts` - posts exact Rock attribute keys to `Workflows/LaunchWorkflow/0?workflowTypeId=348&workflowName=CFDP%20App%20Prayer%20Request`.
- `app/routes/prayer-request/loader.ts` - loads active campuses ordered by Rock campus order.
- `app/routes/prayer-request/types.ts` - form submission and loader return types.

### Key Features

- Submits `FirstName`, `LastName`, `Email`, `MobilePhone`, campus `Guid`, `Request`, optional numeric `FollowUp`, `LaunchSource: app`, and `SendingFormName: CFDP App Prayer Request`.
- Opens the Prayer Request modal from the footer `Request Prayer` link.
- Sends `form_start` and `form_complete` GTM events with `prayer_request` metadata.
- Adds tests for field rendering, loading state, error state, submission route, and success callback ordering.


[CFDP-3980]: https://christfellowshipchurch.atlassian.net/browse/CFDP-3980?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
