### PR TITLE
Complete DreamTeam Onboarding Rock Form Integration

### DIFF
--- a/app/components/rock-embed/index.tsx
+++ b/app/components/rock-embed/index.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { cn } from '~/lib/utils';
+import { resolveRockIframeNavigateUrl } from '~/lib/rock-iframe-navigate';
 import { getRockEmbedOrigin } from '~/lib/rock-iframe-resize';
 
 type RockProxyMode = 'full' | 'minimal';
@@ -84,22 +85,36 @@ export function RockProxyEmbed({
   }, []);
 
   useEffect(() => {
-    if (!autoHeight) return;
-
     const handleMessage = (event: Event) => {
       const messageEvent = event as Event & {
-        data?: { type?: string; height?: number };
+        data?: { type?: string; height?: number; url?: string };
         origin: string;
         source: unknown;
       };
-      if (messageEvent.data?.type !== 'rock-iframe-resize') return;
       if (messageEvent.source !== iframeRef.current?.contentWindow) return;
 
-      // Accept resize messages from the Rock origin (direct embed) or same-origin proxy.
       const allowedOrigins = new Set(
         [embedOrigin, window.location.origin].filter(Boolean),
       );
       if (!allowedOrigins.has(messageEvent.origin)) return;
+
+      if (messageEvent.data?.type === 'rock-iframe-navigate') {
+        const targetUrl = messageEvent.data.url;
+        if (typeof targetUrl !== 'string') return;
+
+        const resolved = resolveRockIframeNavigateUrl(
+          targetUrl,
+          window.location.origin,
+        );
+        if (!resolved) return;
+
+        window.location.assign(resolved);
+        return;
+      }
+
+      if (!autoHeight || messageEvent.data?.type !== 'rock-iframe-resize') {
+        return;
+      }
 
       const nextHeight = messageEvent.data.height;
       if (typeof nextHeight !== 'number' || nextHeight <= 0) return;
@@ -159,7 +174,7 @@ export function RockProxyEmbed({
     style: { height: `${resolvedHeight}px` },
     title: 'Rock RMS Embedded Content',
     sandbox:
-      'allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox allow-fullscreen',
+      'allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox allow-fullscreen allow-top-navigation-by-user-activation',
     scrolling: autoHeight ? ('no' as const) : undefined,
     loading: 'lazy' as const,
     onLoad: handleLoad,

--- a/app/lib/__tests__/rock-iframe-navigate.test.ts
+++ b/app/lib/__tests__/rock-iframe-navigate.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { resolveRockIframeNavigateUrl } from '../rock-iframe-navigate';
+
+describe('resolveRockIframeNavigateUrl', () => {
+  const origin = 'https://christfellowship.church';
+
+  it('accepts same-origin paths', () => {
+    expect(resolveRockIframeNavigateUrl('/volunteer', origin)).toBe(
+      '/volunteer',
+    );
+  });
+
+  it('accepts absolute production URLs', () => {
+    expect(
+      resolveRockIframeNavigateUrl('https://christfellowship.church/volunteer', origin),
+    ).toBe('https://christfellowship.church/volunteer');
+  });
+
+  it('rejects external origins', () => {
+    expect(
+      resolveRockIframeNavigateUrl('https://example.com/volunteer', origin),
+    ).toBeNull();
+  });
+
+  it('rejects protocol-relative URLs', () => {
+    expect(resolveRockIframeNavigateUrl('//example.com/volunteer', origin)).toBeNull();
+  });
+});

--- a/app/lib/__tests__/rock-iframe-navigate.test.ts
+++ b/app/lib/__tests__/rock-iframe-navigate.test.ts
@@ -12,7 +12,10 @@ describe('resolveRockIframeNavigateUrl', () => {
 
   it('accepts absolute production URLs', () => {
     expect(
-      resolveRockIframeNavigateUrl('https://christfellowship.church/volunteer', origin),
+      resolveRockIframeNavigateUrl(
+        'https://christfellowship.church/volunteer',
+        origin,
+      ),
     ).toBe('https://christfellowship.church/volunteer');
   });
 
@@ -23,6 +26,8 @@ describe('resolveRockIframeNavigateUrl', () => {
   });
 
   it('rejects protocol-relative URLs', () => {
-    expect(resolveRockIframeNavigateUrl('//example.com/volunteer', origin)).toBeNull();
+    expect(
+      resolveRockIframeNavigateUrl('//example.com/volunteer', origin),
+    ).toBeNull();
   });
 });

--- a/app/lib/rock-iframe-navigate.ts
+++ b/app/lib/rock-iframe-navigate.ts
@@ -15,10 +15,7 @@ export function resolveRockIframeNavigateUrl(
   const trimmed = rawUrl.trim();
   if (!trimmed) return null;
 
-  const allowedOrigins = new Set([
-    currentOrigin,
-    ...PRODUCTION_SITE_ORIGINS,
-  ]);
+  const allowedOrigins = new Set([currentOrigin, ...PRODUCTION_SITE_ORIGINS]);
 
   if (trimmed.startsWith('/') && !trimmed.startsWith('//')) {
     try {

--- a/app/lib/rock-iframe-navigate.ts
+++ b/app/lib/rock-iframe-navigate.ts
@@ -1,0 +1,41 @@
+/** Allowed origins for parent navigation triggered by Rock iframe postMessage. */
+const PRODUCTION_SITE_ORIGINS = new Set([
+  'https://christfellowship.church',
+  'https://www.christfellowship.church',
+]);
+
+/**
+ * Resolve a navigation target from a Rock iframe postMessage.
+ * Accepts same-origin paths or absolute URLs on the public site.
+ */
+export function resolveRockIframeNavigateUrl(
+  rawUrl: string,
+  currentOrigin: string,
+): string | null {
+  const trimmed = rawUrl.trim();
+  if (!trimmed) return null;
+
+  const allowedOrigins = new Set([
+    currentOrigin,
+    ...PRODUCTION_SITE_ORIGINS,
+  ]);
+
+  if (trimmed.startsWith('/') && !trimmed.startsWith('//')) {
+    try {
+      const url = new URL(trimmed, currentOrigin);
+      if (!allowedOrigins.has(url.origin)) return null;
+      return `${url.pathname}${url.search}${url.hash}`;
+    } catch {
+      return null;
+    }
+  }
+
+  try {
+    const url = new URL(trimmed);
+    if (url.protocol !== 'https:' && url.protocol !== 'http:') return null;
+    if (!allowedOrigins.has(url.origin)) return null;
+    return url.href;
+  } catch {
+    return null;
+  }
+}

--- a/app/lib/rock-iframe-resize.ts
+++ b/app/lib/rock-iframe-resize.ts
@@ -14,6 +14,11 @@ export const ROCK_PARENT_RESIZE_QUERY_PARAM = 'ParentResize';
  * {% if PageParameter.ParentResize == '1' %}
  * <script src="https://YOUR_APP_ORIGIN/rock-iframe-resize.js"></script>
  * {% endif %}
+ *
+ * Parent navigation from inside the iframe (when target="_top" is blocked):
+ * <a href="#" data-rock-parent-navigate="https://christfellowship.church/volunteer">
+ *   Back to volunteer page
+ * </a>
  */
 export function getRockEmbedOrigin(url: string): string | null {
   try {

--- a/app/routes/rock-page/__tests__/loader.test.ts
+++ b/app/routes/rock-page/__tests__/loader.test.ts
@@ -24,13 +24,13 @@ function expectResponse(error: unknown, status: number): void {
 describe('buildChurchOpportunityApplicationUrl', () => {
   it('builds the Rock church opportunity application URL', () => {
     expect(buildChurchOpportunityApplicationUrl('abc-123')).toBe(
-      'https://rock.christfellowship.church/page/5886?OpportunityId=abc-123&ParentResize=1',
+      'https://rock.christfellowship.church/page/5886?OpportunityId=abc-123&returnUrl=https%3A%2F%2Fchristfellowship.church%2Fvolunteer&ParentResize=1',
     );
   });
 
   it('encodes opportunity IDs as query parameter values', () => {
     expect(buildChurchOpportunityApplicationUrl('abc 123?x=y')).toBe(
-      'https://rock.christfellowship.church/page/5886?OpportunityId=abc+123%3Fx%3Dy&ParentResize=1',
+      'https://rock.christfellowship.church/page/5886?OpportunityId=abc+123%3Fx%3Dy&returnUrl=https%3A%2F%2Fchristfellowship.church%2Fvolunteer&ParentResize=1',
     );
   });
 });
@@ -51,7 +51,7 @@ describe('buildRockPageEmbedUrl', () => {
     );
 
     expect(result).toBe(
-      'https://rock.christfellowship.church/page/5886?OpportunityId=abc-123&ParentResize=1',
+      'https://rock.christfellowship.church/page/5886?OpportunityId=abc-123&returnUrl=https%3A%2F%2Fchristfellowship.church%2Fvolunteer&ParentResize=1',
     );
   });
 
@@ -87,7 +87,7 @@ describe('rock-page loader', () => {
     );
 
     expect(result).toEqual({
-      url: 'https://rock.christfellowship.church/page/5886?OpportunityId=abc-123&ParentResize=1',
+      url: 'https://rock.christfellowship.church/page/5886?OpportunityId=abc-123&returnUrl=https%3A%2F%2Fchristfellowship.church%2Fvolunteer&ParentResize=1',
     });
   });
 
@@ -107,7 +107,7 @@ describe('rock-page loader', () => {
     );
 
     expect(result.url).toBe(
-      'https://rock.christfellowship.church/page/5886?OpportunityId=abc-123&ParentResize=1',
+      'https://rock.christfellowship.church/page/5886?OpportunityId=abc-123&returnUrl=https%3A%2F%2Fchristfellowship.church%2Fvolunteer&ParentResize=1',
     );
   });
 

--- a/app/routes/rock-page/__tests__/loader.test.ts
+++ b/app/routes/rock-page/__tests__/loader.test.ts
@@ -38,7 +38,7 @@ describe('buildChurchOpportunityApplicationUrl', () => {
 describe('buildVolunteerApplicationUrl', () => {
   it('builds the Rock volunteer application form embed URL', () => {
     expect(buildVolunteerApplicationUrl()).toBe(
-      'https://rock.christfellowship.church/form-embed?WorkflowTypeGuid=119671db-8ad4-4654-ab45-32d7e79e55e0&ParentResize=1',
+      'https://rock.christfellowship.church/form-embed?WorkflowTypeGuid=119671db-8ad4-4654-ab45-32d7e79e55e0&returnUrl=https%3A%2F%2Fchristfellowship.church%2Fvolunteer&ParentResize=1',
     );
   });
 });
@@ -97,7 +97,7 @@ describe('rock-page loader', () => {
     );
 
     expect(result).toEqual({
-      url: 'https://rock.christfellowship.church/form-embed?WorkflowTypeGuid=119671db-8ad4-4654-ab45-32d7e79e55e0&ParentResize=1',
+      url: 'https://rock.christfellowship.church/form-embed?WorkflowTypeGuid=119671db-8ad4-4654-ab45-32d7e79e55e0&returnUrl=https%3A%2F%2Fchristfellowship.church%2Fvolunteer&ParentResize=1',
     });
   });
 

--- a/app/routes/rock-page/__tests__/loader.test.ts
+++ b/app/routes/rock-page/__tests__/loader.test.ts
@@ -87,6 +87,7 @@ describe('rock-page loader', () => {
     );
 
     expect(result).toEqual({
+      embed: 'church-opportunity',
       url: 'https://rock.christfellowship.church/page/5886?OpportunityId=abc-123&returnUrl=https%3A%2F%2Fchristfellowship.church%2Fvolunteer&ParentResize=1',
     });
   });
@@ -97,6 +98,7 @@ describe('rock-page loader', () => {
     );
 
     expect(result).toEqual({
+      embed: 'volunteer-application',
       url: 'https://rock.christfellowship.church/form-embed?WorkflowTypeGuid=119671db-8ad4-4654-ab45-32d7e79e55e0&returnUrl=https%3A%2F%2Fchristfellowship.church%2Fvolunteer&ParentResize=1',
     });
   });
@@ -118,7 +120,7 @@ describe('rock-page loader', () => {
 
     const result = await loader(makeLoaderArgs(`?${searchParams.toString()}`));
 
-    expect(result).toEqual({ url: rockUrl });
+    expect(result).toEqual({ embed: null, url: rockUrl });
   });
 
   it('rejects unsupported embed links instead of falling back to url', async () => {

--- a/app/routes/rock-page/__tests__/loader.test.ts
+++ b/app/routes/rock-page/__tests__/loader.test.ts
@@ -93,9 +93,7 @@ describe('rock-page loader', () => {
   });
 
   it('returns a validated Rock URL for the volunteer application embed', async () => {
-    const result = await loader(
-      makeLoaderArgs('?embed=volunteer-application'),
-    );
+    const result = await loader(makeLoaderArgs('?embed=volunteer-application'));
 
     expect(result).toEqual({
       embed: 'volunteer-application',

--- a/app/routes/rock-page/__tests__/loader.test.ts
+++ b/app/routes/rock-page/__tests__/loader.test.ts
@@ -3,6 +3,7 @@ import { loader } from '../loader';
 import {
   buildChurchOpportunityApplicationUrl,
   buildRockPageEmbedUrl,
+  buildVolunteerApplicationUrl,
   ROCK_PAGE_EMBED_KEYS,
 } from '../rock-page.data';
 
@@ -30,6 +31,14 @@ describe('buildChurchOpportunityApplicationUrl', () => {
   it('encodes opportunity IDs as query parameter values', () => {
     expect(buildChurchOpportunityApplicationUrl('abc 123?x=y')).toBe(
       'https://rock.christfellowship.church/page/5886?OpportunityId=abc+123%3Fx%3Dy&ParentResize=1',
+    );
+  });
+});
+
+describe('buildVolunteerApplicationUrl', () => {
+  it('builds the Rock volunteer application form embed URL', () => {
+    expect(buildVolunteerApplicationUrl()).toBe(
+      'https://rock.christfellowship.church/form-embed?WorkflowTypeGuid=119671db-8ad4-4654-ab45-32d7e79e55e0&ParentResize=1',
     );
   });
 });
@@ -79,6 +88,16 @@ describe('rock-page loader', () => {
 
     expect(result).toEqual({
       url: 'https://rock.christfellowship.church/page/5886?OpportunityId=abc-123&ParentResize=1',
+    });
+  });
+
+  it('returns a validated Rock URL for the volunteer application embed', async () => {
+    const result = await loader(
+      makeLoaderArgs('?embed=volunteer-application'),
+    );
+
+    expect(result).toEqual({
+      url: 'https://rock.christfellowship.church/form-embed?WorkflowTypeGuid=119671db-8ad4-4654-ab45-32d7e79e55e0&ParentResize=1',
     });
   });
 

--- a/app/routes/rock-page/loader.ts
+++ b/app/routes/rock-page/loader.ts
@@ -11,11 +11,12 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
   if (embed) {
     return {
+      embed,
       url: validateRockUrlString(
         buildRockPageEmbedUrl(embed, requestUrl.searchParams),
       ),
     };
   }
 
-  return { url: validateRockUrl(request) };
+  return { embed: null, url: validateRockUrl(request) };
 }

--- a/app/routes/rock-page/rock-page.data.ts
+++ b/app/routes/rock-page/rock-page.data.ts
@@ -10,9 +10,14 @@ import { ROCK_PARENT_RESIZE_QUERY_PARAM } from '~/lib/rock-iframe-resize';
 // Page IDs for Rock pages that this app embeds by name.
 export const CHURCH_OPPORTUNITY_APPLICATION_PAGE_ID = '5886';
 
+/** Rock workflow form for "Help Me Find a Place" volunteer applications. */
+export const VOLUNTEER_APPLICATION_WORKFLOW_TYPE_GUID =
+  '119671db-8ad4-4654-ab45-32d7e79e55e0';
+
 // Keys for the embeds.
 export const ROCK_PAGE_EMBED_KEYS = {
   churchOpportunity: 'church-opportunity',
+  volunteerApplication: 'volunteer-application',
 } as const;
 
 type RockPageEmbedKey =
@@ -20,7 +25,10 @@ type RockPageEmbedKey =
 
 type RockPageEmbedConfig = {
   path: string;
-  queryParams: Record<string, string>;
+  /** Maps app query param names to Rock query param names (values from request). */
+  queryParams?: Record<string, string>;
+  /** Fixed Rock query params (always appended). */
+  fixedQueryParams?: Record<string, string>;
 };
 
 // Config for the embeds.
@@ -29,6 +37,12 @@ const ROCK_PAGE_EMBEDS: Record<RockPageEmbedKey, RockPageEmbedConfig> = {
     path: `/page/${CHURCH_OPPORTUNITY_APPLICATION_PAGE_ID}`,
     queryParams: {
       opportunityId: 'OpportunityId',
+    },
+  },
+  [ROCK_PAGE_EMBED_KEYS.volunteerApplication]: {
+    path: '/form-embed',
+    fixedQueryParams: {
+      WorkflowTypeGuid: VOLUNTEER_APPLICATION_WORKFLOW_TYPE_GUID,
     },
   },
 };
@@ -45,13 +59,21 @@ export function buildRockPageEmbedUrl(
 
   const url = new URL(embed.path, ROCK_PUBLIC_SITE_ORIGIN);
 
-  for (const [queryParam, rockParam] of Object.entries(embed.queryParams)) {
+  for (const [queryParam, rockParam] of Object.entries(
+    embed.queryParams ?? {},
+  )) {
     const value = searchParams.get(queryParam)?.trim();
 
     if (!value) {
       throw new Response(`${queryParam} parameter required`, { status: 400 });
     }
 
+    url.searchParams.set(rockParam, value);
+  }
+
+  for (const [rockParam, value] of Object.entries(
+    embed.fixedQueryParams ?? {},
+  )) {
     url.searchParams.set(rockParam, value);
   }
 
@@ -66,5 +88,12 @@ export function buildChurchOpportunityApplicationUrl(
   return buildRockPageEmbedUrl(
     ROCK_PAGE_EMBED_KEYS.churchOpportunity,
     new URLSearchParams({ opportunityId }),
+  );
+}
+
+export function buildVolunteerApplicationUrl(): string {
+  return buildRockPageEmbedUrl(
+    ROCK_PAGE_EMBED_KEYS.volunteerApplication,
+    new URLSearchParams(),
   );
 }

--- a/app/routes/rock-page/rock-page.data.ts
+++ b/app/routes/rock-page/rock-page.data.ts
@@ -14,8 +14,12 @@ export const CHURCH_OPPORTUNITY_APPLICATION_PAGE_ID = '5886';
 export const VOLUNTEER_APPLICATION_WORKFLOW_TYPE_GUID =
   '119671db-8ad4-4654-ab45-32d7e79e55e0';
 
-/** Return URL passed to Rock for post-submission navigation back to the site. */
-export const VOLUNTEER_APPLICATION_RETURN_URL =
+/**
+ * Return URL passed to Rock embeds so selection/confirmation pages can link back.
+ * Rock must persist this via a workflow attribute — query params do not survive
+ * form → selection → confirmation redirects. See rock-page embed configs below.
+ */
+export const VOLUNTEER_PAGE_RETURN_URL =
   'https://christfellowship.church/volunteer';
 
 // Keys for the embeds.
@@ -42,12 +46,15 @@ const ROCK_PAGE_EMBEDS: Record<RockPageEmbedKey, RockPageEmbedConfig> = {
     queryParams: {
       opportunityId: 'OpportunityId',
     },
+    fixedQueryParams: {
+      returnUrl: VOLUNTEER_PAGE_RETURN_URL,
+    },
   },
   [ROCK_PAGE_EMBED_KEYS.volunteerApplication]: {
     path: '/form-embed',
     fixedQueryParams: {
       WorkflowTypeGuid: VOLUNTEER_APPLICATION_WORKFLOW_TYPE_GUID,
-      returnUrl: VOLUNTEER_APPLICATION_RETURN_URL,
+      returnUrl: VOLUNTEER_PAGE_RETURN_URL,
     },
   },
 };

--- a/app/routes/rock-page/rock-page.data.ts
+++ b/app/routes/rock-page/rock-page.data.ts
@@ -14,6 +14,10 @@ export const CHURCH_OPPORTUNITY_APPLICATION_PAGE_ID = '5886';
 export const VOLUNTEER_APPLICATION_WORKFLOW_TYPE_GUID =
   '119671db-8ad4-4654-ab45-32d7e79e55e0';
 
+/** Return URL passed to Rock for post-submission navigation back to the site. */
+export const VOLUNTEER_APPLICATION_RETURN_URL =
+  'https://christfellowship.church/volunteer';
+
 // Keys for the embeds.
 export const ROCK_PAGE_EMBED_KEYS = {
   churchOpportunity: 'church-opportunity',
@@ -43,6 +47,7 @@ const ROCK_PAGE_EMBEDS: Record<RockPageEmbedKey, RockPageEmbedConfig> = {
     path: '/form-embed',
     fixedQueryParams: {
       WorkflowTypeGuid: VOLUNTEER_APPLICATION_WORKFLOW_TYPE_GUID,
+      returnUrl: VOLUNTEER_APPLICATION_RETURN_URL,
     },
   },
 };

--- a/app/routes/rock-page/rock-page.data.ts
+++ b/app/routes/rock-page/rock-page.data.ts
@@ -109,3 +109,15 @@ export function buildVolunteerApplicationUrl(): string {
     new URLSearchParams(),
   );
 }
+
+/** In-app back link for volunteer embed routes (outside the Rock iframe). */
+export function getRockPageVolunteerBackLink(embed?: string | null) {
+  if (
+    embed === ROCK_PAGE_EMBED_KEYS.volunteerApplication ||
+    embed === ROCK_PAGE_EMBED_KEYS.churchOpportunity
+  ) {
+    return { href: '/volunteer', label: 'Back to volunteer page' };
+  }
+
+  return null;
+}

--- a/app/routes/rock-page/route.tsx
+++ b/app/routes/rock-page/route.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from 'react';
 import { Link, useLoaderData } from 'react-router-dom';
 import { RockProxyEmbed } from '~/components/rock-embed';
 import Icon from '~/primitives/icon';
@@ -11,6 +12,14 @@ export { loader };
 export default function RockPage() {
   const { url, embed } = useLoaderData<typeof loader>();
   const backLink = getRockPageVolunteerBackLink(embed);
+
+  const handleEmbedLoad = useCallback(() => {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        window.scrollTo({ top: 0, behavior: 'auto' });
+      });
+    });
+  }, []);
 
   return (
     <div className='w-full max-w-screen-content mx-auto px-4 py-4'>
@@ -31,6 +40,7 @@ export default function RockPage() {
         autoHeight
         height={1200}
         showLoading={false}
+        onLoad={handleEmbedLoad}
       />
     </div>
   );

--- a/app/routes/rock-page/route.tsx
+++ b/app/routes/rock-page/route.tsx
@@ -1,15 +1,30 @@
-import { useLoaderData } from 'react-router-dom';
+import { Link, useLoaderData } from 'react-router-dom';
 import { RockProxyEmbed } from '~/components/rock-embed';
+import Icon from '~/primitives/icon';
 import { loader } from './loader';
 import { meta } from './meta';
+import { getRockPageVolunteerBackLink } from './rock-page.data';
 
 export { meta };
 export { loader };
 
 export default function RockPage() {
-  const { url } = useLoaderData<typeof loader>();
+  const { url, embed } = useLoaderData<typeof loader>();
+  const backLink = getRockPageVolunteerBackLink(embed);
+
   return (
-    <div className='w-full max-w-screen-content mx-auto px-4'>
+    <div className='w-full max-w-screen-content mx-auto px-4 py-4'>
+      {backLink && (
+        <nav className='mb-4'>
+          <Link
+            to={backLink.href}
+            className='inline-flex items-center gap-2 text-sm font-semibold text-neutral-darker transition-colors hover:text-ocean'
+          >
+            <Icon name='chevronLeft' size={20} className='shrink-0' />
+            {backLink.label}
+          </Link>
+        </nav>
+      )}
       <RockProxyEmbed
         useAdvancedProxy={false}
         url={url}

--- a/app/routes/volunteer-form/partials/welcome-screen.partial.tsx
+++ b/app/routes/volunteer-form/partials/welcome-screen.partial.tsx
@@ -1,6 +1,9 @@
 import React, { useEffect, useRef } from 'react';
+import { ROCK_PAGE_EMBED_KEYS } from '~/routes/rock-page/rock-page.data';
 import { Button } from '~/primitives/button/button.primitive';
 import Icon from '~/primitives/icon';
+
+const VOLUNTEER_APPLICATION_ROCK_PAGE = `/rock-page?embed=${ROCK_PAGE_EMBED_KEYS.volunteerApplication}`;
 
 export const VolunteerFormWelcome: React.FC = () => {
   const buttonRef = useRef<HTMLButtonElement>(null);
@@ -22,7 +25,7 @@ export const VolunteerFormWelcome: React.FC = () => {
           <Button
             ref={buttonRef}
             intent='primary'
-            href='/volunteer-form/about-you'
+            href={VOLUNTEER_APPLICATION_ROCK_PAGE}
             className='font-normal'
             aria-label='Start Volunteer Form'
             prefetch='viewport'

--- a/app/routes/volunteer-form/partials/welcome-screen.partial.tsx
+++ b/app/routes/volunteer-form/partials/welcome-screen.partial.tsx
@@ -17,8 +17,9 @@ export const VolunteerFormWelcome: React.FC = () => {
       <div className='px-4 flex flex-col items-center justify-center bg-white rounded-xl py-10 shadow-md max-w-md md:max-w-xl mx-auto gap-6 mb-24'>
         <h1 className='heading-h3 text-center'>Help Me Find a Place</h1>
         <p className='text-center text-text-secondary mb-10 max-w-md'>
-          Thank you for your interest in volunteering with us. We're excited to
-          have you join our team.
+          Thank you so much for your interest in volunteering at Christ
+          Fellowship! You are on your way to joining one of the most dynamic
+          ministry teams ever!
         </p>
         <div className='grid grid-cols-3 items-center gap-2'>
           <div />

--- a/public/rock-iframe-resize.js
+++ b/public/rock-iframe-resize.js
@@ -44,6 +44,20 @@
         reportHeight();
       }
     });
+
+    document.addEventListener('click', function (event) {
+      var link = event.target.closest('[data-rock-parent-navigate]');
+      if (!link) return;
+
+      event.preventDefault();
+      var url = link.getAttribute('data-rock-parent-navigate');
+      if (!url) return;
+
+      window.parent.postMessage(
+        { type: 'rock-iframe-navigate', url: url },
+        '*',
+      );
+    });
   }
 
   if (document.readyState === 'loading') {


### PR DESCRIPTION
## Summary
Add support for embedding the Rock "Help Me Find a Place" volunteer application workflow, with return URLs, parent-page navigation from the iframe, and UX polish for the volunteer embed flow.

This PR wires the volunteer form welcome screen to a new Rock embed (`/rock-page?embed=volunteer-application`) instead of an external destination. It extends the existing Rock page embed registry to support fixed query params (workflow GUID, return URL) and improves the embedded experience with back navigation, scroll-to-top on load, and secure parent-page navigation triggered from inside the Rock iframe.

## Screenshots

<img width="1103" height="966" alt="image" src="https://github.com/user-attachments/assets/ed44a22b-1ef7-47c1-b0aa-32170bf7459d" />

## Testing

- [x] Unit tests added/updated for `buildVolunteerApplicationUrl`, `buildRockPageEmbedUrl` (returnUrl), and `resolveRockIframeNavigateUrl`
- [x] Visit `/volunteer-form` and click **Get Started** — should navigate to `/rock-page?embed=volunteer-application`
- [x] Confirm **Back to volunteer page** link appears above the embed and returns to `/volunteer`
- [x] Confirm page scrolls to top when the iframe finishes loading (including in-frame navigation)
- [x] On Rock pages using `data-rock-parent-navigate`, confirm parent window navigates to allowed christfellowship.church URLs only
- [x] No new linter/type errors (`pnpm check`)

## Tickets

[CFDP-4036](https://christfellowshipchurch.atlassian.net/browse/CFDP-4036)

## Changes Made

### New Utilities

- `app/lib/rock-iframe-navigate.ts` — Validates and resolves navigation targets from Rock iframe `postMessage` events (same-origin paths and allowed production site origins only)
- `app/routes/rock-page/rock-page.data.ts` — `buildVolunteerApplicationUrl()`, `getRockPageVolunteerBackLink()`, `VOLUNTEER_APPLICATION_WORKFLOW_TYPE_GUID`, `VOLUNTEER_PAGE_RETURN_URL`

### New Assets

- None (updated existing `public/rock-iframe-resize.js`)

### Route Implementation

- `app/routes/rock-page/rock-page.data.ts` — Added `volunteer-application` embed config (`/form-embed` with WorkflowTypeGuid); added `returnUrl` to church-opportunity embed; extended `buildRockPageEmbedUrl` with `fixedQueryParams`
- `app/routes/rock-page/route.tsx` — Volunteer back link, scroll-to-top on iframe load
- `app/routes/volunteer-form/partials/welcome-screen.partial.tsx` — Links to Rock embed route; updated welcome copy

### Key Features

- **Volunteer application embed** — "Help Me Find a Place" Rock workflow embedded at `/rock-page?embed=volunteer-application`
- **Return URL** — Both volunteer and church-opportunity embeds pass `returnUrl=https://christfellowship.church/volunteer` so Rock confirmation/selection pages can link back
- **Parent navigation from iframe** — Rock pages can trigger parent navigation via `data-rock-parent-navigate` attributes; parent validates origin before navigating
- **Embed UX** — Back link to `/volunteer`, auto scroll to top after iframe load, existing auto-height resize behavior preserved

[CFDP-4036]: https://christfellowshipchurch.atlassian.net/browse/CFDP-4036?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ