### PR TITLE
Add Help Me Find a Group form

### DIFF
--- a/app/components/modals/help-me-find-a-group/__tests__/help-me-find-a-group-form.test.tsx
+++ b/app/components/modals/help-me-find-a-group/__tests__/help-me-find-a-group-form.test.tsx
@@ -1,0 +1,194 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { pushFormEvent } from '~/lib/gtm';
+import HelpMeFindAGroupForm from '../help-me-find-a-group-form.component';
+
+vi.mock('~/lib/gtm', () => ({ pushFormEvent: vi.fn() }));
+
+let mockFetcherState = {
+  state: 'idle' as 'idle' | 'submitting' | 'loading',
+  data: undefined as unknown,
+};
+const mockLoad = vi.fn();
+const mockSubmit = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual =
+    await vi.importActual<typeof import('react-router-dom')>(
+      'react-router-dom',
+    );
+  return {
+    ...actual,
+    useFetcher: () => ({
+      state: mockFetcherState.state,
+      data: mockFetcherState.data,
+      load: mockLoad,
+      submit: mockSubmit,
+    }),
+  };
+});
+
+const mockCampuses = [
+  { guid: 'campus-guid-1', name: 'Palm Beach Gardens' },
+  { guid: 'campus-guid-2', name: 'Stuart' },
+];
+
+const mockHubs = [
+  { guid: 'hub-guid-1', value: 'Crew (Men)' },
+  { guid: 'hub-guid-2', value: 'Sisterhood' },
+];
+
+function renderForm(onSuccess = vi.fn()) {
+  return render(
+    <MemoryRouter>
+      <HelpMeFindAGroupForm onSuccess={onSuccess} />
+    </MemoryRouter>,
+  );
+}
+
+function loadFormData() {
+  mockFetcherState = {
+    state: 'idle',
+    data: {
+      campuses: mockCampuses,
+      hubs: mockHubs,
+    },
+  };
+}
+
+function fillRequiredFields() {
+  fireEvent.change(screen.getByLabelText('First Name'), {
+    target: { value: 'Ada' },
+  });
+  fireEvent.change(screen.getByLabelText('Last Name'), {
+    target: { value: 'Lovelace' },
+  });
+  fireEvent.change(screen.getByLabelText('Campus'), {
+    target: { value: 'campus-guid-1' },
+  });
+  fireEvent.change(screen.getByLabelText('Cell Phone'), {
+    target: { value: '5615551234' },
+  });
+  fireEvent.change(screen.getByLabelText('Email Address'), {
+    target: { value: 'ada@example.com' },
+  });
+  fireEvent.click(screen.getByLabelText('In Person'));
+  fireEvent.click(screen.getByLabelText('Crew (Men)'));
+}
+
+describe('HelpMeFindAGroupForm', () => {
+  beforeEach(() => {
+    mockFetcherState = { state: 'idle', data: undefined };
+    vi.clearAllMocks();
+  });
+
+  it("calls fetcher.load('/api/help-me-find-a-group') on mount", () => {
+    renderForm();
+
+    expect(mockLoad).toHaveBeenCalledWith('/api/help-me-find-a-group');
+  });
+
+  it('renders campus select options from loader data', () => {
+    loadFormData();
+    renderForm();
+
+    expect(screen.getByText('Palm Beach Gardens')).toBeInTheDocument();
+    expect(screen.getByText('Stuart')).toBeInTheDocument();
+  });
+
+  it('renders hub checkbox labels from loader data', () => {
+    loadFormData();
+    renderForm();
+
+    expect(screen.getByLabelText('Crew (Men)')).toBeInTheDocument();
+    expect(screen.getByLabelText('Sisterhood')).toBeInTheDocument();
+  });
+
+  it('submits selected Hub checkboxes under the shared Hub field name', () => {
+    loadFormData();
+    renderForm();
+
+    fillRequiredFields();
+    fireEvent.click(screen.getByLabelText('Sisterhood'));
+    fireEvent.click(screen.getByRole('button', { name: /submit/i }));
+
+    expect(mockSubmit).toHaveBeenCalledWith(expect.any(FormData), {
+      method: 'post',
+      action: '/api/help-me-find-a-group',
+    });
+
+    const submittedFormData = mockSubmit.mock.calls[0][0] as FormData;
+    expect(submittedFormData.getAll('Hub')).toEqual([
+      'hub-guid-1',
+      'hub-guid-2',
+    ]);
+  });
+
+  it('shows server error message from fetcher data', () => {
+    mockFetcherState = {
+      state: 'idle',
+      data: { error: 'Something went wrong' },
+    };
+
+    renderForm();
+
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+  });
+
+  it('shows client error when no Hub is selected', () => {
+    loadFormData();
+    renderForm();
+
+    fireEvent.change(screen.getByLabelText('First Name'), {
+      target: { value: 'Ada' },
+    });
+    fireEvent.change(screen.getByLabelText('Last Name'), {
+      target: { value: 'Lovelace' },
+    });
+    fireEvent.change(screen.getByLabelText('Campus'), {
+      target: { value: 'campus-guid-1' },
+    });
+    fireEvent.change(screen.getByLabelText('Cell Phone'), {
+      target: { value: '5615551234' },
+    });
+    fireEvent.change(screen.getByLabelText('Email Address'), {
+      target: { value: 'ada@example.com' },
+    });
+    fireEvent.click(screen.getByLabelText('In Person'));
+    fireEvent.click(screen.getByRole('button', { name: /submit/i }));
+
+    expect(screen.getByText('Please select at least one area.')).toBeInTheDocument();
+    expect(mockSubmit).not.toHaveBeenCalled();
+  });
+
+  it('fires GTM completion event and calls onSuccess after successful submission', () => {
+    const onSuccess = vi.fn();
+    loadFormData();
+    const { rerender } = renderForm(onSuccess);
+
+    fillRequiredFields();
+    fireEvent.click(screen.getByRole('button', { name: /submit/i }));
+
+    mockFetcherState = {
+      state: 'idle',
+      data: { success: true },
+    };
+
+    rerender(
+      <MemoryRouter>
+        <HelpMeFindAGroupForm onSuccess={onSuccess} />
+      </MemoryRouter>,
+    );
+
+    expect(pushFormEvent).toHaveBeenCalledWith(
+      'form_complete',
+      'help_me_find_a_group',
+      'Help Me Find a Group',
+    );
+    expect(onSuccess).toHaveBeenCalled();
+    expect(vi.mocked(pushFormEvent).mock.invocationCallOrder[0]).toBeLessThan(
+      onSuccess.mock.invocationCallOrder[0],
+    );
+  });
+});

--- a/app/components/modals/help-me-find-a-group/help-me-find-a-group-confirmation.component.tsx
+++ b/app/components/modals/help-me-find-a-group/help-me-find-a-group-confirmation.component.tsx
@@ -1,0 +1,24 @@
+import { Button } from '~/primitives/button/button.primitive';
+
+interface HelpMeFindAGroupConfirmationProps {
+  onSuccess: () => void;
+}
+
+const HelpMeFindAGroupConfirmation: React.FC<
+  HelpMeFindAGroupConfirmationProps
+> = ({ onSuccess }) => {
+  return (
+    <div className='flex flex-col items-center gap-4 p-8'>
+      <h1 className='font-bold text-2xl text-navy'>Thanks!</h1>
+      <p className='text-text_primary'>
+        Someone from our team will be in touch soon to help you find the perfect
+        group.
+      </p>
+      <Button intent='primary' className='rounded-xl w-52' onClick={onSuccess}>
+        Done
+      </Button>
+    </div>
+  );
+};
+
+export default HelpMeFindAGroupConfirmation;

--- a/app/components/modals/help-me-find-a-group/help-me-find-a-group-flow.component.tsx
+++ b/app/components/modals/help-me-find-a-group/help-me-find-a-group-flow.component.tsx
@@ -1,0 +1,43 @@
+import { useState } from 'react';
+import HelpMeFindAGroupConfirmation from './help-me-find-a-group-confirmation.component';
+import HelpMeFindAGroupForm from './help-me-find-a-group-form.component';
+
+enum HelpMeFindAGroupStep {
+  FORM,
+  CONFIRMATION,
+}
+
+const HelpMeFindAGroupFlow = ({
+  setOpenModal,
+}: {
+  setOpenModal: (open: boolean) => void;
+}) => {
+  const [step, setStep] = useState<HelpMeFindAGroupStep>(
+    HelpMeFindAGroupStep.FORM,
+  );
+
+  const renderStep = () => {
+    switch (step) {
+      case HelpMeFindAGroupStep.FORM:
+        return (
+          <HelpMeFindAGroupForm
+            onSuccess={() => setStep(HelpMeFindAGroupStep.CONFIRMATION)}
+          />
+        );
+      case HelpMeFindAGroupStep.CONFIRMATION:
+        return (
+          <HelpMeFindAGroupConfirmation onSuccess={() => setOpenModal(false)} />
+        );
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <div className='pt-10 text-center text-text_primary p-6 w-[90vw] max-w-sm md:max-w-xl lg:max-w-3xl overflow-y-scroll max-h-[85vh] md:max-h-[90vh]'>
+      {renderStep()}
+    </div>
+  );
+};
+
+export default HelpMeFindAGroupFlow;

--- a/app/components/modals/help-me-find-a-group/help-me-find-a-group-form.component.tsx
+++ b/app/components/modals/help-me-find-a-group/help-me-find-a-group-form.component.tsx
@@ -1,0 +1,246 @@
+import * as Form from '@radix-ui/react-form';
+import { useEffect, useState } from 'react';
+import { useFetcher } from 'react-router-dom';
+import { pushFormEvent } from '~/lib/gtm';
+import { cn } from '~/lib/utils';
+import { Button } from '~/primitives/button/button.primitive';
+import { formRadioGroupVerticalStyles } from '~/primitives/inputs/form-control.styles';
+import {
+  radixCheckboxClassName,
+  radixCheckboxOptionLabelClassName,
+  radixFormFieldStackClassName,
+  radixFormLabelClassName,
+  radixRadioClassName,
+  radixSelectClassName,
+  radixTextareaClassName,
+  renderRadixInputField,
+  RadixFormErrorMessage,
+} from '~/primitives/inputs/form-radix-field';
+import type { HelpMeFindAGroupLoaderReturnType } from './types';
+
+const API_ROUTE = '/api/help-me-find-a-group';
+
+const TYPE_OPTIONS = [
+  { value: 'In Person', label: 'In Person' },
+  { value: 'Online', label: 'Online' },
+] as const;
+
+interface HelpMeFindAGroupFormProps {
+  onSuccess: () => void;
+}
+
+const HelpMeFindAGroupForm: React.FC<HelpMeFindAGroupFormProps> = ({
+  onSuccess,
+}) => {
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [campuses, setCampuses] = useState<
+    HelpMeFindAGroupLoaderReturnType['campuses']
+  >([]);
+  const [hubs, setHubs] = useState<HelpMeFindAGroupLoaderReturnType['hubs']>(
+    [],
+  );
+  const fetcher = useFetcher();
+
+  useEffect(() => {
+    fetcher.load(API_ROUTE);
+  }, []);
+
+  useEffect(() => {
+    if (fetcher.state === 'idle' && fetcher.data) {
+      setLoading(false);
+
+      if ('campuses' in fetcher.data) {
+        const data = fetcher.data as HelpMeFindAGroupLoaderReturnType;
+        setCampuses(data.campuses);
+        setHubs(data.hubs);
+      } else if ('error' in fetcher.data) {
+        setError(fetcher.data.error || 'An unexpected error occurred');
+      } else {
+        setError(null);
+        pushFormEvent(
+          'form_complete',
+          'help_me_find_a_group',
+          'Help Me Find a Group',
+        );
+        onSuccess();
+      }
+    }
+
+    if (fetcher.state === 'submitting') {
+      setLoading(true);
+      setError(null);
+    }
+  }, [fetcher.state, fetcher.data, onSuccess]);
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+    const hubValues = formData.getAll('Hub');
+
+    if (hubValues.length === 0) {
+      setError('Please select at least one area.');
+      return;
+    }
+
+    try {
+      fetcher.submit(formData, {
+        method: 'post',
+        action: API_ROUTE,
+      });
+    } catch {
+      setError(
+        'An error occurred while submitting the form. Please try again.',
+      );
+      setLoading(false);
+    }
+  };
+
+  return (
+    <>
+      <h2 className='mb-6 text-3xl text-navy font-bold'>
+        Help Me Find a Group
+      </h2>
+      <Form.Root
+        onSubmit={handleSubmit}
+        className='flex flex-col md:grid text-left grid-cols-1 gap-y-3 gap-x-6 md:grid-cols-2'
+      >
+        {renderRadixInputField(
+          'FirstName',
+          'First Name',
+          'text',
+          'Please enter your first name',
+        )}
+        {renderRadixInputField(
+          'LastName',
+          'Last Name',
+          'text',
+          'Please enter your last name',
+        )}
+
+        <Form.Field
+          name='Campus'
+          className={cn('mb-4 md:col-span-2', radixFormFieldStackClassName)}
+        >
+          <Form.Label className={radixFormLabelClassName}>Campus</Form.Label>
+          <Form.Control asChild>
+            <select className={radixSelectClassName} required>
+              <option value=''>Select a Campus</option>
+              {campuses.map(({ guid, name }) => (
+                <option key={guid} value={guid}>
+                  {name}
+                </option>
+              ))}
+            </select>
+          </Form.Control>
+          <RadixFormErrorMessage match='valueMissing'>
+            Please select a campus
+          </RadixFormErrorMessage>
+        </Form.Field>
+
+        {renderRadixInputField(
+          'PhoneNumber',
+          'Cell Phone',
+          'tel',
+          'Please enter your phone number',
+        )}
+        {renderRadixInputField(
+          'EmailAddress',
+          'Email Address',
+          'email',
+          'Please enter your email address',
+        )}
+
+        <Form.Field
+          name='Type'
+          className={cn(
+            'col-span-1 mt-2 md:col-span-2',
+            radixFormFieldStackClassName,
+          )}
+        >
+          <Form.Label className={radixFormLabelClassName}>
+            I prefer to meet:
+          </Form.Label>
+          <div className={formRadioGroupVerticalStyles} role='radiogroup'>
+            {TYPE_OPTIONS.map((option) => (
+              <label
+                key={option.value}
+                className='inline-flex cursor-pointer items-center gap-2'
+              >
+                <input
+                  type='radio'
+                  name='Type'
+                  value={option.value}
+                  required
+                  className={radixRadioClassName}
+                />
+                <span className='leading-4'>{option.label}</span>
+              </label>
+            ))}
+          </div>
+          <RadixFormErrorMessage match='valueMissing'>
+            Please select a meeting preference
+          </RadixFormErrorMessage>
+        </Form.Field>
+
+        <div
+          className={cn(
+            'col-span-1 mt-2 md:col-span-2',
+            radixFormFieldStackClassName,
+          )}
+        >
+          <p className={radixFormLabelClassName}>
+            I am interested in Groups in these areas:
+          </p>
+          <div className='mt-2 flex flex-col gap-2'>
+            {hubs.map((hub) => (
+              <label
+                key={hub.guid}
+                className={cn(
+                  'flex gap-2 md:items-center',
+                  radixCheckboxOptionLabelClassName,
+                )}
+              >
+                <input
+                  type='checkbox'
+                  name='Hub'
+                  value={hub.guid}
+                  className={radixCheckboxClassName}
+                />
+                {hub.value}
+              </label>
+            ))}
+          </div>
+        </div>
+
+        <Form.Field
+          name='Comments'
+          className={cn(
+            'col-span-1 mt-2 md:col-span-2',
+            radixFormFieldStackClassName,
+          )}
+        >
+          <Form.Label className={radixFormLabelClassName}>Comments</Form.Label>
+          <Form.Control asChild>
+            <textarea className={radixTextareaClassName} rows={4} />
+          </Form.Control>
+        </Form.Field>
+
+        {error && <p className='text-alert col-span-2 text-center'>{error}</p>}
+
+        <Form.Submit className='mt-6 mx-auto col-span-1 md:col-span-2' asChild>
+          <Button
+            className='w-40 h-12'
+            size='md'
+            type='submit'
+            disabled={loading}
+          >
+            {loading ? 'Loading...' : 'Submit'}
+          </Button>
+        </Form.Submit>
+      </Form.Root>
+    </>
+  );
+};
+
+export default HelpMeFindAGroupForm;

--- a/app/components/modals/help-me-find-a-group/help-me-find-a-group-form.component.tsx
+++ b/app/components/modals/help-me-find-a-group/help-me-find-a-group-form.component.tsx
@@ -167,13 +167,15 @@ const HelpMeFindAGroupForm: React.FC<HelpMeFindAGroupFormProps> = ({
                 key={option.value}
                 className='inline-flex cursor-pointer items-center gap-2'
               >
-                <input
-                  type='radio'
-                  name='Type'
-                  value={option.value}
-                  required
-                  className={radixRadioClassName}
-                />
+                <Form.Control asChild>
+                  <input
+                    type='radio'
+                    name='Type'
+                    value={option.value}
+                    required
+                    className={radixRadioClassName}
+                  />
+                </Form.Control>
                 <span className='leading-4'>{option.label}</span>
               </label>
             ))}

--- a/app/components/modals/help-me-find-a-group/index.tsx
+++ b/app/components/modals/help-me-find-a-group/index.tsx
@@ -1,0 +1,50 @@
+import { useState, type ReactNode } from 'react';
+import { pushFormEvent } from '~/lib/gtm';
+import Modal from '~/primitives/Modal';
+import { Button } from '~/primitives/button/button.primitive';
+import { ButtonProps } from '~/primitives/button/button.primitive';
+import HelpMeFindAGroupFlow from './help-me-find-a-group-flow.component';
+
+interface HelpMeFindAGroupModalProps {
+  buttonTitle?: string;
+  triggerStyles?: string;
+  TriggerButton?: React.ComponentType<ButtonProps>;
+  children?: ReactNode;
+}
+
+export function HelpMeFindAGroupModal({
+  buttonTitle = 'Help me find a group',
+  triggerStyles,
+  TriggerButton = Button,
+  children,
+}: HelpMeFindAGroupModalProps) {
+  const [openModal, setOpenModal] = useState(false);
+
+  const handleOpenChange = (open: boolean) => {
+    setOpenModal(open);
+    if (open) {
+      pushFormEvent(
+        'form_start',
+        'help_me_find_a_group',
+        'Help Me Find a Group',
+      );
+    }
+  };
+
+  return (
+    <Modal open={openModal} onOpenChange={handleOpenChange}>
+      {children ? (
+        <Modal.Button asChild>{children}</Modal.Button>
+      ) : (
+        <Modal.Button asChild className='mr-2'>
+          <TriggerButton intent='white' className={triggerStyles}>
+            {buttonTitle}
+          </TriggerButton>
+        </Modal.Button>
+      )}
+      <Modal.Content>
+        <HelpMeFindAGroupFlow setOpenModal={setOpenModal} />
+      </Modal.Content>
+    </Modal>
+  );
+}

--- a/app/components/modals/help-me-find-a-group/types.ts
+++ b/app/components/modals/help-me-find-a-group/types.ts
@@ -1,0 +1,27 @@
+export type CampusOption = {
+  guid: string;
+  name: string;
+};
+
+export type HubOption = {
+  guid: string;
+  value: string;
+};
+
+export type HelpMeFindAGroupLoaderReturnType = {
+  campuses: CampusOption[];
+  hubs: HubOption[];
+};
+
+export type HelpMeFindAGroupFormType = {
+  FirstName: string;
+  LastName: string;
+  EmailAddress: string;
+  PhoneNumber: string;
+  Campus: string;
+  Type: string;
+  Hub: string;
+  Comments?: string;
+  LaunchSource: 'app';
+  SendingFormName: 'CFDP App Help Me Find a Group';
+};

--- a/app/components/modals/index.ts
+++ b/app/components/modals/index.ts
@@ -1,6 +1,7 @@
 export { AuthModal } from './auth';
 export { ConnectCardModal } from './connect-card';
 export { GroupConnectModal } from './group-connect';
+export { HelpMeFindAGroupModal } from './help-me-find-a-group';
 export { NewsletterSubscriptionModal } from './newsletter-subscription';
 export { PrayerRequestModal } from './prayer-request';
 export { SetAReminderModal } from './set-a-reminder';

--- a/app/primitives/inputs/form-control.styles.ts
+++ b/app/primitives/inputs/form-control.styles.ts
@@ -62,8 +62,9 @@ export const formLabelStyles = cn(
   'transition-colors duration-150',
 );
 
-/** Label turns ocean when any control in the field wrapper is focused */
-export const formFieldFocusLabelStyles = 'focus-within:[&_label]:text-ocean';
+/** Label turns ocean when a text/select/textarea control in the field wrapper is focused */
+export const formFieldFocusLabelStyles =
+  'focus-within:[&:has(input:not([type=checkbox]):not([type=radio]):focus,select:focus,textarea:focus)_label]:text-ocean';
 
 /** Radix modal field labels (typography only; use formFieldStackStyles for 12px gaps) */
 export const formCompactFieldLabelStyles = cn(formLabelStyles, 'block');
@@ -98,7 +99,10 @@ export const formFieldInvalidControlStyles = cn(
 );
 
 /** Checkbox / radio option labels beside controls */
-export const formCheckboxOptionLabelStyles = formLabelStyles;
+export const formCheckboxOptionLabelStyles = cn(
+  formLabelStyles,
+  'cursor-pointer select-none',
+);
 
 export const formHelperTextStyles = 'text-base leading-4 text-navy';
 
@@ -125,7 +129,7 @@ export const nativeCheckboxStyles = cn(
 export const nativeRadioStyles = cn(
   'size-5 shrink-0 cursor-pointer appearance-none rounded-full',
   'border-2 border-form-stroke-muted bg-white',
-  'checked:border-ocean checked:bg-ocean',
+  'checked:border-ocean checked:bg-[radial-gradient(circle,var(--color-ocean)_45%,var(--color-white)_36%)]',
   'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ocean/30',
   'disabled:cursor-not-allowed disabled:opacity-60',
 );
@@ -161,19 +165,27 @@ export const formCheckboxLabelDisabledStyles =
 
 /** Custom radio faux control */
 export const formRadioControlOuterStyles = cn(
-  'flex size-5 shrink-0 cursor-pointer items-center justify-center rounded-full',
-  'border-2 border-form-stroke-muted bg-white transition duration-200',
-  'peer-checked:border-ocean peer-focus-visible:ring-2 peer-focus-visible:ring-ocean/30',
-  'peer-disabled:cursor-not-allowed peer-disabled:border-ocean/40 peer-disabled:bg-ocean-subdued',
-  'peer-aria-invalid:border-alert',
+  'flex size-5 shrink-0 items-center justify-center rounded-full',
+  'border-2 bg-white transition duration-200',
 );
 
+export const formRadioControlOuterSelectedStyles = 'border-ocean';
+
+export const formRadioControlOuterUnselectedStyles = 'border-form-stroke-muted';
+
+export const formRadioControlOuterDisabledStyles =
+  'border-ocean/40 bg-ocean-subdued';
+
+export const formRadioControlOuterErrorStyles = 'border-alert';
+
 export const formRadioControlInnerStyles =
-  'size-3 rounded-full bg-ocean peer-checked:opacity-100 opacity-0';
+  'rounded-full bg-ocean transition-opacity duration-200';
 
-export const formRadioControlInnerSelectedStyles = 'bg-ocean';
+export const formRadioControlInnerSelectedStyles = 'opacity-100';
 
-export const formRadioLabelStyles = 'text-text-primary';
+export const formRadioControlInnerUnselectedStyles = 'opacity-0';
+
+export const formRadioLabelStyles = 'text-text-primary select-none';
 
 /** Back-compat aliases */
 export const defaultTextInputStyles = formControlBaseStyles;

--- a/app/primitives/inputs/radio-buttons/radio-buttons.primitive.tsx
+++ b/app/primitives/inputs/radio-buttons/radio-buttons.primitive.tsx
@@ -1,6 +1,13 @@
 import { cn } from '~/lib/utils';
 import {
   formRadioControlInnerSelectedStyles,
+  formRadioControlInnerStyles,
+  formRadioControlInnerUnselectedStyles,
+  formRadioControlOuterDisabledStyles,
+  formRadioControlOuterErrorStyles,
+  formRadioControlOuterSelectedStyles,
+  formRadioControlOuterStyles,
+  formRadioControlOuterUnselectedStyles,
   formRadioGroupHorizontalStyles,
   formRadioGroupVerticalStyles,
   formRadioLabelStyles,
@@ -51,7 +58,7 @@ const RadioButtons: React.FC<RadioButtonsProps> = ({
             key={option.value}
             htmlFor={inputId}
             className={cn(
-              'flex cursor-pointer items-center gap-2',
+              'flex cursor-pointer select-none items-center gap-2',
               disabled && 'cursor-not-allowed opacity-60',
             )}
           >
@@ -60,7 +67,7 @@ const RadioButtons: React.FC<RadioButtonsProps> = ({
               id={inputId}
               name={name}
               value={option.value}
-              className='peer sr-only'
+              className='sr-only'
               checked={isSelected}
               onChange={handleChange}
               disabled={disabled}
@@ -68,16 +75,20 @@ const RadioButtons: React.FC<RadioButtonsProps> = ({
             />
             <span
               className={cn(
-                'flex size-5 shrink-0 items-center justify-center rounded-full border-2 bg-white transition duration-200',
-                isSelected ? 'border-ocean' : 'border-form-stroke-muted',
-                error && 'border-alert',
-                disabled && 'border-ocean/40 bg-ocean-subdued',
+                formRadioControlOuterStyles,
+                isSelected
+                  ? formRadioControlOuterSelectedStyles
+                  : formRadioControlOuterUnselectedStyles,
+                error && formRadioControlOuterErrorStyles,
+                disabled && formRadioControlOuterDisabledStyles,
               )}
             >
               <span
                 className={cn(
-                  'size-3 rounded-full',
-                  isSelected ? formRadioControlInnerSelectedStyles : 'hidden',
+                  formRadioControlInnerStyles,
+                  isSelected
+                    ? formRadioControlInnerSelectedStyles
+                    : formRadioControlInnerUnselectedStyles,
                 )}
               />
             </span>

--- a/app/routes/__tests__/api.help-me-find-a-group.test.ts
+++ b/app/routes/__tests__/api.help-me-find-a-group.test.ts
@@ -1,0 +1,164 @@
+import type { ActionFunctionArgs } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { postRockData } from '~/lib/.server/fetch-rock-data';
+import { action } from '~/routes/api.help-me-find-a-group';
+
+vi.mock('~/lib/.server/fetch-rock-data', () => ({
+  fetchRockData: vi.fn(),
+  postRockData: vi.fn(),
+}));
+
+const createValidRequest = (overrides?: {
+  includeComments?: boolean;
+  hubs?: string[];
+  omitField?: string;
+}) => {
+  const formData = new FormData();
+  const fields: Record<string, string> = {
+    FirstName: 'Test',
+    LastName: 'Person',
+    EmailAddress: 'test@example.com',
+    PhoneNumber: '5555555555',
+    Campus: 'campus-guid-123',
+    Type: 'In Person',
+  };
+
+  for (const [key, value] of Object.entries(fields)) {
+    if (overrides?.omitField !== key) {
+      formData.set(key, value);
+    }
+  }
+
+  const hubs = overrides?.hubs ?? ['hub-guid-1', 'hub-guid-2'];
+  for (const hub of hubs) {
+    formData.append('Hub', hub);
+  }
+
+  if (overrides?.includeComments) {
+    formData.set('Comments', 'Looking for a small group');
+  }
+
+  return new Request('http://localhost/api/help-me-find-a-group', {
+    method: 'POST',
+    body: formData,
+  });
+};
+
+async function parseActionResult(result: unknown) {
+  if (result instanceof Response) {
+    return { status: result.status, data: await result.json() };
+  }
+
+  if (
+    result &&
+    typeof result === 'object' &&
+    'type' in result &&
+    result.type === 'DataWithResponseInit'
+  ) {
+    const typedResult = result as unknown as {
+      data: { error?: string; success?: boolean };
+      init?: { status?: number };
+    };
+
+    return {
+      status: typedResult.init?.status,
+      data: typedResult.data,
+    };
+  }
+
+  throw new Error('Unexpected action result');
+}
+
+describe('help me find a group action', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(postRockData).mockResolvedValue(undefined);
+  });
+
+  it('rejects missing required fields', async () => {
+    const result = await action({
+      request: createValidRequest({ omitField: 'FirstName' }),
+    } as ActionFunctionArgs);
+
+    const { status, data: body } = await parseActionResult(result);
+
+    expect(status).toBe(400);
+    expect(body.error).toBe('Please fill in all required fields.');
+    expect(postRockData).not.toHaveBeenCalled();
+  });
+
+  it('rejects empty Hub selection', async () => {
+    const result = await action({
+      request: createValidRequest({ hubs: [] }),
+    } as ActionFunctionArgs);
+
+    const { status, data: body } = await parseActionResult(result);
+
+    expect(status).toBe(400);
+    expect(body.error).toBe('Please select at least one area.');
+    expect(postRockData).not.toHaveBeenCalled();
+  });
+
+  it('posts comma-separated Hub GUIDs to workflow type 419', async () => {
+    await action({
+      request: createValidRequest(),
+    } as ActionFunctionArgs);
+
+    expect(postRockData).toHaveBeenCalledWith({
+      endpoint:
+        'Workflows/LaunchWorkflow/0?workflowTypeId=419&workflowName=Help%20Me%20Find%20a%20Group',
+      body: expect.objectContaining({
+        Hub: 'hub-guid-1,hub-guid-2',
+      }),
+    });
+  });
+
+  it('includes LaunchSource and SendingFormName', async () => {
+    await action({
+      request: createValidRequest(),
+    } as ActionFunctionArgs);
+
+    expect(postRockData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          LaunchSource: 'app',
+          SendingFormName: 'CFDP App Help Me Find a Group',
+        }),
+      }),
+    );
+  });
+
+  it('includes Comments when provided', async () => {
+    await action({
+      request: createValidRequest({ includeComments: true }),
+    } as ActionFunctionArgs);
+
+    expect(postRockData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          Comments: 'Looking for a small group',
+        }),
+      }),
+    );
+  });
+
+  it('omits Comments when empty', async () => {
+    await action({
+      request: createValidRequest(),
+    } as ActionFunctionArgs);
+
+    const call = vi.mocked(postRockData).mock.calls[0][0];
+    expect(call.body).not.toHaveProperty('Comments');
+  });
+
+  it('returns success on Rock success', async () => {
+    const result = await action({
+      request: createValidRequest(),
+    } as ActionFunctionArgs);
+
+    const { status, data: body } = await parseActionResult(result);
+
+    expect(status).toBe(200);
+    expect(body).toEqual({ success: true });
+  });
+});

--- a/app/routes/__tests__/api.help-me-find-a-group.test.ts
+++ b/app/routes/__tests__/api.help-me-find-a-group.test.ts
@@ -1,11 +1,14 @@
 import type { ActionFunctionArgs } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { postRockData } from '~/lib/.server/fetch-rock-data';
+import { postRockWorkflowLaunchWithApiInitiator } from '~/lib/.server/rock-workflow';
 import { action } from '~/routes/api.help-me-find-a-group';
 
 vi.mock('~/lib/.server/fetch-rock-data', () => ({
   fetchRockData: vi.fn(),
-  postRockData: vi.fn(),
+}));
+
+vi.mock('~/lib/.server/rock-workflow', () => ({
+  postRockWorkflowLaunchWithApiInitiator: vi.fn(),
 }));
 
 const createValidRequest = (overrides?: {
@@ -72,7 +75,9 @@ async function parseActionResult(result: unknown) {
 describe('help me find a group action', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(postRockData).mockResolvedValue(undefined);
+    vi.mocked(postRockWorkflowLaunchWithApiInitiator).mockResolvedValue(
+      undefined,
+    );
   });
 
   it('rejects missing required fields', async () => {
@@ -84,7 +89,7 @@ describe('help me find a group action', () => {
 
     expect(status).toBe(400);
     expect(body.error).toBe('Please fill in all required fields.');
-    expect(postRockData).not.toHaveBeenCalled();
+    expect(postRockWorkflowLaunchWithApiInitiator).not.toHaveBeenCalled();
   });
 
   it('rejects empty Hub selection', async () => {
@@ -96,7 +101,7 @@ describe('help me find a group action', () => {
 
     expect(status).toBe(400);
     expect(body.error).toBe('Please select at least one area.');
-    expect(postRockData).not.toHaveBeenCalled();
+    expect(postRockWorkflowLaunchWithApiInitiator).not.toHaveBeenCalled();
   });
 
   it('posts comma-separated Hub GUIDs to workflow type 419', async () => {
@@ -104,12 +109,13 @@ describe('help me find a group action', () => {
       request: createValidRequest(),
     } as ActionFunctionArgs);
 
-    expect(postRockData).toHaveBeenCalledWith({
-      endpoint:
-        'Workflows/LaunchWorkflow/0?workflowTypeId=419&workflowName=Help%20Me%20Find%20a%20Group',
+    expect(postRockWorkflowLaunchWithApiInitiator).toHaveBeenCalledWith({
+      workflowTypeId: '419',
+      workflowName: 'Help Me Find a Group',
       body: expect.objectContaining({
         Hub: 'hub-guid-1,hub-guid-2',
       }),
+      instanceName: 'Test Person',
     });
   });
 
@@ -118,7 +124,7 @@ describe('help me find a group action', () => {
       request: createValidRequest(),
     } as ActionFunctionArgs);
 
-    expect(postRockData).toHaveBeenCalledWith(
+    expect(postRockWorkflowLaunchWithApiInitiator).toHaveBeenCalledWith(
       expect.objectContaining({
         body: expect.objectContaining({
           LaunchSource: 'app',
@@ -133,7 +139,7 @@ describe('help me find a group action', () => {
       request: createValidRequest({ includeComments: true }),
     } as ActionFunctionArgs);
 
-    expect(postRockData).toHaveBeenCalledWith(
+    expect(postRockWorkflowLaunchWithApiInitiator).toHaveBeenCalledWith(
       expect.objectContaining({
         body: expect.objectContaining({
           Comments: 'Looking for a small group',
@@ -147,7 +153,8 @@ describe('help me find a group action', () => {
       request: createValidRequest(),
     } as ActionFunctionArgs);
 
-    const call = vi.mocked(postRockData).mock.calls[0][0];
+    const call = vi.mocked(postRockWorkflowLaunchWithApiInitiator).mock
+      .calls[0][0];
     expect(call.body).not.toHaveProperty('Comments');
   });
 

--- a/app/routes/api.help-me-find-a-group.tsx
+++ b/app/routes/api.help-me-find-a-group.tsx
@@ -5,7 +5,8 @@ import {
 } from 'react-router-dom';
 import type { HelpMeFindAGroupFormType } from '~/components/modals/help-me-find-a-group/types';
 import type { HelpMeFindAGroupLoaderReturnType } from '~/components/modals/help-me-find-a-group/types';
-import { fetchRockData, postRockData } from '~/lib/.server/fetch-rock-data';
+import { fetchRockData } from '~/lib/.server/fetch-rock-data';
+import { postRockWorkflowLaunchWithApiInitiator } from '~/lib/.server/rock-workflow';
 
 const HUB_DEFINED_TYPE_ID = 366;
 
@@ -87,9 +88,11 @@ export const action: ActionFunction = async ({ request }) => {
       submission.Comments = Comments;
     }
 
-    await postRockData({
-      endpoint: `Workflows/LaunchWorkflow/0?workflowTypeId=419&workflowName=${encodeURIComponent('Help Me Find a Group')}`,
+    await postRockWorkflowLaunchWithApiInitiator({
+      workflowTypeId: '419',
+      workflowName: 'Help Me Find a Group',
       body: submission,
+      instanceName: `${FirstName} ${LastName}`.trim(),
     });
 
     return new Response(JSON.stringify({ success: true }), {

--- a/app/routes/api.help-me-find-a-group.tsx
+++ b/app/routes/api.help-me-find-a-group.tsx
@@ -1,0 +1,107 @@
+import {
+  type ActionFunction,
+  type LoaderFunction,
+  data,
+} from 'react-router-dom';
+import type { HelpMeFindAGroupFormType } from '~/components/modals/help-me-find-a-group/types';
+import type { HelpMeFindAGroupLoaderReturnType } from '~/components/modals/help-me-find-a-group/types';
+import { fetchRockData, postRockData } from '~/lib/.server/fetch-rock-data';
+
+const HUB_DEFINED_TYPE_ID = 366;
+
+export const loader: LoaderFunction = async () => {
+  const [campuses, hubs] = await Promise.all([
+    fetchRockData({
+      endpoint: 'Campuses',
+      queryParams: {
+        $filter: 'IsActive eq true',
+        $orderby: 'Order',
+        $select: 'Name, Guid',
+      },
+    }),
+    fetchRockData({
+      endpoint: 'DefinedValues',
+      queryParams: {
+        $filter: `DefinedTypeId eq ${HUB_DEFINED_TYPE_ID} and IsActive eq true`,
+        $orderby: 'Order',
+        $select: 'Guid, Value',
+      },
+    }),
+  ]);
+
+  const loaderData: HelpMeFindAGroupLoaderReturnType = {
+    campuses,
+    hubs,
+  };
+
+  return loaderData;
+};
+
+export const action: ActionFunction = async ({ request }) => {
+  try {
+    const formData = await request.formData();
+
+    const FirstName = formData.get('FirstName')?.toString().trim();
+    const LastName = formData.get('LastName')?.toString().trim();
+    const EmailAddress = formData.get('EmailAddress')?.toString().trim();
+    const PhoneNumber = formData.get('PhoneNumber')?.toString().trim();
+    const Campus = formData.get('Campus')?.toString().trim();
+    const Type = formData.get('Type')?.toString().trim();
+    const Comments = formData.get('Comments')?.toString().trim();
+    const hubGuids = formData.getAll('Hub').map(String).filter(Boolean);
+
+    if (
+      !FirstName ||
+      !LastName ||
+      !EmailAddress ||
+      !PhoneNumber ||
+      !Campus ||
+      !Type
+    ) {
+      return data(
+        { error: 'Please fill in all required fields.' },
+        { status: 400 },
+      );
+    }
+
+    if (hubGuids.length === 0) {
+      return data(
+        { error: 'Please select at least one area.' },
+        { status: 400 },
+      );
+    }
+
+    const submission: HelpMeFindAGroupFormType = {
+      FirstName,
+      LastName,
+      EmailAddress,
+      PhoneNumber,
+      Campus,
+      Type,
+      Hub: hubGuids.join(','),
+      LaunchSource: 'app',
+      SendingFormName: 'CFDP App Help Me Find a Group',
+    };
+
+    if (Comments) {
+      submission.Comments = Comments;
+    }
+
+    await postRockData({
+      endpoint: `Workflows/LaunchWorkflow/0?workflowTypeId=419&workflowName=${encodeURIComponent('Help Me Find a Group')}`,
+      body: submission,
+    });
+
+    return new Response(JSON.stringify({ success: true }), {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+  } catch (error) {
+    if (error instanceof Error) {
+      return data({ error: error.message }, { status: 400 });
+    }
+    return data({ error: 'Network error please try again' }, { status: 400 });
+  }
+};

--- a/app/routes/group-finder/group-finder.tsx
+++ b/app/routes/group-finder/group-finder.tsx
@@ -1,7 +1,8 @@
+import { HelpMeFindAGroupModal } from '~/components/modals';
+import { Button } from '~/primitives/button/button.primitive';
 import { GroupSearch } from './partials/group-search.partial';
 import { FinderHero } from '../../components/finders/hero';
 
-const helpFindGroupUrl = 'https://rock.gocf.org/page/2113';
 const leadGroupUrl =
   'https://rock.christfellowship.church/dreamteam/locations/opportunities/ministries?AreaId=2030&SetContext=Rock.Model.Campus2&CampusId=2';
 
@@ -20,10 +21,17 @@ export function GroupFinderPage() {
             desktopDescription='No matter where you are in life or your journey with God, Groups connect you with people who encourage you, support you, and help you grow. Find a group today that will help you live the full life God intended for you.'
             ctas={[
               {
-                href: helpFindGroupUrl,
-                title: 'Help me find a group',
-                intent: 'secondaryWhite',
-                className: 'text-base font-normal',
+                key: 'help-me-find-a-group',
+                render: () => (
+                  <HelpMeFindAGroupModal>
+                    <Button
+                      intent='secondaryWhite'
+                      className='text-base font-normal'
+                    >
+                      Help me find a group
+                    </Button>
+                  </HelpMeFindAGroupModal>
+                ),
               },
               {
                 href: leadGroupUrl,
@@ -46,10 +54,14 @@ export function GroupFinderPage() {
             desktopDescription='No matter where you are in life or your journey with God, Groups connect you with people who encourage you, support you, and help you grow. Find a group today that will help you live the full life God intended for you.'
             ctas={[
               {
-                href: helpFindGroupUrl,
-                title: 'Help me find a group',
-                intent: 'white',
-                className: 'text-base font-normal',
+                key: 'help-me-find-a-group',
+                render: () => (
+                  <HelpMeFindAGroupModal>
+                    <Button intent='white' className='text-base font-normal'>
+                      Help me find a group
+                    </Button>
+                  </HelpMeFindAGroupModal>
+                ),
               },
               {
                 href: leadGroupUrl,


### PR DESCRIPTION
## Summary

Adds an in-app "Help Me Find a Group" modal form to the Group Finder page so users can request help without leaving the site. The form loads campus and group area options from Rock, submits to the Help Me Find a Group workflow using the shared workflow launcher, and shows a confirmation state on success.

## Screenshots

<img width="1432" height="1012" alt="image" src="https://github.com/user-attachments/assets/68aec63f-03f4-4c75-b95b-13601864fbfe" />


## Testing

- [x] Open `/group-finder`.
- [x] Click "Help me find a group".
- [x] Fill out all required fields.
- [x] Select a campus.
- [x] Select a meeting preference.
- [x] Select at least one group area.
- [x] Submit the form.
- [x] Confirm the success state appears after submission.
- [x] In Rock, confirm a new "Help Me Find a Group" workflow was triggered with the submitted contact details, campus, meeting preference, selected group area, and comments if provided. [See Workflow Entries here](https://rock.gocf.org/page/288?WorkflowTypeId=419)

## Tickets

[CFDP-4012](https://christfellowshipchurch.atlassian.net/browse/CFDP-4012)

## Changes Made

### New Components Added

- `app/components/modals/help-me-find-a-group/help-me-find-a-group-form.component.tsx` - Radix form for collecting contact info, campus, meeting preference, group area interests, and comments.
- `app/components/modals/help-me-find-a-group/help-me-find-a-group-flow.component.tsx` - Modal flow state between form and confirmation.
- `app/components/modals/help-me-find-a-group/help-me-find-a-group-confirmation.component.tsx` - Success confirmation view.
- `app/components/modals/help-me-find-a-group/index.tsx` - Modal wrapper and trigger integration.

### Route Implementation

- `app/routes/api.help-me-find-a-group.tsx` - Adds loader data for campuses and hubs, validates submissions, and launches workflow type `419` through `postRockWorkflowLaunchWithApiInitiator`.
- `app/routes/group-finder/group-finder.tsx` - Replaces the external "Help me find a group" link with the new modal trigger.

### Key Features

- Adds in-app Help Me Find a Group submission flow.
- Loads active campuses and active group area options from Rock.
- Supports selecting multiple group areas under the shared `Hub` field.
- Tracks GTM form start and completion events.
- Adds focused form and route action test coverage.


[CFDP-4012]: https://christfellowshipchurch.atlassian.net/browse/CFDP-4012?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
