### PR TITLE
[CFDP-4018] Fix hero location search popup positioning and transitions

### DIFF
--- a/app/components/modals/help-me-find-a-group/__tests__/help-me-find-a-group-form.test.tsx
+++ b/app/components/modals/help-me-find-a-group/__tests__/help-me-find-a-group-form.test.tsx
@@ -158,7 +158,9 @@ describe('HelpMeFindAGroupForm', () => {
     fireEvent.click(screen.getByLabelText('In Person'));
     fireEvent.click(screen.getByRole('button', { name: /submit/i }));
 
-    expect(screen.getByText('Please select at least one area.')).toBeInTheDocument();
+    expect(
+      screen.getByText('Please select at least one area.'),
+    ).toBeInTheDocument();
     expect(mockSubmit).not.toHaveBeenCalled();
   });
 

--- a/app/routes/home/components/hero/desktop-hero.component.tsx
+++ b/app/routes/home/components/hero/desktop-hero.component.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { LocationSearch } from '../location-search/location-search.component';
 import { DesktopFeaturedItems } from './desktop-features.component';
 import { Video } from '~/primitives/video/video.primitive';
+import { cn } from '~/lib/utils';
 
 export function DesktopHeroSection() {
   const [isSearching, setIsSearching] = useState(false);
@@ -62,14 +63,17 @@ export function DesktopHeroSection() {
                   Your Purpose.
                 </span>
               </h1>
-              {!isSearching && (
-                <p className='text-white max-w-[470px] xl:max-w-[529px] text-xl z-2'>
-                  From inspiring messages to genuine community, Christ
-                  Fellowship is a place where you and your family can grow in
-                  your faith and make lifelong friendships.
-                </p>
-              )}
-              <div className='flex w-fit relative pb-10 z-3'>
+              <p className='text-white max-w-[470px] xl:max-w-[529px] text-xl z-2'>
+                From inspiring messages to genuine community, Christ
+                Fellowship is a place where you and your family can grow in
+                your faith and make lifelong friendships.
+              </p>
+              <div
+                className={cn(
+                  'relative flex w-fit pb-10',
+                  isSearching ? 'z-20' : 'z-3',
+                )}
+              >
                 {/* Location Search */}
                 <LocationSearch
                   isSearching={isSearching}

--- a/app/routes/home/components/hero/desktop-hero.component.tsx
+++ b/app/routes/home/components/hero/desktop-hero.component.tsx
@@ -64,9 +64,9 @@ export function DesktopHeroSection() {
                 </span>
               </h1>
               <p className='text-white max-w-[470px] xl:max-w-[529px] text-xl z-2'>
-                From inspiring messages to genuine community, Christ
-                Fellowship is a place where you and your family can grow in
-                your faith and make lifelong friendships.
+                From inspiring messages to genuine community, Christ Fellowship
+                is a place where you and your family can grow in your faith and
+                make lifelong friendships.
               </p>
               <div
                 className={cn(

--- a/app/routes/home/components/location-search/location-search-inner.component.tsx
+++ b/app/routes/home/components/location-search/location-search-inner.component.tsx
@@ -41,6 +41,8 @@ export function LocationSearchInner({
 
   const locationSearchBarRef = useRef<HTMLDivElement>(null);
   const [internalIsSearching, setInternalIsSearching] = useState(false);
+  const [isPopupMounted, setIsPopupMounted] = useState(false);
+  const [isPopupVisible, setIsPopupVisible] = useState(false);
 
   const isSearching = controlledIsSearching ?? internalIsSearching;
   const setIsSearching = controlledSetIsSearching ?? setInternalIsSearching;
@@ -77,6 +79,24 @@ export function LocationSearchInner({
       document.removeEventListener('mousedown', handleClickOutside);
     };
   }, [setIsSearching]);
+
+  useEffect(() => {
+    if (isSearching) {
+      setIsPopupMounted(true);
+      setIsPopupVisible(false);
+      const frame = requestAnimationFrame(() => {
+        setIsPopupVisible(true);
+      });
+      return () => cancelAnimationFrame(frame);
+    }
+
+    setIsPopupVisible(false);
+    const timer = window.setTimeout(() => {
+      setIsPopupMounted(false);
+    }, 200);
+
+    return () => clearTimeout(timer);
+  }, [isSearching]);
 
   const handleSearch = useCallback((query: string | null) => {
     if (!query || query.length !== 5 || !isValidZip(query)) {
@@ -156,7 +176,7 @@ export function LocationSearchInner({
   }, [geocodeFetcher.data, geocodeFetcher.state]);
 
   return (
-    <div className={cn(isSearching && 'mt-32')} ref={locationSearchBarRef}>
+    <div>
       <InstantSearch
         indexName='dev_Locations'
         searchClient={searchClient}
@@ -183,26 +203,36 @@ export function LocationSearchInner({
         )}
 
         <div
-          className={cn(
-            'relative w-full md:w-90 z-50 rounded-2xl transition-all duration-300',
-            {
-              'bg-white p-4 shadow-md sm:w-[450px] md:w-[620px] lg:w-[430px] lg:-translate-y-30 short-desktop:-translate-y-70':
-                isSearching,
-              'bg-transparent': !isSearching,
-            },
-          )}
+          ref={locationSearchBarRef}
+          className='relative z-50 w-full rounded-2xl sm:w-[450px] md:w-[620px] lg:w-[400px]'
         >
-          <SearchBar
-            onSearchStateChange={setIsSearching}
-            onSearchSubmit={handleSearch}
-            data-gtm='hero-cta'
-          />
-          {isSearching && (
-            <SearchPopup
-              isDistanceSearch={isDistanceSearch}
-              onRequestPreciseLocation={handlePreciseLocationRequest}
-            />
+          {isPopupMounted && (
+            <div
+              className={cn(
+                'absolute left-0 right-0 top-0 z-10 rounded-2xl bg-white p-4 shadow-md transition-opacity duration-200 ease-out',
+                isPopupVisible ? 'opacity-100' : 'opacity-0',
+                !isPopupVisible && 'pointer-events-none',
+              )}
+            >
+              <div className='h-14 shrink-0' aria-hidden='true' />
+              <SearchPopup
+                isDistanceSearch={isDistanceSearch}
+                onRequestPreciseLocation={handlePreciseLocationRequest}
+              />
+            </div>
           )}
+          <div
+            className={cn(
+              'relative z-20 transition-[padding] duration-200 ease-out',
+              isPopupVisible ? 'p-4 pb-0' : 'p-0',
+            )}
+          >
+            <SearchBar
+              onSearchStateChange={setIsSearching}
+              onSearchSubmit={handleSearch}
+              data-gtm='hero-cta'
+            />
+          </div>
         </div>
       </InstantSearch>
     </div>

--- a/app/routes/home/components/location-search/search-popup.tsx
+++ b/app/routes/home/components/location-search/search-popup.tsx
@@ -21,7 +21,7 @@ export const SearchPopup = ({
     : items;
 
   return (
-    <div className='w-full py-4 z-4 overflow-hidden min-h-[332px]'>
+    <div className='w-full overflow-hidden min-h-[332px]'>
       {/* Search Results */}
       <div className='space-y-4'>
         <div className='flex flex-col overflow-y-auto max-h-[300px]'>


### PR DESCRIPTION
## Summary

Fixes layout and layering issues with the home hero location search popup. Previously, opening search results shifted the hero title, subtitle, and search bar upward, misaligned the popup with the search bar, and allowed `DesktopFeaturedItems` to render on top of results.

This update keeps hero copy visible and in place, absolutely positions the results panel so it does not affect flex layout, raises z-index while searching, and adds smooth fade/padding transitions when entering and exiting popup mode.

## Screenshots

<img width="992" height="981" alt="image" src="https://github.com/user-attachments/assets/82ad0aff-f703-4430-a112-9a38e253be0d" />

## Testing

- [x] Verified locally on desktop hero (`lg+`) by entering a zip code and confirming title/subtitle/search bar do not shift
- [x] Confirmed popup aligns with search bar and white card padding appears in popup mode
- [x] Confirmed `DesktopFeaturedItems` renders behind the popup while search is open
- [x] Confirmed fade in/out and search bar padding transitions feel smooth on open/close
- [x] Ran `pnpm lint` with no errors

**Manual verification steps:**
1. Open the home page on desktop (`lg+` breakpoint)
2. Enter a valid 5-digit zip in the hero location search
3. Confirm hero title/subtitle/search bar stay in place
4. Confirm results popup overlays featured items below
5. Click outside or clear search and confirm popup fades out smoothly

## Tickets

[CFDP-4018](https://christfellowship.atlassian.net/browse/CFDP-4018)

## Changes Made

### Route Implementation

- `app/routes/home/components/hero/desktop-hero.component.tsx` — keep subtitle visible; raise search wrapper z-index while searching
- `app/routes/home/components/location-search/location-search-inner.component.tsx` — absolute popup overlay, mount/visibility animation state, stable container width, smooth padding transition
- `app/routes/home/components/location-search/search-popup.tsx` — remove redundant vertical padding now handled by parent container

### Key Features

- Hero title, subtitle, and search bar remain fixed when location results open
- Search popup is absolutely positioned and no longer pushes hero content via flex reflow
- Popup layers above `DesktopFeaturedItems` during active search
- Unified white card treatment around search bar in popup mode
- 200ms fade and padding transitions on popup open/close

Made with [Cursor](https://cursor.com)

[CFDP-4018]: https://christfellowshipchurch.atlassian.net/browse/CFDP-4018?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ