### PR TITLE
Fixing OG Meta Type & Sharing

### DIFF
--- a/app/components/modals/help-me-find-a-group/__tests__/help-me-find-a-group-form.test.tsx
+++ b/app/components/modals/help-me-find-a-group/__tests__/help-me-find-a-group-form.test.tsx
@@ -158,7 +158,9 @@ describe('HelpMeFindAGroupForm', () => {
     fireEvent.click(screen.getByLabelText('In Person'));
     fireEvent.click(screen.getByRole('button', { name: /submit/i }));
 
-    expect(screen.getByText('Please select at least one area.')).toBeInTheDocument();
+    expect(
+      screen.getByText('Please select at least one area.'),
+    ).toBeInTheDocument();
     expect(mockSubmit).not.toHaveBeenCalled();
   });
 

--- a/app/components/resource-carousel/index.tsx
+++ b/app/components/resource-carousel/index.tsx
@@ -78,7 +78,7 @@ export const CardCarouselSection = ({
                   href={viewMoreLink}
                   size='md'
                   className={cn(
-                    'hidden md:block min-w-32 w-fit',
+                    'hidden md:block min-w-32 w-fit whitespace-nowrap',
                     mode === 'dark' &&
                       'text-white border-white hover:bg-white/10!',
                     viewMoreStyles,
@@ -106,6 +106,7 @@ export const CardCarouselSection = ({
                   href={viewMoreLink}
                   size='md'
                   className={cn(
+                    'whitespace-nowrap',
                     mode === 'dark' && 'text-white border-white',
                     viewMoreStyles,
                   )}

--- a/app/lib/meta-utils.ts
+++ b/app/lib/meta-utils.ts
@@ -45,6 +45,8 @@ export type CreateMetaOptions = {
   license?: string;
   /** Author name for meta author, article:author, and twitter:creator. */
   author?: string;
+  /** og:type value. Defaults to 'website'. Use 'article' for article pages. */
+  type?: 'website' | 'article';
 };
 
 type MetaDescriptor =
@@ -66,6 +68,7 @@ export function createMeta({
   generator,
   license,
   author,
+  type,
 }: CreateMetaOptions): MetaDescriptor[] {
   const fullTitle = title.includes(SITE_NAME)
     ? title
@@ -82,7 +85,7 @@ export function createMeta({
     { name: 'application-name', content: SITE_NAME },
     { property: 'og:title', content: fullTitle },
     { property: 'og:description', content: description },
-    { property: 'og:type', content: 'website' },
+    { property: 'og:type', content: type ?? 'website' },
     { property: 'og:site_name', content: SITE_NAME },
     { property: 'og:image', content: ogImage },
     { name: 'twitter:card', content: 'summary_large_image' },

--- a/app/routes/articles/article-single/loader.ts
+++ b/app/routes/articles/article-single/loader.ts
@@ -68,8 +68,9 @@ const fetchArticleData = async (articlePath: string) => {
   }
 };
 
-export const loader: LoaderFunction = async ({ params }) => {
+export const loader: LoaderFunction = async ({ params, request }) => {
   const articlePath = params?.path || '';
+  const origin = new URL(request.url).origin;
 
   const articleData = await fetchArticleData(articlePath);
   if (!articleData) {
@@ -120,7 +121,7 @@ export const loader: LoaderFunction = async ({ params }) => {
   const pageData: LoaderReturnType = {
     ALGOLIA_APP_ID: process.env.ALGOLIA_APP_ID || '',
     ALGOLIA_SEARCH_API_KEY: process.env.ALGOLIA_SEARCH_API_KEY || '',
-    hostUrl: process.env.HOST_URL || 'host-url-not-found',
+    hostUrl: origin,
     title,
     id: articleData.id,
     content,

--- a/app/routes/articles/article-single/meta.ts
+++ b/app/routes/articles/article-single/meta.ts
@@ -26,5 +26,6 @@ export const meta: MetaFunction<typeof loader> = ({ data, location }) => {
     path: location.pathname,
     keywords,
     author: articleData.author?.fullName?.trim() || undefined,
+    type: 'article',
   });
 };

--- a/app/routes/articles/article-single/partials/related-articles.partial.tsx
+++ b/app/routes/articles/article-single/partials/related-articles.partial.tsx
@@ -32,12 +32,18 @@ export function RelatedArticles() {
         filters={`contentType:"Article" AND articlePrimaryCategories:"${articlePrimaryCategories[0]}" AND rockItemId != ${id}`}
         hitsPerPage={6}
       />
-      <CardCarouselSectionWrapper />
+      <CardCarouselSectionWrapper
+        articlePrimaryCategories={articlePrimaryCategories}
+      />
     </InstantSearch>
   );
 }
 
-const CardCarouselSectionWrapper = () => {
+const CardCarouselSectionWrapper = ({
+  articlePrimaryCategories,
+}: {
+  articlePrimaryCategories: string[];
+}) => {
   const { items } = useHits<ContentItemHit>();
 
   if (items.length === 0) {
@@ -76,7 +82,7 @@ const CardCarouselSectionWrapper = () => {
         },
       }))}
       viewMoreText='More Articles'
-      viewMoreLink={`/articles`}
+      viewMoreLink={`/articles?articlePrimaryCategories=${articlePrimaryCategories[0]}`}
       CardComponent={RelatedArticleCardWrapper}
     />
   );

--- a/app/routes/messages/message-single/loader.ts
+++ b/app/routes/messages/message-single/loader.ts
@@ -200,8 +200,10 @@ const fetchSpeakerData = async (guid: string) => {
 
 export const loader: LoaderFunction = async ({
   params,
+  request,
 }): Promise<LoaderReturnType> => {
   const path = params?.path || '';
+  const origin = new URL(request.url).origin;
 
   const messageData = await fetchMessageByPath(path);
 
@@ -218,6 +220,6 @@ export const loader: LoaderFunction = async ({
     message,
     ALGOLIA_APP_ID: process.env.ALGOLIA_APP_ID,
     ALGOLIA_SEARCH_API_KEY: process.env.ALGOLIA_SEARCH_API_KEY,
-    hostUrl: process.env.HOST_URL || 'host-url-not-found',
+    hostUrl: origin,
   };
 };

--- a/app/routes/podcasts/podcast-show/meta.ts
+++ b/app/routes/podcasts/podcast-show/meta.ts
@@ -2,7 +2,7 @@ import type { MetaFunction } from 'react-router-dom';
 import type { loader } from './loader';
 import { createMeta } from '~/lib/meta-utils';
 
-export const meta: MetaFunction<typeof loader> = ({ data }) => {
+export const meta: MetaFunction<typeof loader> = ({ data, location }) => {
   if (!data?.podcast) {
     return createMeta({
       title: 'Podcast Not Found',
@@ -22,5 +22,6 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
     title: metaTitle,
     description,
     image: podcast.coverImage,
+    path: location.pathname,
   });
 };

--- a/app/routes/series-resources/meta.ts
+++ b/app/routes/series-resources/meta.ts
@@ -2,7 +2,7 @@ import type { MetaFunction } from 'react-router-dom';
 import type { loader } from './loader';
 import { createMeta } from '~/lib/meta-utils';
 
-export const meta: MetaFunction<typeof loader> = ({ data }) => {
+export const meta: MetaFunction<typeof loader> = ({ data, location }) => {
   if (!data?.series) {
     return createMeta({
       title: 'Series Resources',
@@ -16,6 +16,7 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
     description:
       data.series.description ??
       `Messages, resources, and events for ${seriesName} at Christ Fellowship Church.`,
-    path: '/series-resources',
+    image: data.series.attributeValues.coverImage || undefined,
+    path: location.pathname,
   });
 };


### PR DESCRIPTION
## Summary

Add an optional `type` option to `createMeta()` (defaults to `'website'`) and wire it to the `og:type` meta tag. Pass `type: 'article'` on article pages to unlock richer Facebook previews and validate the existing `article:author` tag. Also fix `og:url` / canonical path coverage on podcast show and series-resources pages, and surface the series cover image as the OG image when available.

## Screenshots
|Before|After|
|-|-|
|<img width="1555" height="774" alt="Screenshot 2026-06-09 at 9 29 59 AM" src="https://github.com/user-attachments/assets/66f2ed14-c2c5-48fc-b11e-ca1c2d000b14" />|<img width="1507" height="874" alt="Screenshot 2026-06-09 at 9 56 46 AM" src="https://github.com/user-attachments/assets/5fe63a79-d5e8-4dc4-9a48-b2958bae8818" />|

## Testing

- [x] Open an [article page](https://remix-web-app-git-og-meta-tags-christ-fellowship-church.vercel.app/articles/ancient-truths-for-modern-questions), inspect `<head>` — confirm `og:type` is `article` and `article:author` is present
- [x] Ensure there is no wrapping on the "More Articles" button, and that the button links to the Articles finder with a category filtered.
- [x] Open a podcast show page, inspect `<head>` — confirm `og:url` and `<link rel="canonical">` reflect the correct URL
- [x] Open a series-resources page, inspect `<head>` — confirm `og:image` shows the series cover and `og:url` is correct
- [x] Try the sharing links in an article, they should all now share the Article correctly (only x was fully working before)
- [x] No new linter warnings or errors

## Tickets

[CFDP-4017](https://christfellowshipchurch.atlassian.net/browse/CFDP-4017)

## Changes Made

### New Utilities

- `app/lib/meta-utils.ts` — added optional `type?: 'website' | 'article'` field to `CreateMetaOptions`; `og:type` now uses it instead of the hardcoded `'website'` string

### Route Implementation

- `app/routes/articles/article-single/meta.ts` — pass `type: 'article'` to `createMeta()`; enables richer OG previews on Facebook and makes `article:author` semantically valid
- `app/routes/podcasts/podcast-show/meta.ts` — add `path: location.pathname` so `og:url` and the canonical link tag are generated for podcast show pages
- `app/routes/series-resources/meta.ts` — add `image: data.series.attributeValues.coverImage` for a series-specific OG image; replace hardcoded `/series-resources` path with `location.pathname` so each series page gets its own `og:url`

[CFDP-4017]: https://christfellowshipchurch.atlassian.net/browse/CFDP-4017?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ