### PR TITLE
feat(forms): centralize form tokens and migrate all submission forms [CFDP-4010]

### DIFF
--- a/app/components/modals/auth/account-creation.component.tsx
+++ b/app/components/modals/auth/account-creation.component.tsx
@@ -82,7 +82,7 @@ const AccountCreation: React.FC<AccountCreationProps> = ({
         className='grid grid-cols-1 gap-6 md:grid-cols-2'
       >
         {/* First Name */}
-        <Form.Field name='firstName' className='flex flex-col'>
+        <Form.Field name='firstName' className='flex flex-col group'>
           <Form.Label className={formLabelStyles}>First Name*</Form.Label>
           <Form.Control asChild>
             <input type='text' required className={defaultTextInputStyles} />
@@ -92,7 +92,7 @@ const AccountCreation: React.FC<AccountCreationProps> = ({
           </Form.Message>
         </Form.Field>
         {/* Last Name */}
-        <Form.Field name='lastName' className='flex flex-col'>
+        <Form.Field name='lastName' className='flex flex-col group'>
           <Form.Label className={formLabelStyles}>Last Name*</Form.Label>
           <Form.Control asChild>
             <input type='text' required className={defaultTextInputStyles} />
@@ -102,7 +102,7 @@ const AccountCreation: React.FC<AccountCreationProps> = ({
           </Form.Message>
         </Form.Field>
         {/* Birthdate */}
-        <Form.Field name='birthDate' className='flex flex-col'>
+        <Form.Field name='birthDate' className='flex flex-col group'>
           <Form.Label className={formLabelStyles}>Birth Date*</Form.Label>
           <Form.Control asChild>
             <input type='date' required className={defaultTextInputStyles} />
@@ -115,7 +115,7 @@ const AccountCreation: React.FC<AccountCreationProps> = ({
         {/* Email or Phone */}
         <Form.Field
           name={identityType === 'email' ? 'phone' : 'email'}
-          className='flex flex-col'
+          className='flex flex-col group'
         >
           <Form.Label className={formLabelStyles}>
             {identityType === 'email' ? 'Phone' : 'Email'}
@@ -128,7 +128,7 @@ const AccountCreation: React.FC<AccountCreationProps> = ({
           </Form.Message>
         </Form.Field>
         {/* Gender */}
-        <Form.Field name='gender' className='flex flex-col'>
+        <Form.Field name='gender' className='flex flex-col group'>
           <Form.Label className={formLabelStyles}>Gender</Form.Label>
           <div className='flex gap-4 pt-3'>
             <RadioButtons

--- a/app/components/modals/auth/account-creation.component.tsx
+++ b/app/components/modals/auth/account-creation.component.tsx
@@ -1,7 +1,10 @@
 import * as Form from '@radix-ui/react-form';
 import React, { useState } from 'react';
 import { NewUser } from './login-flow.component';
-import { defaultTextInputStyles } from '~/primitives/inputs/text-field/text-field.primitive';
+import {
+  defaultTextInputStyles,
+  formLabelStyles,
+} from '~/primitives/inputs/form-control.styles';
 import RadioButtons from '~/primitives/inputs/radio-buttons';
 import { Button } from '~/primitives/button/button.primitive';
 
@@ -80,7 +83,7 @@ const AccountCreation: React.FC<AccountCreationProps> = ({
       >
         {/* First Name */}
         <Form.Field name='firstName' className='flex flex-col'>
-          <Form.Label>First Name*</Form.Label>
+          <Form.Label className={formLabelStyles}>First Name*</Form.Label>
           <Form.Control asChild>
             <input type='text' required className={defaultTextInputStyles} />
           </Form.Control>
@@ -90,7 +93,7 @@ const AccountCreation: React.FC<AccountCreationProps> = ({
         </Form.Field>
         {/* Last Name */}
         <Form.Field name='lastName' className='flex flex-col'>
-          <Form.Label>Last Name*</Form.Label>
+          <Form.Label className={formLabelStyles}>Last Name*</Form.Label>
           <Form.Control asChild>
             <input type='text' required className={defaultTextInputStyles} />
           </Form.Control>
@@ -100,7 +103,7 @@ const AccountCreation: React.FC<AccountCreationProps> = ({
         </Form.Field>
         {/* Birthdate */}
         <Form.Field name='birthDate' className='flex flex-col'>
-          <Form.Label>Birth Date*</Form.Label>
+          <Form.Label className={formLabelStyles}>Birth Date*</Form.Label>
           <Form.Control asChild>
             <input type='date' required className={defaultTextInputStyles} />
           </Form.Control>
@@ -114,7 +117,7 @@ const AccountCreation: React.FC<AccountCreationProps> = ({
           name={identityType === 'email' ? 'phone' : 'email'}
           className='flex flex-col'
         >
-          <Form.Label>
+          <Form.Label className={formLabelStyles}>
             {identityType === 'email' ? 'Phone' : 'Email'}
           </Form.Label>
           <Form.Control asChild>
@@ -126,7 +129,7 @@ const AccountCreation: React.FC<AccountCreationProps> = ({
         </Form.Field>
         {/* Gender */}
         <Form.Field name='gender' className='flex flex-col'>
-          <Form.Label>Gender</Form.Label>
+          <Form.Label className={formLabelStyles}>Gender</Form.Label>
           <div className='flex gap-4 pt-3'>
             <RadioButtons
               options={[

--- a/app/components/modals/auth/create-password.component.tsx
+++ b/app/components/modals/auth/create-password.component.tsx
@@ -55,7 +55,7 @@ const CreatePassword: React.FC<CreatePasswordProps> = ({ onSubmit }) => {
         onSubmit={handleSubmit}
         className='flex flex-col p-4 text-left'
       >
-        <Form.Field name='password' className='flex flex-col'>
+        <Form.Field name='password' className='flex flex-col group'>
           <Form.Label className={formLabelStyles}>Password*</Form.Label>
           <div className='relative'>
             <Form.Control asChild>
@@ -82,7 +82,7 @@ const CreatePassword: React.FC<CreatePasswordProps> = ({ onSubmit }) => {
             Password must be at least 8 characters long
           </Form.Message>
         </Form.Field>
-        <Form.Field name='confirmPassword' className='mt-4 flex flex-col'>
+        <Form.Field name='confirmPassword' className='mt-4 flex flex-col group'>
           <Form.Label className={formLabelStyles}>Confirm Password*</Form.Label>
           <Form.Control asChild>
             <input

--- a/app/components/modals/auth/create-password.component.tsx
+++ b/app/components/modals/auth/create-password.component.tsx
@@ -2,7 +2,7 @@ import * as Form from '@radix-ui/react-form';
 import React, { useState } from 'react';
 import { Button } from '~/primitives/button/button.primitive';
 import Icon from '~/primitives/icon';
-import { defaultTextInputStyles } from '~/primitives/inputs/text-field/text-field.primitive';
+import { defaultTextInputStyles } from '~/primitives/inputs/form-control.styles';
 
 interface CreatePasswordProps {
   onSubmit: (password: string) => void;

--- a/app/components/modals/auth/create-password.component.tsx
+++ b/app/components/modals/auth/create-password.component.tsx
@@ -2,7 +2,10 @@ import * as Form from '@radix-ui/react-form';
 import React, { useState } from 'react';
 import { Button } from '~/primitives/button/button.primitive';
 import Icon from '~/primitives/icon';
-import { defaultTextInputStyles } from '~/primitives/inputs/form-control.styles';
+import {
+  defaultTextInputStyles,
+  formLabelStyles,
+} from '~/primitives/inputs/form-control.styles';
 
 interface CreatePasswordProps {
   onSubmit: (password: string) => void;
@@ -53,7 +56,7 @@ const CreatePassword: React.FC<CreatePasswordProps> = ({ onSubmit }) => {
         className='flex flex-col p-4 text-left'
       >
         <Form.Field name='password' className='flex flex-col'>
-          <Form.Label className='text-text_primary'>Password*</Form.Label>
+          <Form.Label className={formLabelStyles}>Password*</Form.Label>
           <div className='relative'>
             <Form.Control asChild>
               <input
@@ -80,7 +83,7 @@ const CreatePassword: React.FC<CreatePasswordProps> = ({ onSubmit }) => {
           </Form.Message>
         </Form.Field>
         <Form.Field name='confirmPassword' className='mt-4 flex flex-col'>
-          <Form.Label className='text-text_primary'>
+          <Form.Label className={formLabelStyles}>
             Confirm Password*
           </Form.Label>
           <Form.Control asChild>

--- a/app/components/modals/auth/create-password.component.tsx
+++ b/app/components/modals/auth/create-password.component.tsx
@@ -83,9 +83,7 @@ const CreatePassword: React.FC<CreatePasswordProps> = ({ onSubmit }) => {
           </Form.Message>
         </Form.Field>
         <Form.Field name='confirmPassword' className='mt-4 flex flex-col'>
-          <Form.Label className={formLabelStyles}>
-            Confirm Password*
-          </Form.Label>
+          <Form.Label className={formLabelStyles}>Confirm Password*</Form.Label>
           <Form.Control asChild>
             <input
               type='password'

--- a/app/components/modals/auth/initial-signup.component.tsx
+++ b/app/components/modals/auth/initial-signup.component.tsx
@@ -67,7 +67,7 @@ const InitialSignUp: React.FC<InitialSignUpProps> = ({ onSubmit }) => {
         Enter your phone number <br /> or email address to get started.
       </p>
       <Form.Root onSubmit={handleSubmit} className='flex flex-col text-left'>
-        <Form.Field name='identity' className='flex flex-col'>
+        <Form.Field name='identity' className='flex flex-col group'>
           <Form.Label className={formLabelStyles}>
             Mobile Number or Email*
           </Form.Label>
@@ -88,7 +88,7 @@ const InitialSignUp: React.FC<InitialSignUpProps> = ({ onSubmit }) => {
         ) : (
           <p className='text-sm text-alert'>{error}</p>
         )}
-        <Form.Field className='mt-4' name='agreement'>
+        <Form.Field className='mt-4 group' name='agreement'>
           <div className='flex items-center gap-3'>
             <Form.Control asChild>
               <input id='c1' type='checkbox' className='text-ocean' required />

--- a/app/components/modals/auth/initial-signup.component.tsx
+++ b/app/components/modals/auth/initial-signup.component.tsx
@@ -68,7 +68,9 @@ const InitialSignUp: React.FC<InitialSignUpProps> = ({ onSubmit }) => {
       </p>
       <Form.Root onSubmit={handleSubmit} className='flex flex-col text-left'>
         <Form.Field name='identity' className='flex flex-col'>
-          <Form.Label className={formLabelStyles}>Mobile Number or Email*</Form.Label>
+          <Form.Label className={formLabelStyles}>
+            Mobile Number or Email*
+          </Form.Label>
           <Form.Control asChild>
             <TextFieldInput
               value={identity}

--- a/app/components/modals/auth/initial-signup.component.tsx
+++ b/app/components/modals/auth/initial-signup.component.tsx
@@ -3,6 +3,7 @@ import * as Form from '@radix-ui/react-form';
 import TextFieldInput from '~/primitives/inputs/text-field/text-field.primitive';
 import { Button } from '~/primitives/button/button.primitive';
 import { useAuth } from '~/providers/auth-provider';
+import { formLabelStyles } from '~/primitives/inputs/form-control.styles';
 
 interface InitialSignUpProps {
   onSubmit: (identity: string) => Promise<void>;
@@ -67,7 +68,7 @@ const InitialSignUp: React.FC<InitialSignUpProps> = ({ onSubmit }) => {
       </p>
       <Form.Root onSubmit={handleSubmit} className='flex flex-col text-left'>
         <Form.Field name='identity' className='flex flex-col'>
-          <Form.Label>Mobile Number or Email*</Form.Label>
+          <Form.Label className={formLabelStyles}>Mobile Number or Email*</Form.Label>
           <Form.Control asChild>
             <TextFieldInput
               value={identity}

--- a/app/components/modals/auth/login.component.tsx
+++ b/app/components/modals/auth/login.component.tsx
@@ -67,7 +67,7 @@ const Login: React.FC<LoginProps> = ({ onSubmit }) => {
     <div className='text-center'>
       <h2 className='mb-6 text-5xl font-bold'>Log In</h2>
       <Form.Root onSubmit={handleSubmit} className='flex flex-col text-left'>
-        <Form.Field name='identity' className='flex flex-col'>
+        <Form.Field name='identity' className='flex flex-col group'>
           <Form.Label className={formLabelStyles}>
             Mobile Number or Email*
           </Form.Label>

--- a/app/components/modals/auth/login.component.tsx
+++ b/app/components/modals/auth/login.component.tsx
@@ -68,7 +68,9 @@ const Login: React.FC<LoginProps> = ({ onSubmit }) => {
       <h2 className='mb-6 text-5xl font-bold'>Log In</h2>
       <Form.Root onSubmit={handleSubmit} className='flex flex-col text-left'>
         <Form.Field name='identity' className='flex flex-col'>
-          <Form.Label className={formLabelStyles}>Mobile Number or Email*</Form.Label>
+          <Form.Label className={formLabelStyles}>
+            Mobile Number or Email*
+          </Form.Label>
           <Form.Control asChild>
             <TextFieldInput
               value={identity}

--- a/app/components/modals/auth/login.component.tsx
+++ b/app/components/modals/auth/login.component.tsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import { Button } from '~/primitives/button/button.primitive';
 import TextFieldInput from '~/primitives/inputs/text-field';
 import { useAuth } from '~/providers/auth-provider';
+import { formLabelStyles } from '~/primitives/inputs/form-control.styles';
 
 interface LoginProps {
   onSubmit: (identity: string) => Promise<void>;
@@ -67,7 +68,7 @@ const Login: React.FC<LoginProps> = ({ onSubmit }) => {
       <h2 className='mb-6 text-5xl font-bold'>Log In</h2>
       <Form.Root onSubmit={handleSubmit} className='flex flex-col text-left'>
         <Form.Field name='identity' className='flex flex-col'>
-          <Form.Label>Mobile Number or Email*</Form.Label>
+          <Form.Label className={formLabelStyles}>Mobile Number or Email*</Form.Label>
           <Form.Control asChild>
             <TextFieldInput
               value={identity}

--- a/app/components/modals/auth/password-screen.component.tsx
+++ b/app/components/modals/auth/password-screen.component.tsx
@@ -57,7 +57,7 @@ const PasswordScreen: React.FC<PasswordScreenProps> = ({ onSubmit }) => {
         onSubmit={handleSubmit}
         className='flex flex-col gap-4 p-4 text-left'
       >
-        <Form.Field name='password' className='flex flex-col'>
+        <Form.Field name='password' className='flex flex-col group'>
           <Form.Label className={formLabelStyles}>Password*</Form.Label>
           <div className='relative'>
             <Form.Control asChild>

--- a/app/components/modals/auth/password-screen.component.tsx
+++ b/app/components/modals/auth/password-screen.component.tsx
@@ -2,7 +2,7 @@ import * as Form from '@radix-ui/react-form';
 import React, { useEffect, useState } from 'react';
 import { Button } from '~/primitives/button/button.primitive';
 import Icon from '~/primitives/icon';
-import { defaultTextInputStyles } from '~/primitives/inputs/text-field/text-field.primitive';
+import { defaultTextInputStyles } from '~/primitives/inputs/form-control.styles';
 
 interface PasswordScreenProps {
   onSubmit: (password: string) => Promise<void>;

--- a/app/components/modals/auth/password-screen.component.tsx
+++ b/app/components/modals/auth/password-screen.component.tsx
@@ -2,7 +2,10 @@ import * as Form from '@radix-ui/react-form';
 import React, { useEffect, useState } from 'react';
 import { Button } from '~/primitives/button/button.primitive';
 import Icon from '~/primitives/icon';
-import { defaultTextInputStyles } from '~/primitives/inputs/form-control.styles';
+import {
+  defaultTextInputStyles,
+  formLabelStyles,
+} from '~/primitives/inputs/form-control.styles';
 
 interface PasswordScreenProps {
   onSubmit: (password: string) => Promise<void>;
@@ -55,7 +58,7 @@ const PasswordScreen: React.FC<PasswordScreenProps> = ({ onSubmit }) => {
         className='flex flex-col gap-4 p-4 text-left'
       >
         <Form.Field name='password' className='flex flex-col'>
-          <Form.Label className='text-gray-700'>Password*</Form.Label>
+          <Form.Label className={formLabelStyles}>Password*</Form.Label>
           <div className='relative'>
             <Form.Control asChild>
               <input

--- a/app/components/modals/auth/pin-screen.component.tsx
+++ b/app/components/modals/auth/pin-screen.component.tsx
@@ -1,7 +1,7 @@
 import * as Form from '@radix-ui/react-form';
 import React, { useEffect, useRef, useState } from 'react';
 import { Button } from '~/primitives/button/button.primitive';
-import { defaultTextInputStyles } from '~/primitives/inputs/text-field/text-field.primitive';
+import { defaultTextInputStyles } from '~/primitives/inputs/form-control.styles';
 
 interface PinScreenProps {
   onSubmit: (pin: string) => Promise<void>;

--- a/app/components/modals/connect-card/connect-form.component.tsx
+++ b/app/components/modals/connect-card/connect-form.component.tsx
@@ -24,7 +24,7 @@ export const renderInputField = (
   requiredMessage: string,
   defaultValue?: string,
 ) => (
-  <Form.Field name={name} className='flex flex-col mb-4'>
+  <Form.Field name={name} className='flex flex-col mb-4 group'>
     <Form.Label className={formLabelStyles}>{label}</Form.Label>
     <Form.Control asChild>
       <input
@@ -52,7 +52,7 @@ export const renderCheckboxField = (
   <Form.Field
     key={index}
     name={`allThatApplies-${index}`}
-    className='flex gap-2 md:items-center'
+    className='flex gap-2 md:items-center group'
   >
     <Form.Control asChild>
       <input
@@ -165,7 +165,7 @@ const ConnectCardForm: React.FC<ConnectCardProps> = ({ onSuccess }) => {
           'Please enter a valid email',
         )}
 
-        <Form.Field name='campus' className='flex flex-col'>
+        <Form.Field name='campus' className='flex flex-col group'>
           <Form.Label className={formLabelStyles}>Campus</Form.Label>
           <Form.Control asChild>
             {campuses && (
@@ -197,7 +197,7 @@ const ConnectCardForm: React.FC<ConnectCardProps> = ({ onSuccess }) => {
           </Form.Message>
         </Form.Field>
 
-        <Form.Field name='decision' className='flex gap-2 md:items-center mt-3'>
+        <Form.Field name='decision' className='flex gap-2 md:items-center mt-3 group'>
           <Form.Control asChild>
             <input
               className={cn('mb-1', nativeCheckboxStyles)}
@@ -218,7 +218,7 @@ const ConnectCardForm: React.FC<ConnectCardProps> = ({ onSuccess }) => {
         {checkboxes.map(renderCheckboxField)}
 
         {otherCheckbox && (
-          <Form.Field name='other' className='flex gap-2 md:items-center'>
+          <Form.Field name='other' className='flex gap-2 md:items-center group'>
             <Form.Control asChild>
               <input
                 className={cn('mb-1', nativeCheckboxStyles)}
@@ -238,7 +238,7 @@ const ConnectCardForm: React.FC<ConnectCardProps> = ({ onSuccess }) => {
         {isOther && (
           <>
             <div />
-            <Form.Field name='otherContent' className='flex flex-col'>
+            <Form.Field name='otherContent' className='flex flex-col group'>
               <Form.Control asChild>
                 <input
                   type='text'

--- a/app/components/modals/connect-card/connect-form.component.tsx
+++ b/app/components/modals/connect-card/connect-form.component.tsx
@@ -1,7 +1,14 @@
 import * as Form from '@radix-ui/react-form';
 import { useEffect, useState } from 'react';
 import { Button } from '~/primitives/button/button.primitive';
-import { defaultTextInputStyles } from '~/primitives/inputs/text-field/text-field.primitive';
+import {
+  formControlBaseStyles,
+  formControlFocusStyles,
+  formErrorMessageStyles,
+  formLabelStyles,
+  nativeCheckboxStyles,
+} from '~/primitives/inputs/form-control.styles';
+import { cn } from '~/lib/utils';
 import { useFetcher } from 'react-router-dom';
 import { ConnectCardLoaderReturnType } from '~/routes/connect-card/types';
 import { pushFormEvent } from '~/lib/gtm';
@@ -18,16 +25,16 @@ export const renderInputField = (
   defaultValue?: string,
 ) => (
   <Form.Field name={name} className='flex flex-col mb-4'>
-    <Form.Label className='font-bold text-sm mb-2'>{label}</Form.Label>
+    <Form.Label className={formLabelStyles}>{label}</Form.Label>
     <Form.Control asChild>
       <input
         type={type}
         required
         defaultValue={defaultValue}
-        className={defaultTextInputStyles}
+        className={cn(formControlBaseStyles, formControlFocusStyles)}
       />
     </Form.Control>
-    <Form.Message className='text-sm text-alert' match='valueMissing'>
+    <Form.Message className={formErrorMessageStyles} match='valueMissing'>
       {requiredMessage}
     </Form.Message>
   </Form.Field>
@@ -48,9 +55,14 @@ export const renderCheckboxField = (
     className='flex gap-2 md:items-center'
   >
     <Form.Control asChild>
-      <input type='checkbox' id={checkbox.guid} value={checkbox.guid} />
+      <input
+        type='checkbox'
+        id={checkbox.guid}
+        value={checkbox.guid}
+        className={nativeCheckboxStyles}
+      />
     </Form.Control>
-    <Form.Label className='font-bold leading-4'>{checkbox.value}</Form.Label>
+    <Form.Label className={formLabelStyles}>{checkbox.value}</Form.Label>
   </Form.Field>
 );
 
@@ -154,11 +166,15 @@ const ConnectCardForm: React.FC<ConnectCardProps> = ({ onSuccess }) => {
         )}
 
         <Form.Field name='campus' className='flex flex-col'>
-          <Form.Label className='font-bold text-sm mb-2'>Campus</Form.Label>
+          <Form.Label className={formLabelStyles}>Campus</Form.Label>
           <Form.Control asChild>
             {campuses && (
               <select
-                className={`appearance-none ${defaultTextInputStyles}`}
+                className={cn(
+                  'appearance-none',
+                  formControlBaseStyles,
+                  formControlFocusStyles,
+                )}
                 required
                 style={{
                   backgroundImage: `url('/assets/icons/chevron-down.svg')`,
@@ -176,7 +192,7 @@ const ConnectCardForm: React.FC<ConnectCardProps> = ({ onSuccess }) => {
               </select>
             )}
           </Form.Control>
-          <Form.Message className='text-sm text-alert' match='valueMissing'>
+          <Form.Message className={formErrorMessageStyles} match='valueMissing'>
             Please select a campus
           </Form.Message>
         </Form.Field>
@@ -184,7 +200,7 @@ const ConnectCardForm: React.FC<ConnectCardProps> = ({ onSuccess }) => {
         <Form.Field name='decision' className='flex gap-2 md:items-center mt-3'>
           <Form.Control asChild>
             <input
-              className='mb-1'
+              className={cn('mb-1', nativeCheckboxStyles)}
               type='checkbox'
               id='decision'
               name='decision'
@@ -205,7 +221,7 @@ const ConnectCardForm: React.FC<ConnectCardProps> = ({ onSuccess }) => {
           <Form.Field name='other' className='flex gap-2 md:items-center'>
             <Form.Control asChild>
               <input
-                className='mb-1'
+                className={cn('mb-1', nativeCheckboxStyles)}
                 type='checkbox'
                 id={otherCheckbox.guid}
                 name={otherCheckbox.guid}
@@ -213,7 +229,7 @@ const ConnectCardForm: React.FC<ConnectCardProps> = ({ onSuccess }) => {
                 onChange={(_e) => setIsOther(!isOther)}
               />
             </Form.Control>
-            <Form.Label className='font-bold leading-4'>
+            <Form.Label className={formLabelStyles}>
               {otherCheckbox.value}
             </Form.Label>
           </Form.Field>
@@ -224,7 +240,10 @@ const ConnectCardForm: React.FC<ConnectCardProps> = ({ onSuccess }) => {
             <div />
             <Form.Field name='otherContent' className='flex flex-col'>
               <Form.Control asChild>
-                <input type='text' className={defaultTextInputStyles} />
+                <input
+                  type='text'
+                  className={cn(formControlBaseStyles, formControlFocusStyles)}
+                />
               </Form.Control>
             </Form.Field>
           </>

--- a/app/components/modals/contact-us/contact-form.component.tsx
+++ b/app/components/modals/contact-us/contact-form.component.tsx
@@ -1,7 +1,14 @@
 import * as Form from '@radix-ui/react-form';
 import { useEffect, useState } from 'react';
 import { Button } from '~/primitives/button/button.primitive';
-import { defaultTextInputStyles } from '~/primitives/inputs/text-field/text-field.primitive';
+import {
+  formControlBaseStyles,
+  formControlFocusStyles,
+  formErrorMessageStyles,
+  formLabelStyles,
+  nativeCheckboxStyles,
+} from '~/primitives/inputs/form-control.styles';
+import { cn } from '~/lib/utils';
 import { useFetcher } from 'react-router-dom';
 import { ContactUsLoaderReturnType } from '~/routes/contact-us/types';
 import { pushFormEvent } from '~/lib/gtm';
@@ -76,56 +83,76 @@ const ContactUsForm: React.FC<ContactUsFormProps> = ({ onSuccess }) => {
         className='flex flex-col md:grid text-left grid-cols-1 gap-y-3 gap-x-6 md:grid-cols-2 px-0 md:px-6'
       >
         <Form.Field name='firstName' className='flex flex-col mb-4'>
-          <Form.Label className='font-bold text-sm mb-2'>First Name</Form.Label>
+          <Form.Label className={formLabelStyles}>First Name</Form.Label>
           <Form.Control asChild>
-            <input type='text' required className={defaultTextInputStyles} />
+            <input
+              type='text'
+              required
+              className={cn(formControlBaseStyles, formControlFocusStyles)}
+            />
           </Form.Control>
-          <Form.Message className='text-sm text-alert' match='valueMissing'>
+          <Form.Message className={formErrorMessageStyles} match='valueMissing'>
             Please enter your first name
           </Form.Message>
         </Form.Field>
 
         <Form.Field name='lastName' className='flex flex-col mb-4'>
-          <Form.Label className='font-bold text-sm mb-2'>Last Name</Form.Label>
+          <Form.Label className={formLabelStyles}>Last Name</Form.Label>
           <Form.Control asChild>
-            <input type='text' required className={defaultTextInputStyles} />
+            <input
+              type='text'
+              required
+              className={cn(formControlBaseStyles, formControlFocusStyles)}
+            />
           </Form.Control>
-          <Form.Message className='text-sm text-alert' match='valueMissing'>
+          <Form.Message className={formErrorMessageStyles} match='valueMissing'>
             Please enter your last name
           </Form.Message>
         </Form.Field>
 
         <Form.Field name='phone' className='flex flex-col mb-4'>
-          <Form.Label className='font-bold text-sm mb-2'>Cell Phone</Form.Label>
+          <Form.Label className={formLabelStyles}>Cell Phone</Form.Label>
           <Form.Control asChild>
-            <input type='tel' required className={defaultTextInputStyles} />
+            <input
+              type='tel'
+              required
+              className={cn(formControlBaseStyles, formControlFocusStyles)}
+            />
           </Form.Control>
-          <Form.Message className='text-sm text-alert' match='valueMissing'>
+          <Form.Message className={formErrorMessageStyles} match='valueMissing'>
             Please enter your phone number
           </Form.Message>
         </Form.Field>
 
         <Form.Field name='email' className='flex flex-col mb-4'>
-          <Form.Label className='font-bold text-sm mb-2'>
+          <Form.Label className={formLabelStyles}>
             Email Address
           </Form.Label>
           <Form.Control asChild>
-            <input type='email' required className={defaultTextInputStyles} />
+            <input
+              type='email'
+              required
+              className={cn(formControlBaseStyles, formControlFocusStyles)}
+            />
           </Form.Control>
-          <Form.Message className='text-sm text-alert' match='valueMissing'>
+          <Form.Message className={formErrorMessageStyles} match='valueMissing'>
             Please enter your email address
           </Form.Message>
-          <Form.Message className='text-sm text-alert' match='typeMismatch'>
+          <Form.Message className={formErrorMessageStyles} match='typeMismatch'>
             Please enter a valid email address
           </Form.Message>
         </Form.Field>
 
         <Form.Field name='campus' className='flex flex-col mb-4 md:col-span-2'>
-          <Form.Label className='font-bold text-sm mb-2'>Location</Form.Label>
+          <Form.Label className={formLabelStyles}>Location</Form.Label>
           <Form.Control asChild>
             {campuses && (
               <select
-                className={`appearance-none ${defaultTextInputStyles}`}
+                className={cn(
+                  'appearance-none',
+                  formControlBaseStyles,
+                  formControlFocusStyles,
+                )}
                 required
                 style={{
                   backgroundImage: `url('/assets/icons/chevron-down.svg')`,
@@ -143,17 +170,25 @@ const ContactUsForm: React.FC<ContactUsFormProps> = ({ onSuccess }) => {
               </select>
             )}
           </Form.Control>
-          <Form.Message className='text-sm text-alert' match='valueMissing'>
+          <Form.Message className={formErrorMessageStyles} match='valueMissing'>
             Please select a campus
           </Form.Message>
         </Form.Field>
 
         <Form.Field name='message' className='flex flex-col mb-4 md:col-span-2'>
-          <Form.Label className='font-bold text-sm mb-2'>Message</Form.Label>
+          <Form.Label className={formLabelStyles}>Message</Form.Label>
           <Form.Control asChild>
-            <textarea required rows={5} className={defaultTextInputStyles} />
+            <textarea
+              required
+              rows={5}
+              className={cn(
+                formControlBaseStyles,
+                formControlFocusStyles,
+                'min-h-[120px] h-auto',
+              )}
+            />
           </Form.Control>
-          <Form.Message className='text-sm text-alert' match='valueMissing'>
+          <Form.Message className={formErrorMessageStyles} match='valueMissing'>
             Please enter a message
           </Form.Message>
         </Form.Field>
@@ -164,7 +199,11 @@ const ContactUsForm: React.FC<ContactUsFormProps> = ({ onSuccess }) => {
         >
           <div className='flex gap-2 items-start'>
             <Form.Control asChild>
-              <input type='checkbox' required className='mt-1 shrink-0' />
+              <input
+                type='checkbox'
+                required
+                className={cn('mt-1 shrink-0', nativeCheckboxStyles)}
+              />
             </Form.Control>
             <Form.Label className='text-sm text-text-secondary leading-5'>
               By submitting, you agree to our{' '}
@@ -202,7 +241,7 @@ const ContactUsForm: React.FC<ContactUsFormProps> = ({ onSuccess }) => {
             </Form.Label>
           </div>
           <Form.Message
-            className='text-sm text-alert pl-5'
+            className={cn(formErrorMessageStyles, 'pl-5')}
             match='valueMissing'
           >
             You must agree to continue

--- a/app/components/modals/contact-us/contact-form.component.tsx
+++ b/app/components/modals/contact-us/contact-form.component.tsx
@@ -82,7 +82,7 @@ const ContactUsForm: React.FC<ContactUsFormProps> = ({ onSuccess }) => {
         onSubmit={handleSubmit}
         className='flex flex-col md:grid text-left grid-cols-1 gap-y-3 gap-x-6 md:grid-cols-2 px-0 md:px-6'
       >
-        <Form.Field name='firstName' className='flex flex-col mb-4'>
+        <Form.Field name='firstName' className='flex flex-col mb-4 group'>
           <Form.Label className={formLabelStyles}>First Name</Form.Label>
           <Form.Control asChild>
             <input
@@ -96,7 +96,7 @@ const ContactUsForm: React.FC<ContactUsFormProps> = ({ onSuccess }) => {
           </Form.Message>
         </Form.Field>
 
-        <Form.Field name='lastName' className='flex flex-col mb-4'>
+        <Form.Field name='lastName' className='flex flex-col mb-4 group'>
           <Form.Label className={formLabelStyles}>Last Name</Form.Label>
           <Form.Control asChild>
             <input
@@ -110,7 +110,7 @@ const ContactUsForm: React.FC<ContactUsFormProps> = ({ onSuccess }) => {
           </Form.Message>
         </Form.Field>
 
-        <Form.Field name='phone' className='flex flex-col mb-4'>
+        <Form.Field name='phone' className='flex flex-col mb-4 group'>
           <Form.Label className={formLabelStyles}>Cell Phone</Form.Label>
           <Form.Control asChild>
             <input
@@ -124,7 +124,7 @@ const ContactUsForm: React.FC<ContactUsFormProps> = ({ onSuccess }) => {
           </Form.Message>
         </Form.Field>
 
-        <Form.Field name='email' className='flex flex-col mb-4'>
+        <Form.Field name='email' className='flex flex-col mb-4 group'>
           <Form.Label className={formLabelStyles}>Email Address</Form.Label>
           <Form.Control asChild>
             <input
@@ -141,7 +141,7 @@ const ContactUsForm: React.FC<ContactUsFormProps> = ({ onSuccess }) => {
           </Form.Message>
         </Form.Field>
 
-        <Form.Field name='campus' className='flex flex-col mb-4 md:col-span-2'>
+        <Form.Field name='campus' className='flex flex-col mb-4 md:col-span-2 group'>
           <Form.Label className={formLabelStyles}>Location</Form.Label>
           <Form.Control asChild>
             {campuses && (
@@ -173,7 +173,7 @@ const ContactUsForm: React.FC<ContactUsFormProps> = ({ onSuccess }) => {
           </Form.Message>
         </Form.Field>
 
-        <Form.Field name='message' className='flex flex-col mb-4 md:col-span-2'>
+        <Form.Field name='message' className='flex flex-col mb-4 md:col-span-2 group'>
           <Form.Label className={formLabelStyles}>Message</Form.Label>
           <Form.Control asChild>
             <textarea
@@ -193,7 +193,7 @@ const ContactUsForm: React.FC<ContactUsFormProps> = ({ onSuccess }) => {
 
         <Form.Field
           name='smsConsent'
-          className='flex flex-col md:col-span-2 mt-2'
+          className='flex flex-col md:col-span-2 mt-2 group'
         >
           <div className='flex gap-2 items-start'>
             <Form.Control asChild>

--- a/app/components/modals/contact-us/contact-form.component.tsx
+++ b/app/components/modals/contact-us/contact-form.component.tsx
@@ -125,9 +125,7 @@ const ContactUsForm: React.FC<ContactUsFormProps> = ({ onSuccess }) => {
         </Form.Field>
 
         <Form.Field name='email' className='flex flex-col mb-4'>
-          <Form.Label className={formLabelStyles}>
-            Email Address
-          </Form.Label>
+          <Form.Label className={formLabelStyles}>Email Address</Form.Label>
           <Form.Control asChild>
             <input
               type='email'

--- a/app/components/modals/group-connect/group-connect-form.component.tsx
+++ b/app/components/modals/group-connect/group-connect-form.component.tsx
@@ -71,7 +71,7 @@ const GroupConnectForm: React.FC<GroupConnectFormProps> = ({
         <input type='hidden' name='groupId' value={groupId} />
 
         {/* First Name */}
-        <Form.Field name='firstName' className='flex flex-col'>
+        <Form.Field name='firstName' className='flex flex-col group'>
           <Form.Label className={formLabelStyles}>First Name*</Form.Label>
           <Form.Control asChild>
             <input
@@ -85,7 +85,7 @@ const GroupConnectForm: React.FC<GroupConnectFormProps> = ({
           </Form.Message>
         </Form.Field>
         {/* Last Name */}
-        <Form.Field name='lastName' className='flex flex-col'>
+        <Form.Field name='lastName' className='flex flex-col group'>
           <Form.Label className={formLabelStyles}>Last Name*</Form.Label>
           <Form.Control asChild>
             <input
@@ -99,7 +99,7 @@ const GroupConnectForm: React.FC<GroupConnectFormProps> = ({
           </Form.Message>
         </Form.Field>
         {/* Phone */}
-        <Form.Field name='phoneNumber' className='flex flex-col'>
+        <Form.Field name='phoneNumber' className='flex flex-col group'>
           <Form.Label className={formLabelStyles}>Phone*</Form.Label>
           <Form.Control asChild>
             <input
@@ -113,7 +113,7 @@ const GroupConnectForm: React.FC<GroupConnectFormProps> = ({
           </Form.Message>
         </Form.Field>
         {/* Email */}
-        <Form.Field name='email' className='flex flex-col'>
+        <Form.Field name='email' className='flex flex-col group'>
           <Form.Label className={formLabelStyles}>Email*</Form.Label>
           <Form.Control asChild>
             <input
@@ -129,7 +129,7 @@ const GroupConnectForm: React.FC<GroupConnectFormProps> = ({
 
         {/* Campus (optional — only shown when campus prop is provided) */}
         {campus !== undefined && (
-          <Form.Field name='campus' className='flex flex-col md:col-span-2'>
+          <Form.Field name='campus' className='flex flex-col md:col-span-2 group'>
             <Form.Label className={formLabelStyles}>Campus</Form.Label>
             <input type='hidden' name='campus' value={campus} />
             <Form.Control asChild>

--- a/app/components/modals/group-connect/group-connect-form.component.tsx
+++ b/app/components/modals/group-connect/group-connect-form.component.tsx
@@ -2,7 +2,13 @@ import * as Form from '@radix-ui/react-form';
 import { useEffect, useState } from 'react';
 import { useFetcher } from 'react-router';
 import { Button } from '~/primitives/button/button.primitive';
-import { defaultTextInputStyles } from '~/primitives/inputs/text-field/text-field.primitive';
+import {
+  formControlBaseStyles,
+  formControlFocusStyles,
+  formErrorMessageStyles,
+  formLabelStyles,
+} from '~/primitives/inputs/form-control.styles';
+import { cn } from '~/lib/utils';
 import { pushFormEvent } from '~/lib/gtm';
 
 interface GroupConnectFormProps {
@@ -66,41 +72,57 @@ const GroupConnectForm: React.FC<GroupConnectFormProps> = ({
 
         {/* First Name */}
         <Form.Field name='firstName' className='flex flex-col'>
-          <Form.Label>First Name*</Form.Label>
+          <Form.Label className={formLabelStyles}>First Name*</Form.Label>
           <Form.Control asChild>
-            <input type='text' required className={defaultTextInputStyles} />
+            <input
+              type='text'
+              required
+              className={cn(formControlBaseStyles, formControlFocusStyles)}
+            />
           </Form.Control>
-          <Form.Message className='text-alert' match='valueMissing'>
+          <Form.Message className={formErrorMessageStyles} match='valueMissing'>
             Please enter your first name
           </Form.Message>
         </Form.Field>
         {/* Last Name */}
         <Form.Field name='lastName' className='flex flex-col'>
-          <Form.Label>Last Name*</Form.Label>
+          <Form.Label className={formLabelStyles}>Last Name*</Form.Label>
           <Form.Control asChild>
-            <input type='text' required className={defaultTextInputStyles} />
+            <input
+              type='text'
+              required
+              className={cn(formControlBaseStyles, formControlFocusStyles)}
+            />
           </Form.Control>
-          <Form.Message className='text-alert' match='valueMissing'>
+          <Form.Message className={formErrorMessageStyles} match='valueMissing'>
             Please enter your last name
           </Form.Message>
         </Form.Field>
         {/* Phone */}
         <Form.Field name='phoneNumber' className='flex flex-col'>
-          <Form.Label>Phone*</Form.Label>
+          <Form.Label className={formLabelStyles}>Phone*</Form.Label>
           <Form.Control asChild>
-            <input type='text' required className={defaultTextInputStyles} />
+            <input
+              type='text'
+              required
+              className={cn(formControlBaseStyles, formControlFocusStyles)}
+            />
           </Form.Control>
-          <Form.Message className='text-alert' match='valueMissing'>
+          <Form.Message className={formErrorMessageStyles} match='valueMissing'>
             Please enter your phone number
           </Form.Message>
         </Form.Field>
         {/* Email */}
         <Form.Field name='email' className='flex flex-col'>
-          <Form.Label>Email*</Form.Label>
+          <Form.Label className={formLabelStyles}>Email*</Form.Label>
           <Form.Control asChild>
-            <input type='text' required className={defaultTextInputStyles} />
+            <input
+              type='text'
+              required
+              className={cn(formControlBaseStyles, formControlFocusStyles)}
+            />
           </Form.Control>
-          <Form.Message className='text-alert' match='valueMissing'>
+          <Form.Message className={formErrorMessageStyles} match='valueMissing'>
             Please enter your email
           </Form.Message>
         </Form.Field>
@@ -108,11 +130,15 @@ const GroupConnectForm: React.FC<GroupConnectFormProps> = ({
         {/* Campus (optional — only shown when campus prop is provided) */}
         {campus !== undefined && (
           <Form.Field name='campus' className='flex flex-col md:col-span-2'>
-            <Form.Label className='font-bold text-sm mb-2'>Campus</Form.Label>
+            <Form.Label className={formLabelStyles}>Campus</Form.Label>
             <input type='hidden' name='campus' value={campus} />
             <Form.Control asChild>
               <select
-                className={`appearance-none ${defaultTextInputStyles} text-neutral-400`}
+                className={cn(
+                  'appearance-none text-neutral-400',
+                  formControlBaseStyles,
+                  formControlFocusStyles,
+                )}
                 required
                 disabled
                 style={{

--- a/app/components/modals/journey-finder-sign-up/journey-finder-sign-up-form.component.tsx
+++ b/app/components/modals/journey-finder-sign-up/journey-finder-sign-up-form.component.tsx
@@ -206,9 +206,7 @@ const JourneyFinderSignUpForm: React.FC<JourneyFinderSignUpFormProps> = ({
           name='atCF'
           className='flex flex-col col-span-1 md:col-span-2 mt-2'
         >
-          <Form.Label className={formLabelStyles}>
-            {copy.atCF}
-          </Form.Label>
+          <Form.Label className={formLabelStyles}>{copy.atCF}</Form.Label>
           <div className='flex flex-col gap-2'>
             {copy.atCFOptions.map((option) => (
               <label key={option.value} className='flex items-center gap-2'>
@@ -234,9 +232,7 @@ const JourneyFinderSignUpForm: React.FC<JourneyFinderSignUpFormProps> = ({
           name='hopeToGet'
           className='flex flex-col col-span-1 md:col-span-2 mt-2'
         >
-          <Form.Label className={formLabelStyles}>
-            {copy.hopeToGet}
-          </Form.Label>
+          <Form.Label className={formLabelStyles}>{copy.hopeToGet}</Form.Label>
           <Form.Control asChild>
             <textarea
               rows={4}

--- a/app/components/modals/journey-finder-sign-up/journey-finder-sign-up-form.component.tsx
+++ b/app/components/modals/journey-finder-sign-up/journey-finder-sign-up-form.component.tsx
@@ -32,7 +32,7 @@ export const renderInputField = (
   defaultValue?: string,
   fieldClassName = '',
 ) => (
-  <Form.Field name={name} className={`flex flex-col mb-4 ${fieldClassName}`}>
+  <Form.Field name={name} className={`flex flex-col mb-4 group ${fieldClassName}`}>
     <Form.Label className={formLabelStyles}>{label}</Form.Label>
     <Form.Control asChild>
       <input
@@ -204,7 +204,7 @@ const JourneyFinderSignUpForm: React.FC<JourneyFinderSignUpFormProps> = ({
 
         <Form.Field
           name='atCF'
-          className='flex flex-col col-span-1 md:col-span-2 mt-2'
+          className='flex flex-col col-span-1 md:col-span-2 mt-2 group'
         >
           <Form.Label className={formLabelStyles}>{copy.atCF}</Form.Label>
           <div className='flex flex-col gap-2'>
@@ -230,7 +230,7 @@ const JourneyFinderSignUpForm: React.FC<JourneyFinderSignUpFormProps> = ({
 
         <Form.Field
           name='hopeToGet'
-          className='flex flex-col col-span-1 md:col-span-2 mt-2'
+          className='flex flex-col col-span-1 md:col-span-2 mt-2 group'
         >
           <Form.Label className={formLabelStyles}>{copy.hopeToGet}</Form.Label>
           <Form.Control asChild>

--- a/app/components/modals/journey-finder-sign-up/journey-finder-sign-up-form.component.tsx
+++ b/app/components/modals/journey-finder-sign-up/journey-finder-sign-up-form.component.tsx
@@ -2,11 +2,16 @@ import * as Form from '@radix-ui/react-form';
 import { useEffect, useState } from 'react';
 import { useFetcher, useSearchParams } from 'react-router-dom';
 import { Button } from '~/primitives/button/button.primitive';
-import { defaultTextInputStyles } from '~/primitives/inputs/text-field/text-field.primitive';
+import {
+  formControlBaseStyles,
+  formControlFocusStyles,
+  formErrorMessageStyles,
+  formLabelStyles,
+  nativeRadioStyles,
+} from '~/primitives/inputs/form-control.styles';
+import { cn } from '~/lib/utils';
 import { pushFormEvent } from '~/lib/gtm';
 import Icon from '~/primitives/icon';
-
-const formControlStyles = `${defaultTextInputStyles} border-transparent bg-[#f4f5f7] text-sm`;
 
 export type JourneyFinderSignUpSuccessDetails = {
   firstName: string;
@@ -28,16 +33,16 @@ export const renderInputField = (
   fieldClassName = '',
 ) => (
   <Form.Field name={name} className={`flex flex-col mb-4 ${fieldClassName}`}>
-    <Form.Label className='font-bold text-sm mb-2'>{label}</Form.Label>
+    <Form.Label className={formLabelStyles}>{label}</Form.Label>
     <Form.Control asChild>
       <input
         type={type}
         required
         defaultValue={defaultValue}
-        className={formControlStyles}
+        className={cn(formControlBaseStyles, formControlFocusStyles)}
       />
     </Form.Control>
-    <Form.Message className='text-sm text-alert' match='valueMissing'>
+    <Form.Message className={formErrorMessageStyles} match='valueMissing'>
       {requiredMessage}
     </Form.Message>
   </Form.Field>
@@ -201,7 +206,7 @@ const JourneyFinderSignUpForm: React.FC<JourneyFinderSignUpFormProps> = ({
           name='atCF'
           className='flex flex-col col-span-1 md:col-span-2 mt-2'
         >
-          <Form.Label className='font-bold text-sm mb-2'>
+          <Form.Label className={formLabelStyles}>
             {copy.atCF}
           </Form.Label>
           <div className='flex flex-col gap-2'>
@@ -213,13 +218,14 @@ const JourneyFinderSignUpForm: React.FC<JourneyFinderSignUpFormProps> = ({
                     name='atCF'
                     value={option.value}
                     required
+                    className={nativeRadioStyles}
                   />
                 </Form.Control>
                 <span className='leading-4'>{option.label}</span>
               </label>
             ))}
           </div>
-          <Form.Message className='text-sm text-alert' match='valueMissing'>
+          <Form.Message className={formErrorMessageStyles} match='valueMissing'>
             {copy.requiredAtCF}
           </Form.Message>
         </Form.Field>
@@ -228,11 +234,18 @@ const JourneyFinderSignUpForm: React.FC<JourneyFinderSignUpFormProps> = ({
           name='hopeToGet'
           className='flex flex-col col-span-1 md:col-span-2 mt-2'
         >
-          <Form.Label className='font-bold text-sm mb-2'>
+          <Form.Label className={formLabelStyles}>
             {copy.hopeToGet}
           </Form.Label>
           <Form.Control asChild>
-            <textarea rows={4} className={formControlStyles} />
+            <textarea
+              rows={4}
+              className={cn(
+                formControlBaseStyles,
+                formControlFocusStyles,
+                'min-h-[120px] h-auto',
+              )}
+            />
           </Form.Control>
         </Form.Field>
 

--- a/app/components/modals/newsletter-subscription/newsletter-subscription-form.component.tsx
+++ b/app/components/modals/newsletter-subscription/newsletter-subscription-form.component.tsx
@@ -135,9 +135,7 @@ const NewsletterSubscriptionForm: React.FC<NewsletterSubscriptionFormProps> = ({
         )}
 
         <Form.Field name='Campus' className='flex flex-col mb-4 md:col-span-2'>
-          <Form.Label className={formLabelStyles}>
-            Campus Location
-          </Form.Label>
+          <Form.Label className={formLabelStyles}>Campus Location</Form.Label>
           <Form.Control asChild>
             {campuses && (
               <select

--- a/app/components/modals/newsletter-subscription/newsletter-subscription-form.component.tsx
+++ b/app/components/modals/newsletter-subscription/newsletter-subscription-form.component.tsx
@@ -22,7 +22,7 @@ export const renderInputField = (
   type: string,
   requiredMessage: string,
 ) => (
-  <Form.Field name={name} className='flex flex-col mb-4'>
+  <Form.Field name={name} className='flex flex-col mb-4 group'>
     <Form.Label className={formLabelStyles}>{label}</Form.Label>
     <Form.Control asChild>
       <input
@@ -134,7 +134,7 @@ const NewsletterSubscriptionForm: React.FC<NewsletterSubscriptionFormProps> = ({
           'Please enter your email address',
         )}
 
-        <Form.Field name='Campus' className='flex flex-col mb-4 md:col-span-2'>
+        <Form.Field name='Campus' className='flex flex-col mb-4 md:col-span-2 group'>
           <Form.Label className={formLabelStyles}>Campus Location</Form.Label>
           <Form.Control asChild>
             {campuses && (

--- a/app/components/modals/newsletter-subscription/newsletter-subscription-form.component.tsx
+++ b/app/components/modals/newsletter-subscription/newsletter-subscription-form.component.tsx
@@ -3,7 +3,13 @@ import { useEffect, useState } from 'react';
 import { useFetcher } from 'react-router-dom';
 import { pushFormEvent } from '~/lib/gtm';
 import { Button } from '~/primitives/button/button.primitive';
-import { defaultTextInputStyles } from '~/primitives/inputs/text-field/text-field.primitive';
+import {
+  formControlBaseStyles,
+  formControlFocusStyles,
+  formErrorMessageStyles,
+  formLabelStyles,
+} from '~/primitives/inputs/form-control.styles';
+import { cn } from '~/lib/utils';
 import { NewsletterSubscriptionLoaderReturnType } from '~/routes/newsletter-subscription/types';
 
 interface NewsletterSubscriptionFormProps {
@@ -17,15 +23,19 @@ export const renderInputField = (
   requiredMessage: string,
 ) => (
   <Form.Field name={name} className='flex flex-col mb-4'>
-    <Form.Label className='font-bold text-sm mb-2'>{label}</Form.Label>
+    <Form.Label className={formLabelStyles}>{label}</Form.Label>
     <Form.Control asChild>
-      <input type={type} required className={defaultTextInputStyles} />
+      <input
+        type={type}
+        required
+        className={cn(formControlBaseStyles, formControlFocusStyles)}
+      />
     </Form.Control>
-    <Form.Message className='text-sm text-alert' match='valueMissing'>
+    <Form.Message className={formErrorMessageStyles} match='valueMissing'>
       {requiredMessage}
     </Form.Message>
     {type === 'email' && (
-      <Form.Message className='text-sm text-alert' match='typeMismatch'>
+      <Form.Message className={formErrorMessageStyles} match='typeMismatch'>
         Please enter a valid email address
       </Form.Message>
     )}
@@ -125,13 +135,17 @@ const NewsletterSubscriptionForm: React.FC<NewsletterSubscriptionFormProps> = ({
         )}
 
         <Form.Field name='Campus' className='flex flex-col mb-4 md:col-span-2'>
-          <Form.Label className='font-bold text-sm mb-2'>
+          <Form.Label className={formLabelStyles}>
             Campus Location
           </Form.Label>
           <Form.Control asChild>
             {campuses && (
               <select
-                className={`appearance-none ${defaultTextInputStyles}`}
+                className={cn(
+                  'appearance-none',
+                  formControlBaseStyles,
+                  formControlFocusStyles,
+                )}
                 required
                 style={{
                   backgroundImage: `url('/assets/icons/chevron-down.svg')`,
@@ -149,7 +163,7 @@ const NewsletterSubscriptionForm: React.FC<NewsletterSubscriptionFormProps> = ({
               </select>
             )}
           </Form.Control>
-          <Form.Message className='text-sm text-alert' match='valueMissing'>
+          <Form.Message className={formErrorMessageStyles} match='valueMissing'>
             Please select a campus
           </Form.Message>
         </Form.Field>

--- a/app/components/modals/prayer-request/prayer-request-form.component.tsx
+++ b/app/components/modals/prayer-request/prayer-request-form.component.tsx
@@ -3,7 +3,13 @@ import { useEffect, useRef, useState } from 'react';
 import { useFetcher } from 'react-router-dom';
 import { pushFormEvent } from '~/lib/gtm';
 import { Button } from '~/primitives/button/button.primitive';
-import { defaultTextInputStyles } from '~/primitives/inputs/text-field/text-field.primitive';
+import {
+  formControlBaseStyles,
+  formControlFocusStyles,
+  formErrorMessageStyles,
+  formLabelStyles,
+} from '~/primitives/inputs/form-control.styles';
+import { cn } from '~/lib/utils';
 import { PrayerRequestLoaderReturnType } from '~/routes/prayer-request/types';
 
 interface PrayerRequestFormProps {
@@ -24,15 +30,19 @@ const renderInputField = (
   requiredMessage: string,
 ) => (
   <Form.Field name={name} className='flex flex-col mb-4'>
-    <Form.Label className='font-bold text-sm mb-2'>{label}</Form.Label>
+    <Form.Label className={formLabelStyles}>{label}</Form.Label>
     <Form.Control asChild>
-      <input type={type} required className={defaultTextInputStyles} />
+      <input
+        type={type}
+        required
+        className={cn(formControlBaseStyles, formControlFocusStyles)}
+      />
     </Form.Control>
-    <Form.Message className='text-sm text-alert' match='valueMissing'>
+    <Form.Message className={formErrorMessageStyles} match='valueMissing'>
       {requiredMessage}
     </Form.Message>
     {type === 'email' && (
-      <Form.Message className='text-sm text-alert' match='typeMismatch'>
+      <Form.Message className={formErrorMessageStyles} match='typeMismatch'>
         Please enter a valid email address
       </Form.Message>
     )}
@@ -124,11 +134,15 @@ const PrayerRequestForm: React.FC<PrayerRequestFormProps> = ({ onSuccess }) => {
         )}
 
         <Form.Field name='Campus' className='flex flex-col mb-4 md:col-span-2'>
-          <Form.Label className='font-bold text-sm mb-2'>Campus</Form.Label>
+          <Form.Label className={formLabelStyles}>Campus</Form.Label>
           <Form.Control asChild>
             {campuses && (
               <select
-                className={`appearance-none ${defaultTextInputStyles}`}
+                className={cn(
+                  'appearance-none',
+                  formControlBaseStyles,
+                  formControlFocusStyles,
+                )}
                 required
                 style={{
                   backgroundImage: `url('/assets/icons/chevron-down.svg')`,
@@ -146,19 +160,27 @@ const PrayerRequestForm: React.FC<PrayerRequestFormProps> = ({ onSuccess }) => {
               </select>
             )}
           </Form.Control>
-          <Form.Message className='text-sm text-alert' match='valueMissing'>
+          <Form.Message className={formErrorMessageStyles} match='valueMissing'>
             Please select a campus
           </Form.Message>
         </Form.Field>
 
         <Form.Field name='Request' className='flex flex-col mb-4 md:col-span-2'>
-          <Form.Label className='font-bold text-sm mb-2'>
+          <Form.Label className={formLabelStyles}>
             How can we pray for you?
           </Form.Label>
           <Form.Control asChild>
-            <textarea required rows={5} className={defaultTextInputStyles} />
+            <textarea
+              required
+              rows={5}
+              className={cn(
+                formControlBaseStyles,
+                formControlFocusStyles,
+                'min-h-[120px] h-auto',
+              )}
+            />
           </Form.Control>
-          <Form.Message className='text-sm text-alert' match='valueMissing'>
+          <Form.Message className={formErrorMessageStyles} match='valueMissing'>
             Please enter your prayer request
           </Form.Message>
         </Form.Field>
@@ -167,12 +189,16 @@ const PrayerRequestForm: React.FC<PrayerRequestFormProps> = ({ onSuccess }) => {
           name='FollowUp'
           className='flex flex-col mb-4 md:col-span-2'
         >
-          <Form.Label className='font-bold text-sm mb-2'>
+          <Form.Label className={formLabelStyles}>
             Would you like our team to follow up with you?
           </Form.Label>
           <Form.Control asChild>
             <select
-              className={`appearance-none ${defaultTextInputStyles}`}
+              className={cn(
+                'appearance-none',
+                formControlBaseStyles,
+                formControlFocusStyles,
+              )}
               style={{
                 backgroundImage: `url('/assets/icons/chevron-down.svg')`,
                 backgroundSize: '24px',

--- a/app/components/modals/prayer-request/prayer-request-form.component.tsx
+++ b/app/components/modals/prayer-request/prayer-request-form.component.tsx
@@ -29,7 +29,7 @@ const renderInputField = (
   type: string,
   requiredMessage: string,
 ) => (
-  <Form.Field name={name} className='flex flex-col mb-4'>
+  <Form.Field name={name} className='flex flex-col mb-4 group'>
     <Form.Label className={formLabelStyles}>{label}</Form.Label>
     <Form.Control asChild>
       <input
@@ -133,7 +133,7 @@ const PrayerRequestForm: React.FC<PrayerRequestFormProps> = ({ onSuccess }) => {
           'Please enter your phone number',
         )}
 
-        <Form.Field name='Campus' className='flex flex-col mb-4 md:col-span-2'>
+        <Form.Field name='Campus' className='flex flex-col mb-4 md:col-span-2 group'>
           <Form.Label className={formLabelStyles}>Campus</Form.Label>
           <Form.Control asChild>
             {campuses && (
@@ -165,7 +165,7 @@ const PrayerRequestForm: React.FC<PrayerRequestFormProps> = ({ onSuccess }) => {
           </Form.Message>
         </Form.Field>
 
-        <Form.Field name='Request' className='flex flex-col mb-4 md:col-span-2'>
+        <Form.Field name='Request' className='flex flex-col mb-4 md:col-span-2 group'>
           <Form.Label className={formLabelStyles}>
             How can we pray for you?
           </Form.Label>
@@ -187,7 +187,7 @@ const PrayerRequestForm: React.FC<PrayerRequestFormProps> = ({ onSuccess }) => {
 
         <Form.Field
           name='FollowUp'
-          className='flex flex-col mb-4 md:col-span-2'
+          className='flex flex-col mb-4 md:col-span-2 group'
         >
           <Form.Label className={formLabelStyles}>
             Would you like our team to follow up with you?

--- a/app/components/modals/set-a-reminder/reminder-form.component.tsx
+++ b/app/components/modals/set-a-reminder/reminder-form.component.tsx
@@ -136,7 +136,7 @@ const ReminderForm: React.FC<ReminderProps> = ({
           email || undefined,
         )}
 
-        <Form.Field name='campus' className='flex flex-col'>
+        <Form.Field name='campus' className='flex flex-col group'>
           <Form.Label className={formLabelStyles}>Campus</Form.Label>
           <Form.Control asChild>
             <select
@@ -159,7 +159,7 @@ const ReminderForm: React.FC<ReminderProps> = ({
           </Form.Control>
         </Form.Field>
 
-        <Form.Field name='serviceTime' className='flex flex-col'>
+        <Form.Field name='serviceTime' className='flex flex-col group'>
           <Form.Label className={formLabelStyles}>
             {isEspanol ? 'Horarios de Servicios' : 'Service Time'}
           </Form.Label>
@@ -204,7 +204,7 @@ const ReminderForm: React.FC<ReminderProps> = ({
 
         <Form.Field
           name='beenToCF'
-          className='flex flex-col col-span-1 md:col-span-2 mt-4'
+          className='flex flex-col col-span-1 md:col-span-2 mt-4 group'
         >
           <Form.Label className={formLabelStyles}>
             {isEspanol

--- a/app/components/modals/set-a-reminder/reminder-form.component.tsx
+++ b/app/components/modals/set-a-reminder/reminder-form.component.tsx
@@ -1,7 +1,14 @@
 import * as Form from '@radix-ui/react-form';
 import { useEffect, useState } from 'react';
 import { Button } from '~/primitives/button/button.primitive';
-import { defaultTextInputStyles } from '~/primitives/inputs/text-field/text-field.primitive';
+import {
+  formControlBaseStyles,
+  formControlFocusStyles,
+  formErrorMessageStyles,
+  formLabelStyles,
+  nativeRadioStyles,
+} from '~/primitives/inputs/form-control.styles';
+import { cn } from '~/lib/utils';
 import { useFetcher } from 'react-router-dom';
 import { renderInputField } from '../connect-card/connect-form.component';
 import { LoaderReturnType } from '~/routes/set-a-reminder/loader';
@@ -130,10 +137,14 @@ const ReminderForm: React.FC<ReminderProps> = ({
         )}
 
         <Form.Field name='campus' className='flex flex-col'>
-          <Form.Label className='font-bold text-sm mb-2'>Campus</Form.Label>
+          <Form.Label className={formLabelStyles}>Campus</Form.Label>
           <Form.Control asChild>
             <select
-              className={`appearance-none ${defaultTextInputStyles} text-neutral-400`}
+              className={cn(
+                'appearance-none text-neutral-400',
+                formControlBaseStyles,
+                formControlFocusStyles,
+              )}
               required
               disabled
               style={{
@@ -149,13 +160,17 @@ const ReminderForm: React.FC<ReminderProps> = ({
         </Form.Field>
 
         <Form.Field name='serviceTime' className='flex flex-col'>
-          <Form.Label className='font-bold text-sm mb-2'>
+          <Form.Label className={formLabelStyles}>
             {isEspanol ? 'Horarios de Servicios' : 'Service Time'}
           </Form.Label>
           <Form.Control asChild>
             {serviceTimes && (
               <select
-                className={`appearance-none ${defaultTextInputStyles} cursor-pointer`}
+                className={cn(
+                  'appearance-none cursor-pointer',
+                  formControlBaseStyles,
+                  formControlFocusStyles,
+                )}
                 required
                 onChange={(e) => setServiceTime(e.target.value)}
                 style={{
@@ -180,7 +195,7 @@ const ReminderForm: React.FC<ReminderProps> = ({
               </select>
             )}
           </Form.Control>
-          <Form.Message className='text-sm text-alert' match='valueMissing'>
+          <Form.Message className={formErrorMessageStyles} match='valueMissing'>
             {isEspanol
               ? 'Porfavor seleccione un horario de servicio'
               : 'Please select a service time'}
@@ -191,7 +206,7 @@ const ReminderForm: React.FC<ReminderProps> = ({
           name='beenToCF'
           className='flex flex-col col-span-1 md:col-span-2 mt-4'
         >
-          <Form.Label className='font-bold text-sm mb-2'>
+          <Form.Label className={formLabelStyles}>
             {isEspanol
               ? '¿Ha estado en Christ Fellowship antes?'
               : 'Have you been to Christ Fellowship before?'}
@@ -203,7 +218,7 @@ const ReminderForm: React.FC<ReminderProps> = ({
                 name='beenToCF'
                 value='true'
                 required
-                className='h-4 w-4 accent-ocean shrink-0'
+                className={nativeRadioStyles}
               />
               {isEspanol ? 'Sí' : 'Yes'}
             </label>
@@ -212,12 +227,12 @@ const ReminderForm: React.FC<ReminderProps> = ({
                 type='radio'
                 name='beenToCF'
                 value='false'
-                className='h-4 w-4 accent-ocean shrink-0'
+                className={nativeRadioStyles}
               />
               No, {isEspanol ? 'es mi primera vez' : "it's my first time"}
             </label>
           </div>
-          <Form.Message className='text-sm text-alert' match='valueMissing'>
+          <Form.Message className={formErrorMessageStyles} match='valueMissing'>
             {isEspanol
               ? 'Porfavor indique si ha estado en Christ Fellowship antes.'
               : 'Please let us know if you have been to Christ Fellowship before.'}

--- a/app/primitives/inputs/checkbox/__tests__/index.test.tsx
+++ b/app/primitives/inputs/checkbox/__tests__/index.test.tsx
@@ -50,4 +50,59 @@ describe('Checkbox', () => {
     render(<Checkbox checked={false} onChange={vi.fn()} label='Optional' />);
     expect(screen.getByRole('checkbox')).not.toBeRequired();
   });
+
+  it('unchecked state has border-form-stroke-muted class on visual box', () => {
+    const { container } = render(
+      <Checkbox checked={false} onChange={vi.fn()} label='Accept' />,
+    );
+    // The visual checkbox is the span after the input
+    const visualBox = container.querySelector('span.absolute');
+    expect(visualBox?.className).toContain('border-form-stroke-muted');
+  });
+
+  it('checked state has bg-ocean class on visual box', () => {
+    const { container } = render(
+      <Checkbox checked={true} onChange={vi.fn()} label='Accept' />,
+    );
+    const visualBox = container.querySelector('span.absolute');
+    expect(visualBox?.className).toContain('bg-ocean');
+  });
+
+  it('error prop: visual box has border-alert class', () => {
+    const { container } = render(
+      <Checkbox
+        checked={false}
+        onChange={vi.fn()}
+        label='Accept'
+        error={true}
+      />,
+    );
+    const visualBox = container.querySelector('span.absolute');
+    expect(visualBox?.className).toContain('border-alert');
+  });
+
+  it('disabled prop: input has disabled attribute', () => {
+    render(
+      <Checkbox
+        checked={false}
+        onChange={vi.fn()}
+        label='Accept'
+        disabled={true}
+      />,
+    );
+    expect(screen.getByRole('checkbox')).toBeDisabled();
+  });
+
+  it('disabled prop: wrapper label has cursor-not-allowed class', () => {
+    const { container } = render(
+      <Checkbox
+        checked={false}
+        onChange={vi.fn()}
+        label='Accept'
+        disabled={true}
+      />,
+    );
+    const label = container.querySelector('label');
+    expect(label?.className).toContain('cursor-not-allowed');
+  });
 });

--- a/app/primitives/inputs/checkbox/checkbox.primitive.tsx
+++ b/app/primitives/inputs/checkbox/checkbox.primitive.tsx
@@ -25,7 +25,7 @@ export const Checkbox: React.FC<CheckboxProps> = ({
   id,
 }) => {
   const visualCheckboxClass = cn(
-    'rounded-[4px] size-5 transition-colors duration-150 border-2',
+    'rounded-md size-5 transition-colors duration-150 border-2',
     checked && !disabled && 'bg-ocean border-ocean',
     checked && disabled && 'bg-ocean/40 border-ocean/40',
     !checked && error && 'bg-white border-alert',
@@ -35,7 +35,7 @@ export const Checkbox: React.FC<CheckboxProps> = ({
   return (
     <label
       className={cn(
-        'flex items-center gap-2 select-none',
+        'flex items-center gap-3 select-none',
         disabled ? 'cursor-not-allowed' : 'cursor-pointer',
         className,
       )}
@@ -85,7 +85,7 @@ export const Checkbox: React.FC<CheckboxProps> = ({
         className={
           labelClassName && labelClassName !== ''
             ? labelClassName
-            : 'text-text-primary font-normal'
+            : 'text-dark-navy font-normal'
         }
       >
         {label}

--- a/app/primitives/inputs/checkbox/checkbox.primitive.tsx
+++ b/app/primitives/inputs/checkbox/checkbox.primitive.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { cn } from '~/lib/utils';
 
 interface CheckboxProps {
   checked: boolean;
@@ -7,6 +8,9 @@ interface CheckboxProps {
   className?: string;
   labelClassName?: string;
   required?: boolean;
+  disabled?: boolean;
+  error?: boolean;
+  id?: string;
 }
 
 export const Checkbox: React.FC<CheckboxProps> = ({
@@ -16,40 +20,65 @@ export const Checkbox: React.FC<CheckboxProps> = ({
   className = '',
   labelClassName = '',
   required = false,
+  disabled = false,
+  error = false,
+  id,
 }) => {
+  const visualCheckboxClass = cn(
+    'rounded-[4px] size-5 transition-colors duration-150 border-2',
+    checked && !disabled && 'bg-ocean border-ocean',
+    checked && disabled && 'bg-ocean/40 border-ocean/40',
+    !checked && error && 'bg-white border-alert',
+    !checked && !error && 'bg-white border-form-stroke-muted',
+  );
+
   return (
     <label
-      className={`flex items-center gap-3 cursor-pointer select-none ${className}`}
+      className={cn(
+        'flex items-center gap-2 select-none',
+        disabled ? 'cursor-not-allowed' : 'cursor-pointer',
+        className,
+      )}
     >
       <span className='relative flex items-center justify-center'>
         <input
           type='checkbox'
           checked={checked}
           onChange={(e) => onChange(e.target.checked)}
-          className='peer appearance-none w-5 h-5 border-1 border-ocean rounded-md transition-colors duration-150 bg-ocean/10 checked:bg-ocean checked:border-ocean focus:outline-none focus:ring-1 focus:ring-ocean'
+          className='peer appearance-none w-5 h-5 focus:outline-none focus:ring-1 focus:ring-ocean'
           aria-checked={checked}
           required={required}
+          disabled={disabled}
+          id={id}
         />
         <span
-          className={`pointer-events-none absolute left-0 top-0 flex h-5 w-5 items-center justify-center transition-opacity duration-150 ${
-            checked ? 'opacity-100' : 'opacity-0'
-          }`}
+          className={cn(
+            'pointer-events-none absolute left-0 top-0 flex h-5 w-5 items-center justify-center',
+            visualCheckboxClass,
+          )}
         >
-          <svg
-            width='20'
-            height='20'
-            viewBox='0 0 20 20'
-            fill='none'
-            xmlns='http://www.w3.org/2000/svg'
+          <span
+            className={cn(
+              'flex items-center justify-center transition-opacity duration-150',
+              checked ? 'opacity-100' : 'opacity-0',
+            )}
           >
-            <path
-              d='M5 10.5L9 14L15 7'
-              stroke='white'
-              strokeWidth='1.5'
-              strokeLinecap='round'
-              strokeLinejoin='round'
-            />
-          </svg>
+            <svg
+              width='20'
+              height='20'
+              viewBox='0 0 20 20'
+              fill='none'
+              xmlns='http://www.w3.org/2000/svg'
+            >
+              <path
+                d='M5 10.5L9 14L15 7'
+                stroke='white'
+                strokeWidth='1.5'
+                strokeLinecap='round'
+                strokeLinejoin='round'
+              />
+            </svg>
+          </span>
         </span>
       </span>
       <span

--- a/app/primitives/inputs/date-input/date-input.primitive.tsx
+++ b/app/primitives/inputs/date-input/date-input.primitive.tsx
@@ -49,7 +49,8 @@ const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
     }, [error]);
 
     const mergedRef = (el: HTMLInputElement | null) => {
-      (inputRef as React.MutableRefObject<HTMLInputElement | null>).current = el;
+      (inputRef as React.MutableRefObject<HTMLInputElement | null>).current =
+        el;
       if (typeof ref === 'function') {
         ref(el);
       } else if (ref) {
@@ -87,7 +88,11 @@ const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
           <input
             ref={mergedRef}
             name={name}
-            className={cn(formControlBaseStyles, formControlFocusStyles, className)}
+            className={cn(
+              formControlBaseStyles,
+              formControlFocusStyles,
+              className,
+            )}
             type='date'
             value={value}
             onChange={(e) => setValue(e.target.value)}

--- a/app/primitives/inputs/date-input/date-input.primitive.tsx
+++ b/app/primitives/inputs/date-input/date-input.primitive.tsx
@@ -7,6 +7,7 @@ import {
   formControlErrorStyles,
   formLabelStyles,
   formErrorMessageStyles,
+  formFieldWrapperStyles,
 } from '~/primitives/inputs/form-control.styles';
 
 export { defaultDateInputStyles } from '~/primitives/inputs/form-control.styles';
@@ -59,7 +60,7 @@ const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
     };
 
     return (
-      <div className='flex flex-col gap-1 w-full'>
+      <div className={formFieldWrapperStyles}>
         {label && (
           <label className={formLabelStyles}>
             {isRequired && <span className='text-ocean mr-1'>{'*'}</span>}

--- a/app/primitives/inputs/form-control.styles.ts
+++ b/app/primitives/inputs/form-control.styles.ts
@@ -20,12 +20,17 @@ export const formControlTrailingIconStyles: string = 'pr-10';
 
 // Typography
 export const formLabelStyles: string =
-  'text-[20px] leading-5 text-dark-navy font-bold';
+  'text-[14px] font-medium leading-5 text-dark-navy tracking-[-0.15px] group-focus-within:text-ocean transition-colors duration-150';
 
-export const formHelperTextStyles: string = 'text-base leading-4 text-navy';
+export const formHelperTextStyles: string =
+  'text-[12px] font-normal leading-4 text-navy';
 
 export const formErrorMessageStyles: string =
-  'text-[20px] leading-5 text-alert flex items-center gap-1.5';
+  'text-[14px] font-normal leading-5 text-alert tracking-[-0.15px] flex items-center gap-1.5';
+
+// Wrapper for a field group (label + input + helper/error). Provides gap-3 spacing
+// and the `group` class needed for label focus-within color change.
+export const formFieldWrapperStyles: string = 'flex flex-col gap-3 w-full group';
 
 // For Radix modal forms that use native inputs inside Form.Control
 export const nativeCheckboxStyles: string =

--- a/app/primitives/inputs/form-control.styles.ts
+++ b/app/primitives/inputs/form-control.styles.ts
@@ -1,0 +1,49 @@
+// Single source of truth for all form control styling.
+// No imports — plain string constants only.
+
+// Control surface (text / select / textarea / date)
+export const formControlBaseStyles: string =
+  'h-[46px] box-border rounded-[10px] px-4 py-2.5 w-full bg-gray border border-dark-navy/10 focus:outline-none focus:ring-0';
+
+export const formControlFocusStyles: string =
+  'focus:h-[48px] focus:bg-white focus:border-2 focus:border-ocean focus:shadow-[0_0_0_3px_rgba(0,146,188,0.15)]';
+
+export const formControlErrorStyles: string =
+  'h-[48px] border-2 border-alert bg-white';
+
+export const formControlDisabledStyles: string =
+  'opacity-50 cursor-not-allowed bg-gray';
+
+export const formControlLeadingIconStyles: string = 'pl-10';
+
+export const formControlTrailingIconStyles: string = 'pr-10';
+
+// Typography
+export const formLabelStyles: string =
+  'text-[20px] leading-5 text-dark-navy font-bold';
+
+export const formHelperTextStyles: string = 'text-base leading-4 text-navy';
+
+export const formErrorMessageStyles: string =
+  'text-[20px] leading-5 text-alert flex items-center gap-1.5';
+
+// For Radix modal forms that use native inputs inside Form.Control
+export const nativeCheckboxStyles: string =
+  'size-5 rounded-[4px] border-2 border-[#d1d5db] bg-white checked:bg-ocean checked:border-ocean focus:outline-none focus:ring-2 focus:ring-ocean/20 accent-ocean';
+
+export const nativeRadioStyles: string =
+  'size-5 rounded-full border-2 border-[#d1d5db] bg-white checked:border-ocean focus:outline-none focus:ring-2 focus:ring-ocean/20 accent-ocean';
+
+// Group containers
+export const formCheckboxGroupStyles: string = 'flex flex-col gap-2';
+
+export const formRadioGroupStyles: string = 'flex flex-col gap-2.5';
+
+// Back-compat re-exports (primitives currently export these from their own files).
+// These are ready-to-use single className strings with base + focus styles combined.
+export const defaultTextInputStyles: string =
+  'box-border h-[46px] rounded-[10px] px-4 py-2.5 w-full bg-gray border border-dark-navy/10 focus:outline-none focus:ring-0 focus:h-[48px] focus:bg-white focus:border-2 focus:border-ocean focus:shadow-[0_0_0_3px_rgba(0,146,188,0.15)]';
+
+export const defaultSelectInputStyles: string = defaultTextInputStyles;
+
+export const defaultDateInputStyles: string = defaultTextInputStyles;

--- a/app/primitives/inputs/form-control.styles.ts
+++ b/app/primitives/inputs/form-control.styles.ts
@@ -29,10 +29,10 @@ export const formErrorMessageStyles: string =
 
 // For Radix modal forms that use native inputs inside Form.Control
 export const nativeCheckboxStyles: string =
-  'size-5 rounded-[4px] border-2 border-[#d1d5db] bg-white checked:bg-ocean checked:border-ocean focus:outline-none focus:ring-2 focus:ring-ocean/20 accent-ocean';
+  'size-5 rounded-[4px] border-2 border-form-stroke-muted bg-white checked:bg-ocean checked:border-ocean focus:outline-none focus:ring-2 focus:ring-ocean/20 accent-ocean';
 
 export const nativeRadioStyles: string =
-  'size-5 rounded-full border-2 border-[#d1d5db] bg-white checked:border-ocean focus:outline-none focus:ring-2 focus:ring-ocean/20 accent-ocean';
+  'size-5 rounded-full border-2 border-form-stroke-muted bg-white checked:border-ocean focus:outline-none focus:ring-2 focus:ring-ocean/20 accent-ocean';
 
 // Group containers
 export const formCheckboxGroupStyles: string = 'flex flex-col gap-2';

--- a/app/primitives/inputs/radio-buttons/__tests__/index.test.tsx
+++ b/app/primitives/inputs/radio-buttons/__tests__/index.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import RadioButtons from '../radio-buttons.primitive';
+
+const defaultOptions = [
+  { value: 'a', label: 'Option A' },
+  { value: 'b', label: 'Option B' },
+];
+
+describe('RadioButtons', () => {
+  it('renders all option labels', () => {
+    render(
+      <RadioButtons
+        options={defaultOptions}
+        selectedOption=''
+        onChange={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('Option A')).toBeInTheDocument();
+    expect(screen.getByText('Option B')).toBeInTheDocument();
+  });
+
+  it('calls onChange with the correct value when an option is clicked', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <RadioButtons
+        options={defaultOptions}
+        selectedOption=''
+        onChange={onChange}
+      />,
+    );
+    // Radio inputs are hidden; click the label for Option A
+    await user.click(screen.getByText('Option A'));
+    expect(onChange).toHaveBeenCalledWith('a');
+  });
+
+  it('name prop: radio inputs have the given name attribute', () => {
+    const { container } = render(
+      <RadioButtons
+        options={defaultOptions}
+        selectedOption=''
+        onChange={vi.fn()}
+        name='my-group'
+      />,
+    );
+    const inputs = container.querySelectorAll('input[type="radio"]');
+    inputs.forEach((input) => {
+      expect(input).toHaveAttribute('name', 'my-group');
+    });
+  });
+
+  it('vertical orientation: wrapper has gap-2.5 class', () => {
+    const { container } = render(
+      <RadioButtons
+        options={defaultOptions}
+        selectedOption=''
+        onChange={vi.fn()}
+        orientation='vertical'
+      />,
+    );
+    const wrapper = container.firstElementChild;
+    expect(wrapper?.className).toContain('gap-2.5');
+  });
+});

--- a/app/primitives/inputs/radio-buttons/radio-buttons.primitive.tsx
+++ b/app/primitives/inputs/radio-buttons/radio-buttons.primitive.tsx
@@ -38,7 +38,7 @@ const RadioButtons: React.FC<RadioButtonsProps> = ({
         const outerCircleClass = cn(
           'flex h-5 w-5 items-center justify-center rounded-full border-2 transition duration-200',
           isSelected && !disabled && 'border-ocean bg-white',
-          isSelected && disabled && 'border-ocean/40 bg-white opacity-50',
+          isSelected && disabled && 'border-ocean/40 bg-white',
           !isSelected && error && 'border-alert bg-white',
           !isSelected && !error && 'border-form-stroke-muted bg-white',
         );

--- a/app/primitives/inputs/radio-buttons/radio-buttons.primitive.tsx
+++ b/app/primitives/inputs/radio-buttons/radio-buttons.primitive.tsx
@@ -1,8 +1,14 @@
+import React from 'react';
+import { cn } from '~/lib/utils';
+
 interface RadioButtonsProps {
   options: { value: string; label: string }[];
   orientation?: 'vertical' | 'horizontal';
   selectedOption: string;
   onChange: (value: string) => void;
+  name?: string;
+  error?: boolean;
+  disabled?: boolean;
 }
 
 const RadioButtons: React.FC<RadioButtonsProps> = ({
@@ -10,6 +16,9 @@ const RadioButtons: React.FC<RadioButtonsProps> = ({
   orientation = 'horizontal',
   selectedOption,
   onChange,
+  name = 'option',
+  error = false,
+  disabled = false,
 }) => {
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     onChange(event.target.value);
@@ -19,33 +28,52 @@ const RadioButtons: React.FC<RadioButtonsProps> = ({
     <div
       className={
         orientation === 'horizontal'
-          ? 'flex flex-row space-x-4'
-          : 'flex flex-col space-y-2'
+          ? 'flex flex-row gap-4'
+          : 'flex flex-col gap-2.5'
       }
     >
-      {options.map((option) => (
-        <label key={option.value} className='flex items-center space-x-2'>
-          <input
-            type='radio'
-            name='option'
-            value={option.value}
-            className='hidden'
-            checked={selectedOption === option.value}
-            onChange={handleChange}
-            id={`option-${option.value}`}
-          />
-          <span
-            className={`flex h-5 w-5 cursor-pointer items-center justify-center rounded-full border border-ocean bg-white transition duration-200`}
+      {options.map((option) => {
+        const isSelected = selectedOption === option.value;
+
+        const outerCircleClass = cn(
+          'flex h-5 w-5 items-center justify-center rounded-full border-2 transition duration-200',
+          isSelected && !disabled && 'border-ocean bg-white',
+          isSelected && disabled && 'border-ocean/40 bg-white opacity-50',
+          !isSelected && error && 'border-alert bg-white',
+          !isSelected && !error && 'border-form-stroke-muted bg-white',
+        );
+
+        const innerDotClass = cn(
+          'h-3 w-3 rounded-full',
+          disabled ? 'bg-ocean/40' : 'bg-ocean',
+          isSelected ? '' : 'hidden',
+        );
+
+        return (
+          <label
+            key={option.value}
+            className={cn(
+              'flex items-center gap-2',
+              disabled ? 'cursor-not-allowed' : 'cursor-pointer',
+            )}
           >
-            <span
-              className={`h-3 w-3 rounded-full bg-ocean ${
-                selectedOption === option.value ? '' : 'hidden'
-              }`}
+            <input
+              type='radio'
+              name={name}
+              value={option.value}
+              className='hidden'
+              checked={isSelected}
+              onChange={handleChange}
+              id={`${name}-${option.value}`}
+              disabled={disabled}
             />
-          </span>
-          <span>{option.label}</span>
-        </label>
-      ))}
+            <span className={outerCircleClass}>
+              <span className={innerDotClass} />
+            </span>
+            <span>{option.label}</span>
+          </label>
+        );
+      })}
     </div>
   );
 };

--- a/app/primitives/inputs/select-input/__tests__/index.test.tsx
+++ b/app/primitives/inputs/select-input/__tests__/index.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import SelectInput from '../select-input.primitive';
+
+const defaultOptions = [
+  { value: 'ca', label: 'California' },
+  { value: 'fl', label: 'Florida' },
+];
+
+describe('SelectInput', () => {
+  it('renders select with options', () => {
+    render(
+      <SelectInput
+        value=''
+        error={null}
+        setValue={vi.fn()}
+        setError={vi.fn()}
+        options={defaultOptions}
+      />,
+    );
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+    expect(screen.getByText('California')).toBeInTheDocument();
+    expect(screen.getByText('Florida')).toBeInTheDocument();
+  });
+
+  it('error state: error message shown below the select', () => {
+    render(
+      <SelectInput
+        value=''
+        error='Please select an option'
+        setValue={vi.fn()}
+        setError={vi.fn()}
+        options={defaultOptions}
+      />,
+    );
+    expect(screen.getByText('Please select an option')).toBeInTheDocument();
+  });
+
+  it('normal state: select has rounded-[10px] class', () => {
+    render(
+      <SelectInput
+        value=''
+        error={null}
+        setValue={vi.fn()}
+        setError={vi.fn()}
+        options={defaultOptions}
+      />,
+    );
+    const select = screen.getByRole('combobox');
+    expect(select.className).toContain('rounded-[10px]');
+  });
+});

--- a/app/primitives/inputs/select-input/select-input.primitive.tsx
+++ b/app/primitives/inputs/select-input/select-input.primitive.tsx
@@ -1,9 +1,15 @@
 import React, { forwardRef } from 'react';
 import Icon from '~/primitives/icon';
-import colors from '~/styles/colors';
+import { cn } from '~/lib/utils';
+import {
+  formControlBaseStyles,
+  formControlFocusStyles,
+  formControlErrorStyles,
+  formLabelStyles,
+  formErrorMessageStyles,
+} from '~/primitives/inputs/form-control.styles';
 
-export const defaultSelectInputStyles =
-  'rounded-md border border-neutral-500 p-2 focus:border-2 focus:border-ocean focus:outline-none focus:ring-0 data-[invalid=true]:focus:border-alert w-full';
+export { defaultSelectInputStyles } from '~/primitives/inputs/form-control.styles';
 
 interface SelectOption {
   value: string;
@@ -40,24 +46,24 @@ const SelectInput = forwardRef<HTMLSelectElement, SelectInputProps>(
     ref,
   ) => {
     return (
-      <div className='relative flex flex-col gap-1 w-full'>
+      <div className='flex flex-col gap-1 w-full'>
         {label && (
-          <label className='font-bold text-text-primary text-sm mb-1'>
+          <label className={formLabelStyles}>
             {isRequired && <span className='text-ocean mr-1'>{'*'}</span>}
             {label}
             {isRequired && (
-              <span className='font-normal text-text-secondary ml-1 italic'>
+              <span className='font-normal text-navy ml-1 italic'>
                 {'(required)'}
               </span>
             )}
           </label>
         )}
-        {error ? (
-          <div className='relative'>
+        <div className='relative'>
+          {error ? (
             <select
               ref={ref}
               name={name}
-              className='w-full rounded-md border-2 border-alert p-2 bg-white'
+              className={cn(formControlErrorStyles, 'appearance-none pr-10')}
               value={value}
               onFocus={() => setError(null)}
               required={isRequired}
@@ -70,34 +76,39 @@ const SelectInput = forwardRef<HTMLSelectElement, SelectInputProps>(
                 </option>
               ))}
             </select>
-            <span className='absolute right-3 top-2.5 text-gray-500'>
-              <Icon name='errorCircle' color={colors.alert} />
-            </span>
-          </div>
-        ) : (
-          <select
-            ref={ref}
-            name={name}
-            className={`${defaultSelectInputStyles} ${className} bg-white appearance-none pr-10`}
-            value={value}
-            onChange={(e) => setValue(e.target.value)}
-            required={isRequired}
-            data-invalid={!!error}
-            style={{
-              background: 'none',
-            }}
-          >
-            {placeholder && <option value=''>{placeholder}</option>}
-            {options.map((opt) => (
-              <option key={opt.value} value={opt.value}>
-                {opt.label}
-              </option>
-            ))}
-          </select>
+          ) : (
+            <select
+              ref={ref}
+              name={name}
+              className={cn(
+                formControlBaseStyles,
+                formControlFocusStyles,
+                'appearance-none pr-10',
+                className,
+              )}
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              required={isRequired}
+              data-invalid={!!error}
+            >
+              {placeholder && <option value=''>{placeholder}</option>}
+              {options.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          )}
+          <span className='pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-gray-500'>
+            <Icon name='chevronDown' size={20} />
+          </span>
+        </div>
+        {error && (
+          <p className={formErrorMessageStyles}>
+            <Icon name='errorCircle' className='shrink-0' size={20} />
+            {error}
+          </p>
         )}
-        <span className='pointer-events-none absolute right-3 top-10 text-gray-500'>
-          <Icon name='chevronDown' size={20} />
-        </span>
       </div>
     );
   },

--- a/app/primitives/inputs/select-input/select-input.primitive.tsx
+++ b/app/primitives/inputs/select-input/select-input.primitive.tsx
@@ -7,6 +7,7 @@ import {
   formControlErrorStyles,
   formLabelStyles,
   formErrorMessageStyles,
+  formFieldWrapperStyles,
 } from '~/primitives/inputs/form-control.styles';
 
 export { defaultSelectInputStyles } from '~/primitives/inputs/form-control.styles';
@@ -46,7 +47,7 @@ const SelectInput = forwardRef<HTMLSelectElement, SelectInputProps>(
     ref,
   ) => {
     return (
-      <div className='flex flex-col gap-1 w-full'>
+      <div className={formFieldWrapperStyles}>
         {label && (
           <label className={formLabelStyles}>
             {isRequired && <span className='text-ocean mr-1'>{'*'}</span>}

--- a/app/primitives/inputs/text-field/__tests__/index.test.tsx
+++ b/app/primitives/inputs/text-field/__tests__/index.test.tsx
@@ -93,9 +93,11 @@ describe('TextFieldInput', () => {
         setError={vi.fn()}
       />,
     );
-    // In error state the input is readOnly — no onChange
+    // Error message is rendered below the field
+    expect(screen.getByText('Invalid email')).toBeInTheDocument();
+    // Input is still editable (not readOnly) in error state
     const input = document.querySelector('input');
-    expect(input).toHaveAttribute('readonly');
+    expect(input).not.toHaveAttribute('readonly');
   });
 
   it('clears error on focus when in error state', () => {
@@ -110,6 +112,89 @@ describe('TextFieldInput', () => {
     );
     fireEvent.focus(screen.getByRole('textbox'));
     expect(setError).toHaveBeenCalledWith(null);
+  });
+
+  it('input has rounded-[10px] class (radius token)', () => {
+    render(
+      <TextFieldInput
+        value=''
+        error={null}
+        setValue={vi.fn()}
+        setError={vi.fn()}
+      />,
+    );
+    const input = document.querySelector('input');
+    expect(input?.className).toContain('rounded-[10px]');
+  });
+
+  it('input has h-[46px] class (height token)', () => {
+    render(
+      <TextFieldInput
+        value=''
+        error={null}
+        setValue={vi.fn()}
+        setError={vi.fn()}
+      />,
+    );
+    const input = document.querySelector('input');
+    expect(input?.className).toContain('h-[46px]');
+  });
+
+  it('input has bg-gray class (background token)', () => {
+    render(
+      <TextFieldInput
+        value=''
+        error={null}
+        setValue={vi.fn()}
+        setError={vi.fn()}
+      />,
+    );
+    const input = document.querySelector('input');
+    expect(input?.className).toContain('bg-gray');
+  });
+
+  it('error message is rendered below the field, not inside the input', () => {
+    render(
+      <TextFieldInput
+        value=''
+        error='Required field'
+        setValue={vi.fn()}
+        setError={vi.fn()}
+      />,
+    );
+    const errorMsg = screen.getByText('Required field');
+    expect(errorMsg.tagName).not.toBe('INPUT');
+    expect(errorMsg.closest('p')).toBeInTheDocument();
+  });
+
+  it('password type renders a toggle button', () => {
+    render(
+      <TextFieldInput
+        value=''
+        error={null}
+        setValue={vi.fn()}
+        setError={vi.fn()}
+        type='password'
+      />,
+    );
+    expect(
+      screen.getByRole('button', { name: /show password/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('isValidated prop: shows trailing icon when true and no error', () => {
+    render(
+      <TextFieldInput
+        value='test'
+        error={null}
+        setValue={vi.fn()}
+        setError={vi.fn()}
+        isValidated={true}
+      />,
+    );
+    // The checkCircle icon span is rendered as a trailing icon
+    const wrapper = document.querySelector('.relative');
+    expect(wrapper?.querySelector('span.absolute')).toBeInTheDocument();
   });
 
   it('renders name attribute when provided', () => {

--- a/app/primitives/inputs/text-field/secure-text-field.primitive.tsx
+++ b/app/primitives/inputs/text-field/secure-text-field.primitive.tsx
@@ -1,7 +1,14 @@
 import React, { forwardRef, useEffect, useRef, useState } from 'react';
 import Icon from '~/primitives/icon';
-import colors from '~/styles/colors';
-import { defaultTextInputStyles } from './text-field.primitive';
+import { cn } from '~/lib/utils';
+import {
+  formControlBaseStyles,
+  formControlFocusStyles,
+  formControlErrorStyles,
+  formControlLeadingIconStyles,
+  formLabelStyles,
+  formErrorMessageStyles,
+} from '~/primitives/inputs/form-control.styles';
 
 interface SecureTextFieldInputProps {
   className?: string;
@@ -89,16 +96,14 @@ const SecureTextFieldInput = forwardRef<
       e.preventDefault();
     };
 
-    const errorStyles = 'border-alert focus:border-alert focus:ring-alert/50';
-
     return (
       <div className='flex flex-col gap-1 w-full'>
         {label && (
-          <label className='font-bold text-text-primary mb-1'>
+          <label className={formLabelStyles}>
             {isRequired && <span className='text-ocean mr-1'>{'*'}</span>}
             {label}
             {isRequired && (
-              <span className='font-normal text-text-secondary ml-1 italic'>
+              <span className='font-normal text-navy ml-1 italic'>
                 {'(required)'}
               </span>
             )}
@@ -117,27 +122,30 @@ const SecureTextFieldInput = forwardRef<
                 ref.current = el;
               }
             }}
-            className={`${defaultTextInputStyles} ${className} pl-10 ${
-              error ? errorStyles : ''
-            }`}
+            className={cn(
+              error ? formControlErrorStyles : cn(formControlBaseStyles, formControlFocusStyles),
+              formControlLeadingIconStyles,
+              className,
+            )}
             type='text'
             value={maskedValue}
             placeholder={placeholder}
             onKeyDown={handleKeyDown}
+            onFocus={() => error && undefined}
             required={isRequired}
             inputMode='numeric'
             autoComplete='off'
           />
-          <span className='absolute left-3 top-2.5'>
+          <span className='absolute left-3 top-1/2 -translate-y-1/2'>
             <Icon name='lockAlt' className='text-navy size-5' />
           </span>
-          {error && (
-            <span className='absolute right-3 top-2.5 text-gray-500'>
-              <Icon name='errorCircle' color={colors.alert} />
-            </span>
-          )}
         </div>
-        {error && <p className='text-sm text-alert'>{error}</p>}
+        {error && (
+          <p className={formErrorMessageStyles}>
+            <Icon name='errorCircle' className='shrink-0' size={20} />
+            {error}
+          </p>
+        )}
       </div>
     );
   },

--- a/app/primitives/inputs/text-field/secure-text-field.primitive.tsx
+++ b/app/primitives/inputs/text-field/secure-text-field.primitive.tsx
@@ -33,6 +33,7 @@ const SecureTextFieldInput = forwardRef<
       value,
       error,
       setValue,
+      setError,
       placeholder = '***-**-0000',
       label,
       isRequired = false,
@@ -131,7 +132,7 @@ const SecureTextFieldInput = forwardRef<
             value={maskedValue}
             placeholder={placeholder}
             onKeyDown={handleKeyDown}
-            onFocus={() => error && undefined}
+            onFocus={() => setError(null)}
             required={isRequired}
             inputMode='numeric'
             autoComplete='off'

--- a/app/primitives/inputs/text-field/secure-text-field.primitive.tsx
+++ b/app/primitives/inputs/text-field/secure-text-field.primitive.tsx
@@ -124,7 +124,9 @@ const SecureTextFieldInput = forwardRef<
               }
             }}
             className={cn(
-              error ? formControlErrorStyles : cn(formControlBaseStyles, formControlFocusStyles),
+              error
+                ? formControlErrorStyles
+                : cn(formControlBaseStyles, formControlFocusStyles),
               formControlLeadingIconStyles,
               className,
             )}

--- a/app/primitives/inputs/text-field/secure-text-field.primitive.tsx
+++ b/app/primitives/inputs/text-field/secure-text-field.primitive.tsx
@@ -8,6 +8,7 @@ import {
   formControlLeadingIconStyles,
   formLabelStyles,
   formErrorMessageStyles,
+  formFieldWrapperStyles,
 } from '~/primitives/inputs/form-control.styles';
 
 interface SecureTextFieldInputProps {
@@ -98,7 +99,7 @@ const SecureTextFieldInput = forwardRef<
     };
 
     return (
-      <div className='flex flex-col gap-1 w-full'>
+      <div className={formFieldWrapperStyles}>
         {label && (
           <label className={formLabelStyles}>
             {isRequired && <span className='text-ocean mr-1'>{'*'}</span>}

--- a/app/primitives/inputs/text-field/text-field.primitive.tsx
+++ b/app/primitives/inputs/text-field/text-field.primitive.tsx
@@ -8,12 +8,21 @@ import React, {
   HTMLInputTypeAttribute,
   useEffect,
   useRef,
+  useState,
 } from 'react';
 import Icon from '~/primitives/icon';
-import colors from '~/styles/colors';
+import { cn } from '~/lib/utils';
+import {
+  formControlBaseStyles,
+  formControlFocusStyles,
+  formControlErrorStyles,
+  formControlLeadingIconStyles,
+  formControlTrailingIconStyles,
+  formLabelStyles,
+  formErrorMessageStyles,
+} from '~/primitives/inputs/form-control.styles';
 
-export const defaultTextInputStyles =
-  'overflow-x-hidden rounded-md border border-neutral-500 p-2 focus:border-2 focus:border-ocean focus:outline-none focus:ring-0 data-[invalid=true]:focus:border-alert w-full';
+export { defaultTextInputStyles } from '~/primitives/inputs/form-control.styles';
 
 interface TextFieldInputProps {
   name?: string;
@@ -27,6 +36,7 @@ interface TextFieldInputProps {
   label?: string;
   isRequired?: boolean;
   customIcon?: React.ReactNode;
+  isValidated?: boolean;
 }
 
 const TextFieldInput = forwardRef<HTMLInputElement, TextFieldInputProps>(
@@ -43,10 +53,12 @@ const TextFieldInput = forwardRef<HTMLInputElement, TextFieldInputProps>(
       label,
       isRequired = false,
       customIcon,
+      isValidated = false,
     },
     ref,
   ) => {
     const inputRef = useRef<HTMLInputElement>(null);
+    const [showPassword, setShowPassword] = useState(false);
 
     useEffect(() => {
       if (error === null && inputRef.current) {
@@ -54,73 +66,110 @@ const TextFieldInput = forwardRef<HTMLInputElement, TextFieldInputProps>(
       }
     }, [error]);
 
+    const hasLeadingIcon = type === 'email' || type === 'tel' || !!customIcon;
+    const isPassword = type === 'password';
+    const hasTrailingIcon = isPassword || (isValidated && !error);
+    const resolvedType = isPassword && showPassword ? 'text' : type;
+
+    const mergedRef = (el: HTMLInputElement | null) => {
+      (inputRef as React.MutableRefObject<HTMLInputElement | null>).current = el;
+      if (typeof ref === 'function') {
+        ref(el);
+      } else if (ref) {
+        ref.current = el;
+      }
+    };
+
     return (
       <div className='flex flex-col gap-1 w-full'>
         {label && (
-          <label className='font-bold text-text-primary mb-1'>
+          <label className={formLabelStyles}>
             {isRequired && <span className='text-ocean mr-1'>{'*'}</span>}
             {label}
             {isRequired && (
-              <span className='font-normal text-text-secondary ml-1 italic'>
+              <span className='font-normal text-navy ml-1 italic'>
                 {'(required)'}
               </span>
             )}
           </label>
         )}
-        {error ? (
-          <div className='relative'>
+        <div className='relative'>
+          {error ? (
             <input
               ref={ref}
-              className='w-full rounded-md border-2 border-alert p-2 pl-10'
-              type={type}
+              className={cn(
+                formControlErrorStyles,
+                hasLeadingIcon && formControlLeadingIconStyles,
+                hasTrailingIcon && formControlTrailingIconStyles,
+              )}
+              type={resolvedType}
               name={name}
               value={value}
               placeholder={placeholder}
               required={isRequired}
               onFocus={() => setError(null)}
-              readOnly
+              onChange={(e) => setValue(e.target.value)}
             />
-            <span className='absolute right-3 top-2.5 text-gray-500'>
-              <Icon name='errorCircle' color={colors.alert} />
-            </span>
-          </div>
-        ) : (
-          <div className='relative'>
+          ) : (
             <input
-              ref={(el) => {
-                (
-                  inputRef as React.MutableRefObject<HTMLInputElement | null>
-                ).current = el;
-                if (typeof ref === 'function') {
-                  ref(el);
-                } else if (ref) {
-                  ref.current = el;
-                }
-              }}
+              ref={mergedRef}
               name={name}
-              className={`${defaultTextInputStyles} ${className} ${
-                type === 'email' || type === 'tel' || customIcon ? 'pl-10' : ''
-              }`}
-              type={type}
+              className={cn(
+                formControlBaseStyles,
+                formControlFocusStyles,
+                hasLeadingIcon && formControlLeadingIconStyles,
+                hasTrailingIcon && formControlTrailingIconStyles,
+                className,
+              )}
+              type={resolvedType}
               value={value}
               placeholder={placeholder}
               onChange={(e) => setValue(e.target.value)}
               required={isRequired}
             />
-            {type === 'email' && (
-              <span className='absolute left-3 top-2.5'>
-                <Icon name='envelope' className='text-navy size-5 mt-[1px]' />
-              </span>
-            )}
-            {type === 'tel' && (
-              <span className='absolute left-3 top-2.5'>
-                <Icon name='smartphone' className='text-navy size-5' />
-              </span>
-            )}
-            {customIcon && (
-              <span className='absolute left-3 top-2.5'>{customIcon}</span>
-            )}
-          </div>
+          )}
+          {/* Leading icons */}
+          {type === 'email' && (
+            <span className='absolute left-3 top-1/2 -translate-y-1/2'>
+              <Icon name='envelope' className='text-navy size-5 mt-[1px]' />
+            </span>
+          )}
+          {type === 'tel' && (
+            <span className='absolute left-3 top-1/2 -translate-y-1/2'>
+              <Icon name='smartphone' className='text-navy size-5' />
+            </span>
+          )}
+          {customIcon && (
+            <span className='absolute left-3 top-1/2 -translate-y-1/2'>
+              {customIcon}
+            </span>
+          )}
+          {/* Trailing icons */}
+          {isPassword && (
+            <button
+              type='button'
+              className='absolute right-3 top-1/2 -translate-y-1/2'
+              onClick={() => setShowPassword((prev) => !prev)}
+              tabIndex={-1}
+              aria-label={showPassword ? 'Hide password' : 'Show password'}
+            >
+              <Icon
+                name={showPassword ? 'eyeSlash' : 'eye'}
+                className='text-navy size-5'
+              />
+            </button>
+          )}
+          {!isPassword && isValidated && !error && (
+            <span className='absolute right-3 top-1/2 -translate-y-1/2'>
+              <Icon name='checkCircle' className='text-success size-5' />
+            </span>
+          )}
+        </div>
+        {error && (
+          <p className={formErrorMessageStyles}>
+            <Icon name='errorCircle' className='shrink-0' size={20} />
+            {error}
+          </p>
         )}
       </div>
     );

--- a/app/primitives/inputs/text-field/text-field.primitive.tsx
+++ b/app/primitives/inputs/text-field/text-field.primitive.tsx
@@ -72,7 +72,8 @@ const TextFieldInput = forwardRef<HTMLInputElement, TextFieldInputProps>(
     const resolvedType = isPassword && showPassword ? 'text' : type;
 
     const mergedRef = (el: HTMLInputElement | null) => {
-      (inputRef as React.MutableRefObject<HTMLInputElement | null>).current = el;
+      (inputRef as React.MutableRefObject<HTMLInputElement | null>).current =
+        el;
       if (typeof ref === 'function') {
         ref(el);
       } else if (ref) {

--- a/app/primitives/inputs/text-field/text-field.primitive.tsx
+++ b/app/primitives/inputs/text-field/text-field.primitive.tsx
@@ -96,7 +96,7 @@ const TextFieldInput = forwardRef<HTMLInputElement, TextFieldInputProps>(
         <div className='relative'>
           {error ? (
             <input
-              ref={ref}
+              ref={mergedRef}
               className={cn(
                 formControlErrorStyles,
                 hasLeadingIcon && formControlLeadingIconStyles,

--- a/app/primitives/inputs/text-field/text-field.primitive.tsx
+++ b/app/primitives/inputs/text-field/text-field.primitive.tsx
@@ -20,6 +20,7 @@ import {
   formControlTrailingIconStyles,
   formLabelStyles,
   formErrorMessageStyles,
+  formFieldWrapperStyles,
 } from '~/primitives/inputs/form-control.styles';
 
 export { defaultTextInputStyles } from '~/primitives/inputs/form-control.styles';
@@ -82,7 +83,7 @@ const TextFieldInput = forwardRef<HTMLInputElement, TextFieldInputProps>(
     };
 
     return (
-      <div className='flex flex-col gap-1 w-full'>
+      <div className={formFieldWrapperStyles}>
         {label && (
           <label className={formLabelStyles}>
             {isRequired && <span className='text-ocean mr-1'>{'*'}</span>}

--- a/app/primitives/inputs/textarea/__tests__/index.test.tsx
+++ b/app/primitives/inputs/textarea/__tests__/index.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import TextareaInput from '../textarea.primitive';
+
+describe('TextareaInput', () => {
+  it('renders a textarea element', () => {
+    render(
+      <TextareaInput
+        value=''
+        error={null}
+        setValue={vi.fn()}
+        setError={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+    expect(screen.getByRole('textbox').tagName).toBe('TEXTAREA');
+  });
+
+  it('error state: error message shown below the textarea', () => {
+    render(
+      <TextareaInput
+        value=''
+        error='This field is required'
+        setValue={vi.fn()}
+        setError={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('This field is required')).toBeInTheDocument();
+  });
+
+  it('helperText prop: helper text is shown', () => {
+    render(
+      <TextareaInput
+        value=''
+        error={null}
+        setValue={vi.fn()}
+        setError={vi.fn()}
+        helperText='Max 500 characters'
+      />,
+    );
+    expect(screen.getByText('Max 500 characters')).toBeInTheDocument();
+  });
+
+  it('has min-h-[120px] class', () => {
+    render(
+      <TextareaInput
+        value=''
+        error={null}
+        setValue={vi.fn()}
+        setError={vi.fn()}
+      />,
+    );
+    const textarea = screen.getByRole('textbox');
+    expect(textarea.className).toContain('min-h-[120px]');
+  });
+});

--- a/app/primitives/inputs/textarea/index.ts
+++ b/app/primitives/inputs/textarea/index.ts
@@ -1,0 +1,2 @@
+import TextareaInput from './textarea.primitive';
+export default TextareaInput;

--- a/app/primitives/inputs/textarea/textarea.primitive.tsx
+++ b/app/primitives/inputs/textarea/textarea.primitive.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useEffect, useRef } from 'react';
+import React, { forwardRef } from 'react';
 import Icon from '~/primitives/icon';
 import { cn } from '~/lib/utils';
 import {
@@ -9,22 +9,20 @@ import {
   formErrorMessageStyles,
 } from '~/primitives/inputs/form-control.styles';
 
-export { defaultDateInputStyles } from '~/primitives/inputs/form-control.styles';
-
-interface DateInputProps {
+interface TextareaInputProps {
   name?: string;
   className?: string;
   value: string;
   error: string | null;
   setValue: (value: string) => void;
   setError: (value: string | null) => void;
+  placeholder?: string;
   label?: string;
   isRequired?: boolean;
-  min?: string;
-  max?: string;
+  rows?: number;
 }
 
-const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
+const TextareaInput = forwardRef<HTMLTextAreaElement, TextareaInputProps>(
   (
     {
       name,
@@ -33,30 +31,13 @@ const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
       error,
       setValue,
       setError,
+      placeholder = '',
       label,
       isRequired = false,
-      min,
-      max,
+      rows,
     },
     ref,
   ) => {
-    const inputRef = useRef<HTMLInputElement>(null);
-
-    useEffect(() => {
-      if (error === null && inputRef.current) {
-        inputRef.current.focus();
-      }
-    }, [error]);
-
-    const mergedRef = (el: HTMLInputElement | null) => {
-      (inputRef as React.MutableRefObject<HTMLInputElement | null>).current = el;
-      if (typeof ref === 'function') {
-        ref(el);
-      } else if (ref) {
-        ref.current = el;
-      }
-    };
-
     return (
       <div className='flex flex-col gap-1 w-full'>
         {label && (
@@ -71,29 +52,32 @@ const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
           </label>
         )}
         {error ? (
-          <input
+          <textarea
             ref={ref}
             name={name}
-            className={formControlErrorStyles}
-            type='date'
+            className={cn(formControlErrorStyles, 'min-h-[120px] h-auto')}
             value={value}
+            placeholder={placeholder}
             onFocus={() => setError(null)}
             onChange={(e) => setValue(e.target.value)}
             required={isRequired}
-            min={min}
-            max={max}
+            rows={rows}
           />
         ) : (
-          <input
-            ref={mergedRef}
+          <textarea
+            ref={ref}
             name={name}
-            className={cn(formControlBaseStyles, formControlFocusStyles, className)}
-            type='date'
+            className={cn(
+              formControlBaseStyles,
+              formControlFocusStyles,
+              'min-h-[120px] h-auto',
+              className,
+            )}
             value={value}
+            placeholder={placeholder}
             onChange={(e) => setValue(e.target.value)}
             required={isRequired}
-            min={min}
-            max={max}
+            rows={rows}
           />
         )}
         {error && (
@@ -107,6 +91,6 @@ const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
   },
 );
 
-DateInput.displayName = 'DateInput';
+TextareaInput.displayName = 'TextareaInput';
 
-export default DateInput;
+export default TextareaInput;

--- a/app/primitives/inputs/textarea/textarea.primitive.tsx
+++ b/app/primitives/inputs/textarea/textarea.primitive.tsx
@@ -6,6 +6,7 @@ import {
   formControlFocusStyles,
   formControlErrorStyles,
   formLabelStyles,
+  formHelperTextStyles,
   formErrorMessageStyles,
 } from '~/primitives/inputs/form-control.styles';
 
@@ -20,6 +21,7 @@ interface TextareaInputProps {
   label?: string;
   isRequired?: boolean;
   rows?: number;
+  helperText?: string;
 }
 
 const TextareaInput = forwardRef<HTMLTextAreaElement, TextareaInputProps>(
@@ -35,6 +37,7 @@ const TextareaInput = forwardRef<HTMLTextAreaElement, TextareaInputProps>(
       label,
       isRequired = false,
       rows,
+      helperText,
     },
     ref,
   ) => {
@@ -80,6 +83,7 @@ const TextareaInput = forwardRef<HTMLTextAreaElement, TextareaInputProps>(
             rows={rows}
           />
         )}
+        {helperText && <p className={formHelperTextStyles}>{helperText}</p>}
         {error && (
           <p className={formErrorMessageStyles}>
             <Icon name='errorCircle' className='shrink-0' size={20} />

--- a/app/primitives/inputs/textarea/textarea.primitive.tsx
+++ b/app/primitives/inputs/textarea/textarea.primitive.tsx
@@ -8,6 +8,7 @@ import {
   formLabelStyles,
   formHelperTextStyles,
   formErrorMessageStyles,
+  formFieldWrapperStyles,
 } from '~/primitives/inputs/form-control.styles';
 
 interface TextareaInputProps {
@@ -42,7 +43,7 @@ const TextareaInput = forwardRef<HTMLTextAreaElement, TextareaInputProps>(
     ref,
   ) => {
     return (
-      <div className='flex flex-col gap-1 w-full'>
+      <div className={formFieldWrapperStyles}>
         {label && (
           <label className={formLabelStyles}>
             {isRequired && <span className='text-ocean mr-1'>{'*'}</span>}

--- a/app/routes/volunteer-form/partials/form-interests.partial.tsx
+++ b/app/routes/volunteer-form/partials/form-interests.partial.tsx
@@ -3,7 +3,10 @@ import { INTERESTS, STRENGTHS, VolunteerFormInterests } from '../types';
 import { Button } from '~/primitives/button/button.primitive';
 import Slider from '~/primitives/inputs/slider/slider.primitive';
 import { Checkbox } from '~/primitives/inputs/checkbox/checkbox.primitive';
-import { defaultTextInputStyles } from '~/primitives/inputs/text-field/text-field.primitive';
+import {
+  formControlBaseStyles,
+  formControlFocusStyles,
+} from '~/primitives/inputs/form-control.styles';
 import SecureTextField from '~/primitives/inputs/text-field/secure-text-field.primitive';
 import { Form, useActionData } from 'react-router-dom';
 
@@ -121,7 +124,7 @@ export const VolunteerFormInterestsPartial: React.FC<Props> = ({
         <label className='font-bold'>What are you passionate about?</label>
         <textarea
           name='comments'
-          className={defaultTextInputStyles}
+          className={`${formControlBaseStyles} ${formControlFocusStyles} min-h-[120px] h-auto`}
           value={formData.comments}
           rows={5}
           onChange={(e) => handleChange('comments', e.target.value)}

--- a/app/routes/volunteer/outreach-opportunity/components/signup-form.component.tsx
+++ b/app/routes/volunteer/outreach-opportunity/components/signup-form.component.tsx
@@ -62,7 +62,7 @@ const SignupForm: React.FC<SignupFormProps> = ({
     >
       <input type='hidden' name='groupGuid' value={groupGuid} />
 
-      <Form.Field name='firstName' className='flex flex-col'>
+      <Form.Field name='firstName' className='flex flex-col group'>
         <Form.Label className={formLabelStyles}>First Name*</Form.Label>
         <Form.Control asChild>
           <input
@@ -76,7 +76,7 @@ const SignupForm: React.FC<SignupFormProps> = ({
         </Form.Message>
       </Form.Field>
 
-      <Form.Field name='lastName' className='flex flex-col'>
+      <Form.Field name='lastName' className='flex flex-col group'>
         <Form.Label className={formLabelStyles}>Last Name*</Form.Label>
         <Form.Control asChild>
           <input
@@ -90,7 +90,7 @@ const SignupForm: React.FC<SignupFormProps> = ({
         </Form.Message>
       </Form.Field>
 
-      <Form.Field name='phoneNumber' className='flex flex-col'>
+      <Form.Field name='phoneNumber' className='flex flex-col group'>
         <Form.Label className={formLabelStyles}>Cell Phone*</Form.Label>
         <Form.Control asChild>
           <input
@@ -104,7 +104,7 @@ const SignupForm: React.FC<SignupFormProps> = ({
         </Form.Message>
       </Form.Field>
 
-      <Form.Field name='email' className='flex flex-col'>
+      <Form.Field name='email' className='flex flex-col group'>
         <Form.Label className={formLabelStyles}>Email*</Form.Label>
         <Form.Control asChild>
           <input
@@ -121,7 +121,7 @@ const SignupForm: React.FC<SignupFormProps> = ({
         </Form.Message>
       </Form.Field>
 
-      <Form.Field name='birthdate' className='flex flex-col'>
+      <Form.Field name='birthdate' className='flex flex-col group'>
         <Form.Label className={formLabelStyles}>Birthdate*</Form.Label>
         <Form.Control asChild>
           <input
@@ -136,7 +136,7 @@ const SignupForm: React.FC<SignupFormProps> = ({
         </Form.Message>
       </Form.Field>
 
-      <Form.Field name='campus' className='flex flex-col'>
+      <Form.Field name='campus' className='flex flex-col group'>
         <Form.Label className={formLabelStyles}>Campus*</Form.Label>
         <Form.Control asChild>
           <select
@@ -165,7 +165,7 @@ const SignupForm: React.FC<SignupFormProps> = ({
 
       <Form.Field
         name='waiverAccepted'
-        className='flex flex-col gap-2 md:col-span-2 my-1 md:my-4'
+        className='flex flex-col gap-2 md:col-span-2 my-1 md:my-4 group'
       >
         <label className='flex items-center gap-3 cursor-pointer select-none'>
           <Form.Control asChild>

--- a/app/routes/volunteer/outreach-opportunity/components/signup-form.component.tsx
+++ b/app/routes/volunteer/outreach-opportunity/components/signup-form.component.tsx
@@ -3,7 +3,14 @@ import { useEffect, useState } from 'react';
 import { useFetcher } from 'react-router';
 
 import { Button } from '~/primitives/button/button.primitive';
-import { defaultTextInputStyles } from '~/primitives/inputs/text-field/text-field.primitive';
+import {
+  formControlBaseStyles,
+  formControlFocusStyles,
+  formErrorMessageStyles,
+  formLabelStyles,
+  nativeCheckboxStyles,
+} from '~/primitives/inputs/form-control.styles';
+import { cn } from '~/lib/utils';
 import { pushFormEvent } from '~/lib/gtm';
 import { RockCampuses } from '~/lib/rock-config';
 
@@ -56,69 +63,89 @@ const SignupForm: React.FC<SignupFormProps> = ({
       <input type='hidden' name='groupGuid' value={groupGuid} />
 
       <Form.Field name='firstName' className='flex flex-col'>
-        <Form.Label className='font-bold text-sm mb-1'>First Name*</Form.Label>
+        <Form.Label className={formLabelStyles}>First Name*</Form.Label>
         <Form.Control asChild>
-          <input type='text' required className={defaultTextInputStyles} />
+          <input
+            type='text'
+            required
+            className={cn(formControlBaseStyles, formControlFocusStyles)}
+          />
         </Form.Control>
-        <Form.Message className='text-alert text-sm' match='valueMissing'>
+        <Form.Message className={formErrorMessageStyles} match='valueMissing'>
           Please enter your first name
         </Form.Message>
       </Form.Field>
 
       <Form.Field name='lastName' className='flex flex-col'>
-        <Form.Label className='font-bold text-sm mb-1'>Last Name*</Form.Label>
+        <Form.Label className={formLabelStyles}>Last Name*</Form.Label>
         <Form.Control asChild>
-          <input type='text' required className={defaultTextInputStyles} />
+          <input
+            type='text'
+            required
+            className={cn(formControlBaseStyles, formControlFocusStyles)}
+          />
         </Form.Control>
-        <Form.Message className='text-alert text-sm' match='valueMissing'>
+        <Form.Message className={formErrorMessageStyles} match='valueMissing'>
           Please enter your last name
         </Form.Message>
       </Form.Field>
 
       <Form.Field name='phoneNumber' className='flex flex-col'>
-        <Form.Label className='font-bold text-sm mb-1'>Cell Phone*</Form.Label>
+        <Form.Label className={formLabelStyles}>Cell Phone*</Form.Label>
         <Form.Control asChild>
-          <input type='tel' required className={defaultTextInputStyles} />
+          <input
+            type='tel'
+            required
+            className={cn(formControlBaseStyles, formControlFocusStyles)}
+          />
         </Form.Control>
-        <Form.Message className='text-alert text-sm' match='valueMissing'>
+        <Form.Message className={formErrorMessageStyles} match='valueMissing'>
           Please enter your phone number
         </Form.Message>
       </Form.Field>
 
       <Form.Field name='email' className='flex flex-col'>
-        <Form.Label className='font-bold text-sm mb-1'>Email*</Form.Label>
+        <Form.Label className={formLabelStyles}>Email*</Form.Label>
         <Form.Control asChild>
-          <input type='email' required className={defaultTextInputStyles} />
+          <input
+            type='email'
+            required
+            className={cn(formControlBaseStyles, formControlFocusStyles)}
+          />
         </Form.Control>
-        <Form.Message className='text-alert text-sm' match='valueMissing'>
+        <Form.Message className={formErrorMessageStyles} match='valueMissing'>
           Please enter your email
         </Form.Message>
-        <Form.Message className='text-alert text-sm' match='typeMismatch'>
+        <Form.Message className={formErrorMessageStyles} match='typeMismatch'>
           Please enter a valid email
         </Form.Message>
       </Form.Field>
 
       <Form.Field name='birthdate' className='flex flex-col'>
-        <Form.Label className='font-bold text-sm mb-1'>Birthdate*</Form.Label>
+        <Form.Label className={formLabelStyles}>Birthdate*</Form.Label>
         <Form.Control asChild>
           <input
             type='date'
             required
             max={new Date().toISOString().slice(0, 10)}
-            className={defaultTextInputStyles}
+            className={cn(formControlBaseStyles, formControlFocusStyles)}
           />
         </Form.Control>
-        <Form.Message className='text-alert text-sm' match='valueMissing'>
+        <Form.Message className={formErrorMessageStyles} match='valueMissing'>
           Please enter your birthdate
         </Form.Message>
       </Form.Field>
 
       <Form.Field name='campus' className='flex flex-col'>
-        <Form.Label className='font-bold text-sm mb-1'>Campus*</Form.Label>
+        <Form.Label className={formLabelStyles}>Campus*</Form.Label>
         <Form.Control asChild>
           <select
             required
-            className={`appearance-none ${defaultTextInputStyles}`}
+            className={cn(
+              'appearance-none',
+              formControlBaseStyles,
+              formControlFocusStyles,
+            )}
             defaultValue=''
           >
             <option value='' disabled>
@@ -131,7 +158,7 @@ const SignupForm: React.FC<SignupFormProps> = ({
             ))}
           </select>
         </Form.Control>
-        <Form.Message className='text-alert text-sm' match='valueMissing'>
+        <Form.Message className={formErrorMessageStyles} match='valueMissing'>
           Please select your home campus
         </Form.Message>
       </Form.Field>
@@ -146,7 +173,7 @@ const SignupForm: React.FC<SignupFormProps> = ({
               type='checkbox'
               required
               value='true'
-              className='h-5 w-5 shrink-0 rounded border border-ocean accent-ocean'
+              className={cn('shrink-0', nativeCheckboxStyles)}
             />
           </Form.Control>
           <span className='text-sm'>
@@ -163,7 +190,7 @@ const SignupForm: React.FC<SignupFormProps> = ({
             *
           </span>
         </label>
-        <Form.Message className='text-alert text-sm' match='valueMissing'>
+        <Form.Message className={formErrorMessageStyles} match='valueMissing'>
           You must accept the waiver to sign up.
         </Form.Message>
       </Form.Field>

--- a/app/routes/yes/partials/yes-about-you.partial.tsx
+++ b/app/routes/yes/partials/yes-about-you.partial.tsx
@@ -4,7 +4,7 @@ import { useFetcher, useNavigate } from 'react-router-dom';
 import { Button } from '~/primitives/button/button.primitive';
 import TextFieldInput from '~/primitives/inputs/text-field';
 import DateInput from '~/primitives/inputs/date-input/date-input.primitive';
-import { defaultTextInputStyles } from '~/primitives/inputs/text-field/text-field.primitive';
+import { defaultSelectInputStyles } from '~/primitives/inputs/form-control.styles';
 import { YesFormPersonalInfo } from '../types';
 import { ConnectCardLoaderReturnType } from '~/routes/connect-card/types';
 
@@ -178,7 +178,7 @@ const YesFormPersonalInfoPartial: React.FC<Props> = ({ data, isSpanish }) => {
           {campuses && campuses.length > 0 && (
             <select
               name='campus'
-              className={`appearance-none ${defaultTextInputStyles}`}
+              className={`appearance-none ${defaultSelectInputStyles}`}
               required
               style={{
                 backgroundImage: `url('/assets/icons/chevron-down.svg')`,

--- a/app/styles/tailwind.css
+++ b/app/styles/tailwind.css
@@ -84,6 +84,9 @@
   --color-neutral-darker: #222222;
   --color-neutral-darkest: #111111;
 
+  /* Form */
+  --color-form-stroke-muted: #d1d5db;
+
   /* Semantic – background */
   --color-background-primary: var(--color-white);
   --color-background-secondary: var(--color-soft-white);

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -46,6 +46,7 @@ export default [
         HTMLInputElement: 'readonly',
         HTMLButtonElement: 'readonly',
         HTMLSelectElement: 'readonly',
+        HTMLTextAreaElement: 'readonly',
         HTMLSpanElement: 'readonly',
         HTMLFormElement: 'readonly',
         HTMLImageElement: 'readonly',


### PR DESCRIPTION
## Summary

Implements CFDP-4010 — updates all submission forms to match Web 3.0 Figma form component specs by centralizing style tokens and migrating every in-scope form.

- Created `app/primitives/inputs/form-control.styles.ts` as a single source of truth for all form control tokens (height, radius, padding, colors, label/error/helper typography, native checkbox/radio styles)
- Updated all input primitives (`TextFieldInput`, `SelectInput`, `DateInput`, `SecureTextField`) and added a new `TextareaInput` primitive; updated `Checkbox` and `RadioButtons` with Figma error/disabled/name states
- Migrated all 8 Radix modal forms (contact, connect card, prayer request, newsletter, journey finder, set a reminder, group connect, outreach signup) and all route/auth forms (volunteer partials, Yes about-you, login/signup/account creation/password screens) to shared tokens

## Screenshots

[Paste your screenshots here]

## Testing

- [x] 131/131 tests passing (`pnpm test --run`)
- [x] TypeScript typecheck passes (`pnpm typecheck`)
- [x] Lint passes (`pnpm lint`)
- [x] Format check passes (`pnpm format:check`)
- [ ] Visual QA of: Auth login + account creation/password
- [ ] Ensure `Contact Us` form looks as expected and submits correctly.
- [ ] Ensure `Connect Card` form looks as expected and submits correctly.
- [ ] Ensure `Prayer Request` form looks as expected and submits correctly.
- [ ] Ensure `Newsletter` form looks as expected and submits correctly.
- [ ]  Ensure `Volunteer about-you` form looks as expected and submits correctly.

## Tickets

[CFDP-4010](https://christfellowshipchurch.atlassian.net/browse/CFDP-4010)

## Changes Made

### New Components Added

- `app/primitives/inputs/textarea/textarea.primitive.tsx` — new `TextareaInput` primitive mirroring `TextFieldInput` API with `min-h-[120px]`
- `app/primitives/inputs/textarea/index.ts` — barrel export

### New Utilities

- `app/primitives/inputs/form-control.styles.ts` — shared form token exports: `formControlBaseStyles`, `formControlFocusStyles`, `formControlErrorStyles`, `formControlDisabledStyles`, `formLabelStyles`, `formHelperTextStyles`, `formErrorMessageStyles`, `nativeCheckboxStyles`, `nativeRadioStyles`, `formCheckboxGroupStyles`, `formRadioGroupStyles`, plus back-compat `defaultTextInputStyles` / `defaultSelectInputStyles` / `defaultDateInputStyles`

### New Assets

N/A

### Dependencies

None

### Route Implementation

No new routes. Updated partials:
- `app/routes/volunteer-form/partials/form-interests.partial.tsx`
- `app/routes/yes/partials/yes-about-you.partial.tsx`

### Key Features

- Figma-spec control surface: `h-[46px]` default / `h-[48px]` focused+error, `rounded-[10px]`, `px-4 py-2.5`, `bg-gray` fill, `border-dark-navy/10` default stroke, `border-ocean` focus stroke with shadow, `border-alert` error stroke
- `formLabelStyles`: `text-[20px] leading-5 text-dark-navy font-bold` across all forms
- Error messages rendered below fields (not inline) with icon + `formErrorMessageStyles`
- Password show/hide toggle added to `TextFieldInput` when `type='password'`
- `isValidated` prop on `TextFieldInput` shows trailing success icon
- `Checkbox`: new `error`, `disabled`, `id` props; `gap-2` group spacing
- `RadioButtons`: configurable `name` prop (was hardcoded `'option'`), `error` and `disabled` props, `gap-2.5` vertical spacing
- Journey-finder local style override (`bg-[#f4f5f7] border-transparent`) removed
- `--color-form-stroke-muted: #d1d5db` added to Tailwind theme
- All back-compat re-exports preserved — no breaking changes to existing import paths

[CFDP-4010]: https://christfellowshipchurch.atlassian.net/browse/CFDP-4010?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ