### PR TITLE
Fixes to Events Back Button, Overflow from Logo in Navbar, Contact Us copy, and Group Finder Tags

### DIFF
--- a/app/components/finders/search-filters/filter-popup.component.tsx
+++ b/app/components/finders/search-filters/filter-popup.component.tsx
@@ -514,7 +514,15 @@ const FilterPopupContent = ({
   popupTitle,
   cancelSignalRef,
 }: FilterPopupContentProps) => {
-  const { items, refine } = useRefinementList({ attribute: data.attribute });
+  // `useRefinementList` defaults to a limit of 10 facet values (top 10 by
+  // count). That silently dropped lower-count topics (e.g. "Prayer",
+  // "Watch Party") and could truncate other facets like the campus dropdown.
+  // Raise it well above the number of distinct values so every tagged option
+  // is available to the section's display logic below.
+  const { items, refine } = useRefinementList({
+    attribute: data.attribute,
+    limit: 50,
+  });
   const [localAgeInput, setLocalAgeInput] = useState<string>(ageInput || '');
   const [showAgeInputError, setShowAgeInputError] = useState(false);
 
@@ -524,7 +532,7 @@ const FilterPopupContent = ({
   const communityFunTopics = [
     'Friendship',
     'Sports',
-    'Activty/Hobby',
+    'Activity/Hobby',
     'Book Club',
     'Watch Party',
     'Podcast',

--- a/app/components/modals/contact-us/contact-form.component.tsx
+++ b/app/components/modals/contact-us/contact-form.component.tsx
@@ -77,9 +77,9 @@ const ContactUsForm: React.FC<ContactUsFormProps> = ({ onSuccess }) => {
         Contact Us
       </h2>
       <p className='mb-8 text-pretty text-center'>
-        With a lot of locations it’s easy to feel lost in the shuffle, so we’ve
-        made a point to personally answer every question, comment, or prayer
-        request you send us. <br /> <br /> We look forward to hearing from you!
+        We believe every person matters, so we personally respond to every
+        question, comment, and prayer request you send us. <br /> <br /> We look
+        forward to hearing from you!
       </p>
       <Form.Root
         onSubmit={handleSubmit}

--- a/app/components/navbar/navbar.component.tsx
+++ b/app/components/navbar/navbar.component.tsx
@@ -245,7 +245,7 @@ export function Navbar() {
           </div>
           <div
             className={cn(
-              'w-full content-padding transition-colors duration-200',
+              'w-full content-padding transition-colors duration-200 overflow-hidden',
               mode === 'light' || isSearchOpen
                 ? 'bg-white shadow-sm'
                 : openDropdown

--- a/app/routes/events/all-events/components/all-events-content.component.tsx
+++ b/app/routes/events/all-events/components/all-events-content.component.tsx
@@ -27,6 +27,7 @@ import {
 } from '../partials/featured-events.partial';
 import { parseEventsFinderUrlState } from '../../events-url-state';
 import type { EventsFinderUrlState } from '../../events-url-state';
+import { buildEventSingleUrl } from '../../events-back-url';
 
 import { formatEventCardDate } from './featured-card.component';
 import { EventsFiltersViewport } from './events-filters-viewport.component';
@@ -81,13 +82,7 @@ function getEventHitLocation(
         'Christ Fellowship Church';
 }
 
-function MobileEventHitCard({
-  hit,
-  fromEventsUrl,
-}: {
-  hit: ContentItemHit;
-  fromEventsUrl: string;
-}) {
+function MobileEventHitCard({ hit, to }: { hit: ContentItemHit; to: string }) {
   const dateParts = hit.startDateTime
     ? formatMobileEventDateParts(hit.startDateTime)
     : null;
@@ -95,8 +90,7 @@ function MobileEventHitCard({
 
   return (
     <Link
-      to={`/events/${hit.url}`}
-      state={fromEventsUrl ? { fromEvents: fromEventsUrl } : undefined}
+      to={to}
       className='flex h-[88px] w-full items-start overflow-hidden rounded-xl border border-neutral-lighter bg-white text-text-primary transition-colors duration-200 hover:border-neutral-light md:hidden'
       prefetch='intent'
     >
@@ -160,9 +154,13 @@ function EventHit({
   const imageUri = hit.coverImage?.sources?.[0]?.uri ?? '';
   const location = getEventHitLocation(hit);
 
+  // Forward the active finder filters so the event's back button can restore
+  // them (stateless `from` query param — see events-back-url.ts).
+  const eventSingleUrl = buildEventSingleUrl(hit.url, fromEventsUrl);
+
   return (
     <>
-      <MobileEventHitCard hit={hit} fromEventsUrl={fromEventsUrl} />
+      <MobileEventHitCard hit={hit} to={eventSingleUrl} />
       <div className='hidden h-full md:block'>
         <ResourceCard
           resource={{
@@ -172,11 +170,10 @@ function EventHit({
             name: hit.title,
             summary: hit.summary ?? '',
             image: imageUri,
-            pathname: `/events/${hit.url}`,
+            pathname: eventSingleUrl,
             startDate: formattedDate,
             location,
           }}
-          linkState={fromEventsUrl ? { fromEvents: fromEventsUrl } : undefined}
         />
       </div>
     </>

--- a/app/routes/events/event-single/event-single-page.tsx
+++ b/app/routes/events/event-single/event-single-page.tsx
@@ -10,12 +10,14 @@ import { AboutPartial } from './partials/about.partial';
 import { EventBanner } from './components/event-banner.component';
 import { RegistrationSection } from './partials/registration.partial';
 import BackBanner from '~/components/back-banner';
+import { useEventsBackUrl } from '../events-back-url';
 
 const SECTION_IDS = ['about', 'faq', 'register'] as const;
 
 export const EventSinglePage: React.FC = () => {
   const data = useLoaderData<EventSinglePageType>();
   const location = useLocation();
+  const backToEventsUrl = useEventsBackUrl();
 
   // Scroll to section when landing with a hash (e.g. /events/baptism#register)
   useEffect(() => {
@@ -48,7 +50,7 @@ export const EventSinglePage: React.FC = () => {
         <BackBanner
           backText='Back to Events'
           pageTitle={data.title}
-          link='/events'
+          link={backToEventsUrl}
         />
 
         <EventsSingleHero

--- a/app/routes/events/events-back-url.ts
+++ b/app/routes/events/events-back-url.ts
@@ -1,0 +1,37 @@
+import { useSearchParams } from 'react-router-dom';
+
+const EVENTS_PATH = '/events';
+
+/**
+ * Build an Event Single URL, forwarding the active Event Finder filters (the
+ * finder URL's query string) as a stateless `from` param so the detail page's
+ * back button can restore them.
+ *
+ * `fromEventsUrl` is the finder URL (path + search), e.g.
+ * `/events?q=baptism&eventLocations=Main+Campus`. Using a query param (not
+ * router `state`) keeps it working across refreshes and shared links.
+ */
+export function buildEventSingleUrl(
+  eventPath: string,
+  fromEventsUrl?: string,
+): string {
+  const base = `/events/${eventPath}`;
+  if (!fromEventsUrl) return base;
+  const qIndex = fromEventsUrl.indexOf('?');
+  const search = qIndex >= 0 ? fromEventsUrl.slice(qIndex + 1) : '';
+  return search ? `${base}?from=${encodeURIComponent(search)}` : base;
+}
+
+/**
+ * Back-link target for the Event Single page.
+ *
+ * Restores the forwarded Event Finder filters (the `from` param set by
+ * {@link buildEventSingleUrl}), falling back to the bare finder for direct-link
+ * arrivals. Always targets the finder page (never history `-1`), so the back
+ * button is consistent regardless of how the user reached the event.
+ */
+export function useEventsBackUrl(): string {
+  const [searchParams] = useSearchParams();
+  const from = searchParams.get('from')?.trim();
+  return from ? `${EVENTS_PATH}?${from}` : EVENTS_PATH;
+}

--- a/app/routes/group-finder/types.ts
+++ b/app/routes/group-finder/types.ts
@@ -61,7 +61,7 @@ export type GroupTopic =
   | 'Parenting'
   | 'Finances'
   | 'Friendship'
-  | 'Activty/Hobby'
+  | 'Activity/Hobby'
   | 'Book Club'
   | 'Sports'
   | 'Podcast'


### PR DESCRIPTION
## Summary

Three finder/form fixes bundled into one PR:

- **CFDP-4021 — Event Single back button.** The back button now reliably returns users to the Events finder regardless of how they arrived (direct link, shared URL, browser back), and preserves their active finder filters on the way back instead of dumping them on an unfiltered list.
- **CFDP-4030 — Group Finder topic filter.** All topics tagged on at least one group now appear in the topic filter. Previously some were silently dropped (e.g. "Activity/Hobby", "Prayer", "Watch Party").
- **CFDP-4023 — Contact Us copy.** Updates the opening copy on the Contact Us form to the new approved messaging.

## Screenshots

[Paste your screenshots here]

## Testing

- [x] **How were these changes tested?** Verified in a running browser on desktop (1280px) and mobile (375px). For CFDP-4030, the Algolia `dev_Groups` topic facet was queried directly to confirm the full set of values, counts, and exact labels. CFDP-4023 is a static copy change verified by code review + lint/format (no viewport-conditional rendering).
- [x] **Steps to verify — CFDP-4021:**
  1. Open `/events`, apply a filter/search (e.g. `?eventCategories=next-steps`).
  2. Open any event → confirm the URL carries a `from` param.
  3. Click "Back to Events" → you return to `/events?eventCategories=next-steps` with filters restored.
  4. Open an event via a direct link, like from the featured events section, and then clicking "Back to Events" → navigates cleanly to `/events` (no filtering).
- [x] **Steps to verify — CFDP-4023:**
  1. Open the Contact Us modal (e.g. from a location page's CTA or FAQ).
  2. Confirm the opening paragraph reads exactly: "We believe every person matters, so we personally respond to every question, comment, and prayer request you send us." followed by "We look forward to hearing from you!"
- [x] **Steps to verify — CFDP-4030:**
  1. Open the Group Finder → open the Topic filter.
  2. Confirm all 12 topics appear across the three bands, including **Activity/Hobby**, **Prayer**, and **Watch Party**.
  3. Repeat on mobile (topics live under the "More" sheet).
- [x] **New linter errors/warnings?** None. `pnpm typecheck` (0 errors), `pnpm lint` (clean), and `prettier --check` all pass on the changed files.

## Tickets
[CFDP-4021](https://christfellowshipchurch.atlassian.net/browse/CFDP-4021)
[CFDP-4023](https://christfellowshipchurch.atlassian.net/browse/CFDP-4023)
[CFDP-4030](https://christfellowshipchurch.atlassian.net/browse/CFDP-4030)

## Changes Made

### New Components Added

- None.

### New Utilities

- `app/routes/events/events-back-url.ts` *(new)* — `useEventsBackUrl()` reads a forwarded `from` query param and returns `/events?<restored filters>` (or bare `/events` when absent); `buildEventSingleUrl(eventPath, fromEventsUrl)` builds an event detail URL that forwards the finder's query string as a stateless `from` param. (CFDP-4021)

### New Assets

- None.

### Dependencies

- None.

### Route Implementation

- `app/routes/events/event-single/event-single-page.tsx` — the `BackBanner` link now uses `useEventsBackUrl()` instead of a hardcoded `/events`, so it always targets the finder (never history `-1`) and restores filters when present. (CFDP-4021)
- `app/routes/events/all-events/components/all-events-content.component.tsx` — event grid cards (mobile + desktop `ResourceCard`) now link to `/events/{slug}?from=…`, forwarding the active finder filters; removed the unused React Router `state` that was never read. (CFDP-4021)
- `app/components/finders/search-filters/filter-popup.component.tsx` — added `limit: 50` to `useRefinementList` (react-instantsearch defaults to 10, which truncated low-count topics and could clip the campus dropdown); corrected the hardcoded band label typo `Activty/Hobby` → `Activity/Hobby`. (CFDP-4030)
- `app/routes/group-finder/types.ts` — fixed the same `Activty/Hobby` → `Activity/Hobby` typo in the `GroupTopic` union for consistency. (CFDP-4030)
- `app/components/modals/contact-us/contact-form.component.tsx` — replaced the Contact Us form's opening sentence with the approved copy, preserving the "We look forward to hearing from you!" sign-off and all surrounding layout/styling. (CFDP-4023)

### Key Features

- **Consistent, filter-preserving back navigation (CFDP-4021):** Returning from an event always lands on the Events finder, and restores the user's prior filters statelessly via a `from` query param (survives refreshes and shared links). Direct-link arrivals route cleanly to `/events`.
- **Complete topic filter (CFDP-4030):** All topics tagged on active groups now appear. Root cause was twofold — react-instantsearch's default facet `limit` of 10 truncated the 12-value topic list (dropping "Prayer" and "Watch Party"), and a hardcoded label typo hid "Activity/Hobby". No inactive/duplicate values are introduced (Algolia only returns values with count ≥ 1).
- **Approved Contact Us messaging (CFDP-4023):** The opening copy now matches the approved text exactly, with no other content or layout changes to the form.

[CFDP-4021]: https://christfellowshipchurch.atlassian.net/browse/CFDP-4021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ