### PR TITLE
 FAQ order, collection card dates & clickthrough auto-advance

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -5,7 +5,8 @@
       "name": "dev",
       "runtimeExecutable": "pnpm",
       "runtimeArgs": ["dev"],
-      "port": 5173
+      "port": 5173,
+      "autoPort": true
     }
   ]
 }

--- a/app/components/navbar/navbar.component.tsx
+++ b/app/components/navbar/navbar.component.tsx
@@ -202,7 +202,8 @@ export function Navbar() {
     watchReadListen?.featureCards,
   );
   const isTransparentMode = mode === 'dark' && !openDropdown && !isSearchOpen;
-  const useOceanLogo = mode === 'light' || openDropdown !== null || isSearchOpen;
+  const useOceanLogo =
+    mode === 'light' || openDropdown !== null || isSearchOpen;
 
   // Search handling
   const handleSearchClick = () => {

--- a/app/routes/events/event-single/components/clickthrough-registration.component.tsx
+++ b/app/routes/events/event-single/components/clickthrough-registration.component.tsx
@@ -69,7 +69,6 @@ export const ClickThroughRegistration = ({
   const [selectedDate, setSelectedDate] = useState<string>('');
   const [selectedTime, setSelectedTime] = useState<string>('');
   const [campusSearchQuery, setCampusSearchQuery] = useState<string>('');
-  const [isGoingBack, setIsGoingBack] = useState(false);
   const [pendingRegisterScroll, setPendingRegisterScroll] = useState(false);
   const previousStepRef = useRef<number>(1);
 
@@ -80,7 +79,6 @@ export const ClickThroughRegistration = ({
     setSelectedDate('');
     setSelectedTime('');
     setCampusSearchQuery('');
-    setIsGoingBack(false);
     previousStepRef.current = 1;
     setPendingRegisterScroll(true);
   };
@@ -105,8 +103,6 @@ export const ClickThroughRegistration = ({
 
   const handleBack = () => {
     if (step > 1) {
-      // Set flag to disable auto-select (will be reset when user makes a selection)
-      setIsGoingBack(true);
       previousStepRef.current = step;
       // Clear selections when going back based on current step
       if (step === 5) {
@@ -131,8 +127,6 @@ export const ClickThroughRegistration = ({
   };
 
   const navigateToStep = (targetDisplayStep: number) => {
-    // Set flag to disable auto-select (will be reset when user makes a selection)
-    setIsGoingBack(true);
     previousStepRef.current = step;
     const targetActualStep = getActualStep(targetDisplayStep);
     // Clear selections for steps after the target step
@@ -319,29 +313,24 @@ export const ClickThroughRegistration = ({
                   selectedDate={selectedDate}
                   selectedTime={selectedTime}
                   campusSearchQuery={campusSearchQuery}
-                  isGoingBack={isGoingBack}
                   groupType={extractedGroupType}
                   onCampusSelect={(campus) => {
                     setSelectedCampus(campus);
-                    setIsGoingBack(false);
                     previousStepRef.current = 1;
                     setStep(hasSubGroups ? 2 : 3);
                   }}
                   onSubGroupTypeSelect={(subGroupType) => {
                     setSelectedSubGroupType(subGroupType);
-                    setIsGoingBack(false);
                     previousStepRef.current = 2;
                     setStep(3);
                   }}
                   onDateSelect={(date) => {
                     setSelectedDate(date);
-                    setIsGoingBack(false);
                     previousStepRef.current = hasSubGroups ? 3 : 3;
                     setStep(4);
                   }}
                   onTimeSelect={(time) => {
                     setSelectedTime(time);
-                    setIsGoingBack(false);
                     previousStepRef.current = hasSubGroups ? 4 : 3;
                     setStep(5);
                   }}
@@ -389,7 +378,6 @@ interface StepContentProps {
   selectedDate: string;
   selectedTime: string;
   campusSearchQuery: string;
-  isGoingBack: boolean;
   groupType: string;
   hasSubGroups: boolean;
   onCampusSelect: (campus: string) => void;
@@ -407,7 +395,6 @@ const StepContent = ({
   selectedDate,
   selectedTime,
   campusSearchQuery,
-  isGoingBack,
   groupType,
   hasSubGroups,
   onCampusSelect,
@@ -418,20 +405,6 @@ const StepContent = ({
   onResetRegistration,
 }: StepContentProps) => {
   const { items } = useHits<EventFinderHit>();
-  const stepRef = useRef(step);
-  const wasGoingBackRef = useRef(false);
-
-  // Track if we're going back by comparing current step to previous step
-  useEffect(() => {
-    if (step < stepRef.current) {
-      // Going backward - set flag
-      wasGoingBackRef.current = true;
-    } else if (step > stepRef.current) {
-      // Going forward - clear flag
-      wasGoingBackRef.current = false;
-    }
-    stepRef.current = step;
-  }, [step]);
 
   // Handle case where no hits are available
   if (items.length === 0 && step !== 5) {
@@ -451,7 +424,6 @@ const StepContent = ({
         onSelect={onCampusSelect}
         searchQuery={campusSearchQuery}
         onSearchChange={onCampusSearchChange}
-        isGoingBack={isGoingBack || wasGoingBackRef.current}
       />
     );
   }
@@ -463,7 +435,6 @@ const StepContent = ({
         selectedCampus={selectedCampus}
         groupType={groupType}
         onSelect={onSubGroupTypeSelect}
-        isGoingBack={isGoingBack || wasGoingBackRef.current}
       />
     );
   }
@@ -476,7 +447,6 @@ const StepContent = ({
         selectedSubGroupType={selectedSubGroupType}
         hasSubGroups={hasSubGroups}
         onSelect={onDateSelect}
-        isGoingBack={isGoingBack || wasGoingBackRef.current}
       />
     );
   }
@@ -490,7 +460,6 @@ const StepContent = ({
         selectedDate={selectedDate}
         hasSubGroups={hasSubGroups}
         onSelect={onTimeSelect}
-        isGoingBack={isGoingBack || wasGoingBackRef.current}
       />
     );
   }
@@ -529,7 +498,6 @@ interface CampusStepProps {
   onSelect: (campus: string) => void;
   searchQuery: string;
   onSearchChange: (query: string) => void;
-  isGoingBack: boolean;
 }
 
 const CampusStep = ({
@@ -537,7 +505,6 @@ const CampusStep = ({
   onSelect,
   searchQuery,
   onSearchChange,
-  isGoingBack,
 }: CampusStepProps) => {
   // Get unique campuses
   const uniqueCampuses = useMemo(() => {
@@ -582,13 +549,6 @@ const CampusStep = ({
     );
   }, [uniqueCampuses, searchQuery]);
 
-  // Auto-select if only one option (only when not searching and not going back)
-  useEffect(() => {
-    if (!isGoingBack && !searchQuery && filteredCampuses.length === 1) {
-      onSelect(filteredCampuses[0].name);
-    }
-  }, [filteredCampuses, searchQuery, onSelect, isGoingBack]);
-
   return (
     <div className='flex flex-col gap-4'>
       {/* Search Input */}
@@ -631,7 +591,6 @@ interface SubGroupTypeStepProps {
   selectedCampus: string;
   groupType: string;
   onSelect: (subGroupType: string) => void;
-  isGoingBack: boolean;
 }
 
 const SubGroupTypeStep = ({
@@ -639,7 +598,6 @@ const SubGroupTypeStep = ({
   selectedCampus,
   groupType,
   onSelect,
-  isGoingBack,
 }: SubGroupTypeStepProps) => {
   // Get unique subGroupTypes for selected campus
   const uniqueSubGroupTypes = useMemo(() => {
@@ -658,13 +616,6 @@ const SubGroupTypeStep = ({
       });
     return Array.from(subGroupTypeMap.values()).sort();
   }, [hits, selectedCampus]);
-
-  // Auto-select if only one option (only when not going back)
-  useEffect(() => {
-    if (!isGoingBack && uniqueSubGroupTypes.length === 1) {
-      onSelect(uniqueSubGroupTypes[0]);
-    }
-  }, [uniqueSubGroupTypes, onSelect, isGoingBack]);
 
   if (uniqueSubGroupTypes.length === 0) {
     return (
@@ -704,7 +655,6 @@ interface DateStepProps {
   selectedSubGroupType: string;
   hasSubGroups: boolean;
   onSelect: (date: string) => void;
-  isGoingBack: boolean;
 }
 
 const DateStep = ({
@@ -713,7 +663,6 @@ const DateStep = ({
   selectedSubGroupType,
   hasSubGroups,
   onSelect,
-  isGoingBack,
 }: DateStepProps) => {
   // Get unique dates for selected campus and subGroupType (if applicable)
   const uniqueDates = useMemo(() => {
@@ -746,13 +695,6 @@ const DateStep = ({
     );
   }, [hits, selectedCampus, selectedSubGroupType, hasSubGroups]);
 
-  // Auto-select if only one option (only when not going back)
-  useEffect(() => {
-    if (!isGoingBack && uniqueDates.length === 1) {
-      onSelect(uniqueDates[0].date);
-    }
-  }, [uniqueDates, onSelect, isGoingBack]);
-
   return (
     <div className='flex flex-wrap justify-center gap-4'>
       {uniqueDates.map((dateInfo) => (
@@ -777,7 +719,6 @@ interface TimeStepProps {
   selectedDate: string;
   hasSubGroups: boolean;
   onSelect: (time: string) => void;
-  isGoingBack: boolean;
 }
 
 const TimeStep = ({
@@ -787,7 +728,6 @@ const TimeStep = ({
   selectedDate,
   hasSubGroups,
   onSelect,
-  isGoingBack,
 }: TimeStepProps) => {
   // Get unique times for selected campus, subGroupType (if applicable), and date
   const uniqueTimes = useMemo(() => {
@@ -823,13 +763,6 @@ const TimeStep = ({
 
     return Array.from(timeMap.values());
   }, [hits, selectedCampus, selectedSubGroupType, selectedDate, hasSubGroups]);
-
-  // Auto-select if only one option (only when not going back)
-  useEffect(() => {
-    if (!isGoingBack && uniqueTimes.length === 1) {
-      onSelect(uniqueTimes[0].time);
-    }
-  }, [uniqueTimes, onSelect, isGoingBack]);
 
   if (uniqueTimes.length === 0) {
     return (

--- a/app/routes/page-builder/loader.tsx
+++ b/app/routes/page-builder/loader.tsx
@@ -376,9 +376,14 @@ export const mapPageBuilderChildItems = async (
                   );
               }
 
-              // Generate the start date for the item
+              // Generate the start date for the item.
+              // Page Builder items have no meaningful start date in a
+              // collection context, so skip it (same as REDIRECT_CARD).
               let startDate = '';
-              if (contentType !== 'REDIRECT_CARD') {
+              if (
+                contentType !== 'REDIRECT_CARD' &&
+                contentType !== 'PAGE_BUILDER'
+              ) {
                 const startDateTime = item.startDateTime || '';
                 if (startDateTime) {
                   startDate = format(
@@ -462,6 +467,7 @@ export const mapPageBuilderChildItems = async (
           endpoint: `AttributeMatrixItems`,
           queryParams: {
             $filter: `AttributeMatrix/${getIdentifierType(matrixId).query}`,
+            $orderby: 'Order',
             loadAttributes: 'simple',
           },
         });


### PR DESCRIPTION
## Summary

Three independent content-rendering bug fixes for the public site, plus a
minor lint/tooling cleanup.

- **FAQ ordering (CFDP-4038):** Wedding Guide (and all page-builder) FAQs now
  render in the order set in Rock. The `AttributeMatrixItems` query was missing
  an `$orderby`, so FAQs came back in default (Id) order. Added
  `$orderby: 'Order'`, matching the pattern already used for content channel
  items in the same loader.
- **Collection card start dates (CFDP-4042):** Page Builder content items
  rendered inside a collection no longer show a meaningless start date. The
  collection loader generated a `startDate` for every content type except
  `REDIRECT_CARD`; added `PAGE_BUILDER` to that exclusion so no date is produced.
- **Clickthrough auto-advance (CFDP-4020):** The Event Finder's Clickthrough
  Registration no longer auto-advances to the next step when only one option is
  available. Removed the four auto-select effects (campus / event type / date /
  time) and the now-dead `isGoingBack` + `wasGoingBackRef` gating plumbing that
  existed solely to suppress auto-advance. Users now progress by explicit click
  at every step.

## Screenshots

N/A — text/data rendering fixes. Verification details below.

## Testing

- [x] What steps can someone follow to verify functionality?
  1. `/wedding-guide` → confirm FAQs match Rock order ("Other Details" last).
  2. `/ministries/freedom-and-care` → confirm Page Builder cards in collections
     show no start date.
  3. Open an Event Finder registration with a group type that has a single
     campus/date/time → confirm it does NOT auto-skip; each step needs a click.
- [x] No linter errors/warnings

## Tickets

[CFDP-4020](https://christfellowshipchurch.atlassian.net/browse/CFDP-4020)
[CFDP-4038](https://christfellowshipchurch.atlassian.net/browse/CFDP-4038)
[CFDP-4042](https://christfellowshipchurch.atlassian.net/browse/CFDP-4042)


## Changes Made

### Route Implementation

- `app/routes/page-builder/loader.tsx`
  - FAQ section: added `$orderby: 'Order'` to the `AttributeMatrixItems` query
    so FAQs respect the order set in Rock. (CFDP-4038)
  - Collection items: added `PAGE_BUILDER` to the start-date exclusion alongside
    `REDIRECT_CARD`, so Page Builder cards in collections render no date.
    (CFDP-4042)
- `app/routes/events/event-single/components/clickthrough-registration.component.tsx`
  - Removed the four single-option auto-advance effects and the associated
    `isGoingBack` / `wasGoingBackRef` step-tracking plumbing. (CFDP-4020)

### New Components Added

- None

### New Utilities

- None

### New Assets

- None

### Dependencies

- None

### Key Features

- None (bug fixes). Net effect: FAQ/collection content renders as authored in
  Rock, and the registration flow stays under explicit user control.

### Other / Incidental

- `app/components/navbar/navbar.component.tsx` — formatting-only lint fix
  (line wrap), no behavior change.
- `.claude/launch.json` — enabled `autoPort` for local preview (dev tooling only).

[CFDP-4020]: https://christfellowshipchurch.atlassian.net/browse/CFDP-4020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ