### PR TITLE
Event Registration Skeleton

### DIFF
--- a/app/components/modals/set-a-reminder/__tests__/reminder-confirmation.test.tsx
+++ b/app/components/modals/set-a-reminder/__tests__/reminder-confirmation.test.tsx
@@ -4,13 +4,24 @@ import { MemoryRouter } from 'react-router-dom';
 import ReminderConfirmation from '../confirmation.component';
 
 vi.mock('~/lib/gtm', () => ({ pushFormEvent: vi.fn() }));
+
+const mockCalendarEvent = {
+  title: 'Sunday service at Christ Fellowship Church in Palm Beach Gardens',
+  description: 'Join us this Sunday!',
+  address: '123 Main St',
+  startTime: new Date('2025-06-08T09:00:00'),
+  endTime: new Date('2025-06-08T10:30:00'),
+  url: 'https://christfellowship.church/locations/pbg',
+};
+
 vi.mock('~/lib/utils', async () => {
   const actual =
     await vi.importActual<typeof import('~/lib/utils')>('~/lib/utils');
   return {
     ...actual,
-    icsLink: () => 'webcal://example.com/event.ics',
-    icsLinkEvents: () => [{ event: {} }],
+    icsLinkEvents: () => [{ label: '9:00 AM', event: mockCalendarEvent }],
+    googleCalendarLink: () =>
+      'https://calendar.google.com/calendar/render?action=TEMPLATE',
   };
 });
 vi.mock('~/primitives/icon', () => ({
@@ -110,7 +121,7 @@ describe('ReminderConfirmation', () => {
     expect(onSuccess).toHaveBeenCalledOnce();
   });
 
-  it('renders Add to Calendar link', () => {
+  it('renders Add to Calendar button with calendar options in dropdown', () => {
     mockFetcherData = {
       address: '123 Main St',
       url: 'pbg',
@@ -118,7 +129,18 @@ describe('ReminderConfirmation', () => {
       campusName: 'Palm Beach Gardens',
     };
     renderConfirmation();
-    const link = screen.getByRole('link', { name: /Add to Calendar/i });
-    expect(link).toHaveAttribute('href', 'webcal://example.com/event.ics');
+    fireEvent.click(screen.getByRole('button', { name: /Add to Calendar/i }));
+    expect(
+      screen.getByRole('link', { name: /Google Calendar/i }),
+    ).toHaveAttribute(
+      'href',
+      'https://calendar.google.com/calendar/render?action=TEMPLATE',
+    );
+    expect(
+      screen.getByRole('link', { name: /Apple Calendar/i }),
+    ).toHaveAttribute(
+      'href',
+      '/calendar-ics?campus=palm-beach-gardens&time=9%3A00%20AM',
+    );
   });
 });

--- a/app/routes/events/event-single/components/clickthrough-registration.component.tsx
+++ b/app/routes/events/event-single/components/clickthrough-registration.component.tsx
@@ -62,6 +62,7 @@ export const ClickThroughRegistration = ({
     return actualStep - 1;
   };
 
+  const [hitsReady, setHitsReady] = useState(false);
   const [step, setStep] = useState(1);
   const [selectedCampus, setSelectedCampus] = useState<string>('');
   const [selectedSubGroupType, setSelectedSubGroupType] = useState<string>('');
@@ -192,154 +193,168 @@ export const ClickThroughRegistration = ({
   };
 
   return (
-    <InstantSearch
-      indexName='dev_EventFinderItems'
-      searchClient={searchClient}
-      future={{
-        preserveSharedStateOnUnmount: true,
-      }}
-    >
-      <Configure
-        filters={buildFilter()}
-        hitsPerPage={1000}
-        query={step === 1 && campusSearchQuery ? campusSearchQuery : ''}
-        restrictSearchableAttributes={
-          step === 1 && campusSearchQuery
-            ? ['campus.name', 'campus.city']
-            : undefined
-        }
-      />
+    <>
+      {!hitsReady && <RegistrationSkeleton totalSteps={totalSteps} />}
+      <InstantSearch
+        indexName='dev_EventFinderItems'
+        searchClient={searchClient}
+        future={{
+          preserveSharedStateOnUnmount: true,
+        }}
+      >
+        <Configure
+          filters={buildFilter()}
+          hitsPerPage={1000}
+          query={step === 1 && campusSearchQuery ? campusSearchQuery : ''}
+          restrictSearchableAttributes={
+            step === 1 && campusSearchQuery
+              ? ['campus.name', 'campus.city']
+              : undefined
+          }
+        />
 
-      <section className='flex items-center w-full py-8 md:py-16 content-padding bg-gray'>
-        <div className='w-full max-w-3xl flex flex-col gap-13 mx-auto'>
-          <div className='flex flex-col gap-4'>
-            <h2 className='font-extrabold text-center text-black text-[32px]'>
-              Register for {title}
-            </h2>
-            <p className='text-center text-[#717182] text-lg font-medium md:mx-4'>
-              Ready to take the next step? Complete our {totalSteps}-step
-              registration process to secure your spot.
-            </p>
-          </div>
+        <HitsDetector onReady={() => setHitsReady(true)} />
+        {hitsReady && (
+          <section className='flex items-center w-full py-8 md:py-16 content-padding bg-gray'>
+            <div className='w-full max-w-3xl flex flex-col gap-13 mx-auto'>
+              <div className='flex flex-col gap-4'>
+                <h2 className='font-extrabold text-center text-black text-[32px]'>
+                  Register for {title}
+                </h2>
+                <p className='text-center text-[#717182] text-lg font-medium md:mx-4'>
+                  Ready to take the next step? Complete our {totalSteps}-step
+                  registration process to secure your spot.
+                </p>
+              </div>
 
-          <div className='flex flex-col gap-3'>
-            {/* Top */}
-            <div className='flex flex-col gap-2 items-center'>
-              <div className='flex gap-4 items-center'>
-                {step > 1 && (
-                  <div
-                    className='flex items-center cursor-pointer'
-                    onClick={handleBack}
-                  >
-                    <Icon name='chevronLeft' size={16} className='text-black' />
-                    <p className='text-xs font-semibold text-[#616161]'>Back</p>
+              <div className='flex flex-col gap-3'>
+                {/* Top */}
+                <div className='flex flex-col gap-2 items-center'>
+                  <div className='flex gap-4 items-center'>
+                    {step > 1 && (
+                      <div
+                        className='flex items-center cursor-pointer'
+                        onClick={handleBack}
+                      >
+                        <Icon
+                          name='chevronLeft'
+                          size={16}
+                          className='text-black'
+                        />
+                        <p className='text-xs font-semibold text-[#616161]'>
+                          Back
+                        </p>
+                      </div>
+                    )}
+                    <h3 className='text-xl font-bold text-black'>
+                      {getCurrentStepData().title}
+                    </h3>
+                  </div>
+
+                  <div className='flex gap-2 items-center'>
+                    {Array.from({ length: totalSteps }, (_, i) => i + 1).map(
+                      (dotStep) => {
+                        const displayStep = getDisplayStep(step);
+                        return (
+                          <div
+                            key={dotStep}
+                            className={`${
+                              dotStep <= displayStep
+                                ? 'bg-ocean'
+                                : 'bg-[#AEAEAE]'
+                            } size-[10px] rounded-full`}
+                          />
+                        );
+                      },
+                    )}
+                  </div>
+
+                  <p className='text-black font-semibold text-sm mb-4'>
+                    Step {getDisplayStep(step)} of {totalSteps}
+                  </p>
+                </div>
+
+                {/* Selected Bar - shows previous selections */}
+                {(selectedCampus ||
+                  selectedSubGroupType ||
+                  selectedDate ||
+                  selectedTime) && (
+                  <div className='flex gap-4 items-center justify-center flex-wrap mb-4'>
+                    {selectedCampus && (
+                      <SelectedBar
+                        icon='map'
+                        text={selectedCampus}
+                        onClick={() => navigateToStep(1)}
+                      />
+                    )}
+                    {selectedSubGroupType && hasSubGroups && (
+                      <SelectedBar
+                        icon='group'
+                        text={selectedSubGroupType}
+                        onClick={() => navigateToStep(2)}
+                      />
+                    )}
+                    {selectedDate && (
+                      <SelectedBar
+                        icon='calendarAlt'
+                        text={formatDateDisplay(selectedDate)}
+                        onClick={() => navigateToStep(hasSubGroups ? 3 : 2)}
+                      />
+                    )}
+                    {selectedTime && (
+                      <SelectedBar
+                        icon='timeFive'
+                        text={`${selectedTime} ET`}
+                        onClick={() => navigateToStep(hasSubGroups ? 4 : 3)}
+                      />
+                    )}
                   </div>
                 )}
-                <h3 className='text-xl font-bold text-black'>
-                  {getCurrentStepData().title}
-                </h3>
-              </div>
 
-              <div className='flex gap-2 items-center'>
-                {Array.from({ length: totalSteps }, (_, i) => i + 1).map(
-                  (dotStep) => {
-                    const displayStep = getDisplayStep(step);
-                    return (
-                      <div
-                        key={dotStep}
-                        className={`${
-                          dotStep <= displayStep ? 'bg-ocean' : 'bg-[#AEAEAE]'
-                        } size-[10px] rounded-full`}
-                      />
-                    );
-                  },
-                )}
+                {/* Step Content */}
+                <StepContent
+                  step={step}
+                  selectedCampus={selectedCampus}
+                  selectedSubGroupType={selectedSubGroupType}
+                  selectedDate={selectedDate}
+                  selectedTime={selectedTime}
+                  campusSearchQuery={campusSearchQuery}
+                  isGoingBack={isGoingBack}
+                  groupType={extractedGroupType}
+                  onCampusSelect={(campus) => {
+                    setSelectedCampus(campus);
+                    setIsGoingBack(false);
+                    previousStepRef.current = 1;
+                    setStep(hasSubGroups ? 2 : 3);
+                  }}
+                  onSubGroupTypeSelect={(subGroupType) => {
+                    setSelectedSubGroupType(subGroupType);
+                    setIsGoingBack(false);
+                    previousStepRef.current = 2;
+                    setStep(3);
+                  }}
+                  onDateSelect={(date) => {
+                    setSelectedDate(date);
+                    setIsGoingBack(false);
+                    previousStepRef.current = hasSubGroups ? 3 : 3;
+                    setStep(4);
+                  }}
+                  onTimeSelect={(time) => {
+                    setSelectedTime(time);
+                    setIsGoingBack(false);
+                    previousStepRef.current = hasSubGroups ? 4 : 3;
+                    setStep(5);
+                  }}
+                  hasSubGroups={hasSubGroups}
+                  onCampusSearchChange={setCampusSearchQuery}
+                  onResetRegistration={resetRegistrationFlow}
+                />
               </div>
-
-              <p className='text-black font-semibold text-sm mb-4'>
-                Step {getDisplayStep(step)} of {totalSteps}
-              </p>
             </div>
-
-            {/* Selected Bar - shows previous selections */}
-            {(selectedCampus ||
-              selectedSubGroupType ||
-              selectedDate ||
-              selectedTime) && (
-              <div className='flex gap-4 items-center justify-center flex-wrap mb-4'>
-                {selectedCampus && (
-                  <SelectedBar
-                    icon='map'
-                    text={selectedCampus}
-                    onClick={() => navigateToStep(1)}
-                  />
-                )}
-                {selectedSubGroupType && hasSubGroups && (
-                  <SelectedBar
-                    icon='group'
-                    text={selectedSubGroupType}
-                    onClick={() => navigateToStep(2)}
-                  />
-                )}
-                {selectedDate && (
-                  <SelectedBar
-                    icon='calendarAlt'
-                    text={formatDateDisplay(selectedDate)}
-                    onClick={() => navigateToStep(hasSubGroups ? 3 : 2)}
-                  />
-                )}
-                {selectedTime && (
-                  <SelectedBar
-                    icon='timeFive'
-                    text={`${selectedTime} ET`}
-                    onClick={() => navigateToStep(hasSubGroups ? 4 : 3)}
-                  />
-                )}
-              </div>
-            )}
-
-            {/* Step Content */}
-            <StepContent
-              step={step}
-              selectedCampus={selectedCampus}
-              selectedSubGroupType={selectedSubGroupType}
-              selectedDate={selectedDate}
-              selectedTime={selectedTime}
-              campusSearchQuery={campusSearchQuery}
-              isGoingBack={isGoingBack}
-              groupType={extractedGroupType}
-              onCampusSelect={(campus) => {
-                setSelectedCampus(campus);
-                setIsGoingBack(false);
-                previousStepRef.current = 1;
-                setStep(hasSubGroups ? 2 : 3);
-              }}
-              onSubGroupTypeSelect={(subGroupType) => {
-                setSelectedSubGroupType(subGroupType);
-                setIsGoingBack(false);
-                previousStepRef.current = 2;
-                setStep(3);
-              }}
-              onDateSelect={(date) => {
-                setSelectedDate(date);
-                setIsGoingBack(false);
-                previousStepRef.current = hasSubGroups ? 3 : 3;
-                setStep(4);
-              }}
-              onTimeSelect={(time) => {
-                setSelectedTime(time);
-                setIsGoingBack(false);
-                previousStepRef.current = hasSubGroups ? 4 : 3;
-                setStep(5);
-              }}
-              hasSubGroups={hasSubGroups}
-              onCampusSearchChange={setCampusSearchQuery}
-              onResetRegistration={resetRegistrationFlow}
-            />
-          </div>
-        </div>
-      </section>
-    </InstantSearch>
+          </section>
+        )}
+      </InstantSearch>
+    </>
   );
 };
 
@@ -987,6 +1002,55 @@ const FormStep = ({
     </div>
   );
 };
+
+// Fires onReady once when Algolia returns its first batch of hits
+const HitsDetector = ({ onReady }: { onReady: () => void }) => {
+  const { items } = useHits<EventFinderHit>();
+  const calledRef = useRef(false);
+
+  useEffect(() => {
+    if (items.length > 0 && !calledRef.current) {
+      calledRef.current = true;
+      onReady();
+    }
+  }, [items.length, onReady]);
+
+  return null;
+};
+
+const RegistrationSkeleton = ({ totalSteps }: { totalSteps: number }) => (
+  <section className='flex items-center w-full py-8 md:py-16 content-padding bg-gray'>
+    <div className='w-full max-w-3xl flex flex-col gap-13 mx-auto'>
+      <div className='flex flex-col gap-4'>
+        <div className='h-9 rounded animate-pulse bg-neutral-lighter w-64 mx-auto' />
+        <div className='h-5 rounded animate-pulse bg-neutral-lighter w-80 mx-auto' />
+      </div>
+      <div className='flex flex-col gap-3'>
+        <div className='flex flex-col gap-2 items-center'>
+          <div className='h-7 rounded animate-pulse bg-neutral-lighter w-48' />
+          <div className='flex gap-2 items-center'>
+            {Array.from({ length: totalSteps }, (_, i) => (
+              <div
+                key={i}
+                className='size-[10px] rounded-full bg-neutral-lighter animate-pulse'
+              />
+            ))}
+          </div>
+          <div className='h-4 rounded animate-pulse bg-neutral-lighter w-24 mb-4' />
+        </div>
+        <div className='h-10 rounded-lg animate-pulse bg-neutral-lighter max-w-[400px] mx-auto w-full mb-4' />
+        <div className='flex flex-wrap justify-center gap-4'>
+          {Array.from({ length: 12 }, (_, i) => (
+            <div
+              key={i}
+              className='rounded-lg animate-pulse bg-neutral-lighter w-full md:w-[calc(33.333%-0.67rem)] md:max-w-[300px] h-[120px]'
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  </section>
+);
 
 // Helper Functions
 const formatDateDisplay = (dateString: string, dayName?: string): string => {

--- a/app/routes/events/event-single/event-single-page.tsx
+++ b/app/routes/events/event-single/event-single-page.tsx
@@ -22,7 +22,7 @@ export const EventSinglePage: React.FC = () => {
     const hash = location.hash?.slice(1);
     if (!hash || !SECTION_IDS.includes(hash as (typeof SECTION_IDS)[number]))
       return;
-    scrollToAnchor(hash);
+    scrollToAnchor(hash, { behavior: 'auto' });
   }, [location.hash]);
 
   // Check if sessionScheduleCards exist


### PR DESCRIPTION
## Summary

The click-through event registration section had no visible content while Algolia loaded, causing two problems: direct links to `/events/<slug>#register` scrolled to the wrong position (section had no height yet), and users saw a blank area for 1–2 seconds before campus cards appeared.

A skeleton placeholder was added to `ClickThroughRegistration` so the section has the correct height immediately on mount, allowing hash-based scrolling to land accurately in one scroll. The "My Groups & Classes" nav link was also updated to reflect a URL change.

## Screenshots
<img width="2211" height="1082" alt="Screenshot 2026-06-04 at 11 04 06 AM" src="https://github.com/user-attachments/assets/4f2e0766-cb08-47d8-8738-3af5730c803f" />


## Testing
- [ ] Navigated directly to `/events/journey#register` and `/events/dream-team-kickoff#register` — page scrolls to the registration section in one motion, skeleton is visible while Algolia loads, then campus cards fill in. 
_Throttle to Fast 4G for better testing._
- [ ] No new linter errors/warnings.

## Tickets
[CFDP-4009](https://christfellowshipchurch.atlassian.net/browse/CFDP-4009)

## Changes Made

### New Components Added

- `HitsDetector` — `app/routes/events/event-single/components/clickthrough-registration.component.tsx`
  Null-rendering component inside `InstantSearch` that uses `useHits` to detect when Algolia returns results and triggers the `hitsReady` state in the parent.
- `RegistrationSkeleton` — `app/routes/events/event-single/components/clickthrough-registration.component.tsx`
  Animated placeholder that mirrors the campus-selection step layout. Rendered outside `InstantSearch` so it appears immediately on mount.

### New Utilities

N/A

### New Assets

N/A

### Dependencies

N/A

### Route Implementation

N/A

### Key Features

- **Registration skeleton** — All click-through event registration pages now show an animated skeleton while Algolia data loads, eliminating the blank section flash and ensuring hash-scroll links land at the correct position without re-scrolling.
- **My Groups URL update** — `https://groups.christfellowship.church/login` updated to `https://legacy-my-groups.vercel.app/login` in both desktop (`navbar.data.tsx`) and mobile (`mobile-menu-content.tsx`) nav.

[CFDP-4009]: https://christfellowshipchurch.atlassian.net/browse/CFDP-4009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ