### PR TITLE
Group Finder Cleanup

### DIFF
--- a/app/components/modals/help-me-find-a-group/help-me-find-a-group-form.component.tsx
+++ b/app/components/modals/help-me-find-a-group/help-me-find-a-group-form.component.tsx
@@ -118,6 +118,19 @@ const HelpMeFindAGroupForm: React.FC<HelpMeFindAGroupFormProps> = ({
           'Please enter your last name',
         )}
 
+        {renderRadixInputField(
+          'PhoneNumber',
+          'Phone',
+          'tel',
+          'Please enter your phone number',
+        )}
+        {renderRadixInputField(
+          'EmailAddress',
+          'Email',
+          'email',
+          'Please enter your email address',
+        )}
+
         <Form.Field
           name='Campus'
           className={cn('mb-4 md:col-span-2', radixFormFieldStackClassName)}
@@ -138,26 +151,7 @@ const HelpMeFindAGroupForm: React.FC<HelpMeFindAGroupFormProps> = ({
           </RadixFormErrorMessage>
         </Form.Field>
 
-        {renderRadixInputField(
-          'PhoneNumber',
-          'Cell Phone',
-          'tel',
-          'Please enter your phone number',
-        )}
-        {renderRadixInputField(
-          'EmailAddress',
-          'Email Address',
-          'email',
-          'Please enter your email address',
-        )}
-
-        <Form.Field
-          name='Type'
-          className={cn(
-            'col-span-1 mt-2 md:col-span-2',
-            radixFormFieldStackClassName,
-          )}
-        >
+        <Form.Field name='Type' className={cn(radixFormFieldStackClassName)}>
           <Form.Label className={radixFormLabelClassName}>
             I prefer to meet:
           </Form.Label>
@@ -185,12 +179,7 @@ const HelpMeFindAGroupForm: React.FC<HelpMeFindAGroupFormProps> = ({
           </RadixFormErrorMessage>
         </Form.Field>
 
-        <div
-          className={cn(
-            'col-span-1 mt-2 md:col-span-2',
-            radixFormFieldStackClassName,
-          )}
-        >
+        <div className={cn('col-span-1 mt-2', radixFormFieldStackClassName)}>
           <p className={radixFormLabelClassName}>
             I am interested in Groups in these areas:
           </p>

--- a/app/routes/class-finder/class-single/components/faq.component.tsx
+++ b/app/routes/class-finder/class-single/components/faq.component.tsx
@@ -1,3 +1,4 @@
+import { HelpMeFindAGroupModal } from '~/components/modals';
 import { Button } from '~/primitives/button/button.primitive';
 import { FinderSingleFAQ } from '~/routes/group-single/components/faq.component';
 
@@ -52,18 +53,11 @@ export const ClassFAQ = () => {
           <h3 className='text-[28px] font-extrabold'>
             Need Help Finding a Group or Class?
           </h3>
-          <p className='text-lg'>
-            Reach out to the class leader for more information.
-          </p>
         </div>
 
-        <Button
-          href='https://rock.gocf.org/page/5521?contentChannelId=170'
-          target='_blank'
-          intent='secondary'
-        >
-          Contact
-        </Button>
+        <HelpMeFindAGroupModal>
+          <Button intent='secondary'>Contact</Button>
+        </HelpMeFindAGroupModal>
       </div>
     </div>
   );

--- a/app/routes/group-finder/components/group-finder-query-input.component.tsx
+++ b/app/routes/group-finder/components/group-finder-query-input.component.tsx
@@ -38,7 +38,7 @@ export function GroupFinderQueryInput({
         type='search'
         value={localQuery}
         onChange={(event) => setLocalQuery(event.target.value)}
-        placeholder='Search'
+        placeholder='Find a group'
         aria-label='Search groups'
         className='w-full flex-grow text-base text-neutral-default placeholder:text-neutral-default px-2 py-1 focus:outline-none md:text-sm'
       />

--- a/app/routes/group-finder/components/group-finder-query-input.component.tsx
+++ b/app/routes/group-finder/components/group-finder-query-input.component.tsx
@@ -38,7 +38,7 @@ export function GroupFinderQueryInput({
         type='search'
         value={localQuery}
         onChange={(event) => setLocalQuery(event.target.value)}
-        placeholder='Find a group'
+        placeholder='Search by group name'
         aria-label='Search groups'
         className='w-full flex-grow text-base text-neutral-default placeholder:text-neutral-default px-2 py-1 focus:outline-none md:text-sm'
       />

--- a/app/routes/group-finder/components/group-hit.component.tsx
+++ b/app/routes/group-finder/components/group-hit.component.tsx
@@ -15,6 +15,22 @@ function formatGroupHitCampusName(campusName: string): string {
   return afterMarker ? `CFE ${afterMarker}` : 'CFE';
 }
 
+/**
+ * City for the card's bottom bar: the group's own meeting city when set
+ * (`meetingLocation` is "City, FL 33458"), else the campus city, else the
+ * campus name itself (e.g. "Online (CF Everywhere)").
+ */
+function groupHitCityLabel(
+  hit: GroupType,
+  campusCityByName: Record<string, string>,
+): string {
+  const meetingCity = (hit.meetingLocation || '').split(',')[0]?.trim();
+  if (meetingCity) return meetingCity;
+  return (
+    campusCityByName[hit.campusName] ?? formatGroupHitCampusName(hit.campusName)
+  );
+}
+
 function formatDistanceMiles(meters: number): string {
   const miles = meters / 1609.344;
   return `${miles.toFixed(1)} miles away`;
@@ -36,13 +52,18 @@ export function GroupHit({
   hit,
   backUrl,
   isGeoSearch = false,
+  campusCityByName = {},
 }: {
   hit: GroupType;
   backUrl?: string;
   isGeoSearch?: boolean;
+  campusCityByName?: Record<string, string>;
 }) {
   const coverImage = hit.coverImage?.sources?.[0]?.uri || '';
   const preference = hit.groupFor?.trim() || 'Anyone';
+  const campusBadge = hit.campusName?.trim()
+    ? formatGroupHitCampusName(hit.campusName)
+    : '';
   const topicTags = splitGroupTopics(hit.topics);
 
   const formatTime = (timeString: string) => {
@@ -157,7 +178,7 @@ export function GroupHit({
 
           <div className='flex min-h-0 flex-1 flex-col gap-3 pt-[10px]'>
             <div className='flex flex-col px-6 gap-3'>
-              <div className='flex flex-col gap-[10px]'>
+              <div className='flex flex-wrap items-center gap-2'>
                 <div
                   className={`${
                     preference === 'Women'
@@ -172,6 +193,11 @@ export function GroupHit({
                 >
                   {preference}
                 </div>
+                {campusBadge && (
+                  <div className='bg-navy-subdued text-dark-navy w-fit flex rounded-sm text-xs font-semibold px-2 py-1'>
+                    {campusBadge}
+                  </div>
+                )}
               </div>
 
               <div className='flex flex-col gap-1'>
@@ -194,7 +220,7 @@ export function GroupHit({
               <p className='text-sm font-semibold'>
                 {isGeoSearch
                   ? (distanceLabel ?? 'Location Varies')
-                  : formatGroupHitCampusName(hit.campusName)}
+                  : groupHitCityLabel(hit, campusCityByName)}
               </p>
             </div>
           </div>

--- a/app/routes/group-finder/group-search-filters.data.ts
+++ b/app/routes/group-finder/group-search-filters.data.ts
@@ -34,9 +34,13 @@ export function getGroupSearchDesktopFilters(
             attribute: 'meetingType',
             isMeetingType: true,
           },
+          // Zip/distance rows render location inputs, not refinement items; the
+          // attribute is a placeholder for the popup hooks. It must be one this
+          // popup already owns (`meetingType`) so campus selections (People)
+          // don't count toward — or get cleared by — the Location pill.
           {
             title: 'Filter by zip code',
-            attribute: 'campusName',
+            attribute: 'meetingType',
             isLocation: true,
             coordinates: opts.coordinates,
             setCoordinates: opts.setCoordinates,
@@ -45,7 +49,7 @@ export function getGroupSearchDesktopFilters(
           },
           {
             title: 'Filter by distance',
-            attribute: 'campusName',
+            attribute: 'meetingType',
             isCurrentLocation: true,
             coordinates: opts.coordinates,
             setCoordinates: opts.setCoordinates,
@@ -70,6 +74,11 @@ export function getGroupSearchDesktopFilters(
           {
             title: 'I want to meet people who are...',
             attribute: 'peopleWhoAre',
+          },
+          {
+            title: 'I want to meet people who attend...',
+            attribute: 'campusName',
+            isDropdown: true,
           },
           {
             title: 'Your Age',
@@ -119,11 +128,6 @@ export function getGroupSearchDesktopFilters(
             checkbox: true,
           },
           { title: 'Language', attribute: 'language' },
-          {
-            title: 'Christ Fellowship Campus',
-            attribute: 'campusName',
-            isDropdown: true,
-          },
         ],
       },
     },

--- a/app/routes/group-finder/loader.tsx
+++ b/app/routes/group-finder/loader.tsx
@@ -3,6 +3,7 @@ import type { LoaderFunctionArgs } from 'react-router';
 import { algoliasearch } from 'algoliasearch';
 
 import { AuthenticationError } from '~/lib/.server/error-types';
+import { LOCATION_SEARCH_INDEX_NAME } from '../locations/location-search/location-search.constants';
 
 import { buildGroupFinderAlgoliaSearchParams } from './components/build-group-finder-algolia-search';
 import { parseGroupFinderUrlState } from './group-finder-url-state';
@@ -16,6 +17,13 @@ export type LoaderReturnType = {
   groupNbPages: number;
   groupPage: number;
   minMaxAgeValues: string[];
+  /** Campus name -> campus city, for group cards whose groups have no meeting location. */
+  campusCityByName: Record<string, string>;
+};
+
+type CampusCityHit = {
+  campusName?: string;
+  campusLocation?: { city?: string };
 };
 
 /**
@@ -35,6 +43,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   let groupNbHits = 0;
   let groupNbPages = 0;
   let minMaxAgeValues: string[] = [];
+  const campusCityByName: Record<string, string> = {};
   const url = new URL(request.url);
 
   // The loader owns first paint and deep links. Once hydrated, same-page filter
@@ -46,15 +55,40 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   const client = algoliasearch(appId, searchApiKey, {});
 
   try {
-    const facetRes = await client.searchSingleIndex({
-      indexName: GROUPS_ALGOLIA_INDEX_NAME,
-      searchParams: {
-        facets: ['minMaxAge'],
-        hitsPerPage: 0,
-        maxValuesPerFacet: 1000,
-      },
-    });
+    // Campus cities are a card-display nicety; don't let a failure here drop
+    // the group results, just fall back to campus names on the cards.
+    const [facetRes, campusRes] = await Promise.all([
+      client.searchSingleIndex({
+        indexName: GROUPS_ALGOLIA_INDEX_NAME,
+        searchParams: {
+          facets: ['minMaxAge'],
+          hitsPerPage: 0,
+          maxValuesPerFacet: 1000,
+        },
+      }),
+      client
+        .searchSingleIndex({
+          indexName: LOCATION_SEARCH_INDEX_NAME,
+          searchParams: {
+            query: '',
+            hitsPerPage: 100,
+            attributesToRetrieve: ['campusName', 'campusLocation.city'],
+            attributesToHighlight: [],
+          },
+        })
+        .catch((error) => {
+          console.error('[group-finder] campus city fetch failed', error);
+          return null;
+        }),
+    ]);
     minMaxAgeValues = Object.keys(facetRes.facets?.minMaxAge ?? {});
+
+    for (const h of campusRes?.hits ?? []) {
+      const campus = h as unknown as CampusCityHit;
+      const name = campus.campusName?.trim();
+      const city = campus.campusLocation?.city?.trim();
+      if (name && city) campusCityByName[name] = city;
+    }
 
     const built = buildGroupFinderAlgoliaSearchParams(
       urlState,
@@ -83,5 +117,6 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
     groupNbPages,
     groupPage,
     minMaxAgeValues,
+    campusCityByName,
   } satisfies LoaderReturnType);
 };

--- a/app/routes/group-finder/partials/group-search.partial.tsx
+++ b/app/routes/group-finder/partials/group-search.partial.tsx
@@ -66,15 +66,6 @@ import {
  * See also `.github/ALGOLIA-URL-STATE-REUSABILITY.md` (Pattern A).
  */
 
-function firstCampusRefinement(
-  refinementList: Record<string, string[]> | undefined,
-): string | null {
-  const values = refinementList?.campusName;
-  if (!values?.length) return null;
-  const first = values[0]?.trim();
-  return first ? first : null;
-}
-
 function coordinatesFromUrlState(
   urlState: ReturnType<typeof parseGroupFinderUrlState>,
 ) {
@@ -96,13 +87,10 @@ function coordinatesFromUrlState(
 function getInitialStateFromUrl(searchParams: URLSearchParams) {
   const urlState = parseGroupFinderUrlState(searchParams);
   const ageInput = urlState.age ?? '';
-  const selectedLocation =
-    firstCampusRefinement(urlState.refinementList) ?? null;
 
   return {
     coordinates: coordinatesFromUrlState(urlState),
     ageInput,
-    selectedLocation,
     initialUiState: buildGroupFinderInstantSearchUiState(urlState),
   };
 }
@@ -117,6 +105,7 @@ export const GroupSearch = () => {
     groupNbPages,
     groupPage,
     minMaxAgeValues,
+    campusCityByName,
   } = loaderData;
   const [searchParams, setSearchParams] = useSearchParams();
   const location = useLocation();
@@ -150,9 +139,6 @@ export const GroupSearch = () => {
     null,
   );
   const [ageInput, setAgeInputState] = useState<string>(initial.ageInput);
-  const [selectedLocation, setSelectedLocationState] = useState<string | null>(
-    initial.selectedLocation,
-  );
 
   // `setCoordinates` must keep a STABLE identity. It is passed down into
   // `FinderLocationSearch`, whose effects list it as a dependency; if it changed
@@ -168,9 +154,6 @@ export const GroupSearch = () => {
   useEffect(() => {
     const urlState = parseGroupFinderUrlState(searchParams);
     setAgeInputState(urlState.age ?? '');
-    setSelectedLocationState(
-      firstCampusRefinement(urlState.refinementList) ?? null,
-    );
     // Keep the previous object identity when lat/lng are unchanged.
     // `coordinatesFromUrlState` mints a fresh object on every call, so writing
     // it unconditionally gave `coordinates` a new identity on *every* URL change
@@ -197,7 +180,6 @@ export const GroupSearch = () => {
     setCoordinatesState(null);
     setLocationSource(null);
     setAgeInputState('');
-    setSelectedLocationState(null);
     setSearchParams(groupFinderUrlStateToParams(groupFinderEmptyState), {
       replace: true,
       preventScrollReset: true,
@@ -284,15 +266,14 @@ export const GroupSearch = () => {
       if (item.id === 'people') return ageInput.trim().length >= 2;
       if (item.id === 'location')
         return (
-          selectedLocation != null ||
-          (coordinates?.lat != null &&
-            coordinates?.lng != null &&
-            !Number.isNaN(coordinates.lat) &&
-            !Number.isNaN(coordinates.lng))
+          coordinates?.lat != null &&
+          coordinates?.lng != null &&
+          !Number.isNaN(coordinates.lat) &&
+          !Number.isNaN(coordinates.lng)
         );
       return false;
     },
-    [ageInput, selectedLocation, coordinates],
+    [ageInput, coordinates],
   );
 
   // Merges InstantSearch refinements with age + lat/lng that live in URL but outside uiState.
@@ -411,6 +392,12 @@ export const GroupSearch = () => {
                   query={urlState.query}
                   onQueryCommit={commitQuery}
                 />
+                {/* Separates keyword search from the location/filter pills so
+                    users don't type zip codes into the keyword field. */}
+                <div
+                  aria-hidden
+                  className='hidden h-8 w-px shrink-0 bg-[#DEE0E3] md:block'
+                />
                 <SearchFilters
                   onClearAllToUrl={clearAllFiltersFromUrl}
                   desktopFilters={desktopFilters}
@@ -451,6 +438,7 @@ export const GroupSearch = () => {
               initialNbHits={groupNbHits}
               fromGroupFinderUrl={fromGroupFinderUrl}
               isGeoSearch={coordinates?.lat != null && coordinates?.lng != null}
+              campusCityByName={campusCityByName}
             />
           </InstantSearch>
         ) : (
@@ -463,6 +451,10 @@ export const GroupSearch = () => {
                 <GroupFinderQueryInput
                   query={urlState.query}
                   onQueryCommit={commitQuery}
+                />
+                <div
+                  aria-hidden
+                  className='hidden h-8 w-px shrink-0 bg-[#DEE0E3] md:block'
                 />
                 <GroupFinderFiltersSkeleton />
               </div>
@@ -478,6 +470,7 @@ export const GroupSearch = () => {
               fromGroupFinderUrl={fromGroupFinderUrl}
               onPageChange={goToPage}
               isGeoSearch={coordinates?.lat != null && coordinates?.lng != null}
+              campusCityByName={campusCityByName}
             />
           </>
         )}
@@ -491,11 +484,13 @@ function GroupFinderInstantSearchResults({
   initialNbHits,
   fromGroupFinderUrl,
   isGeoSearch,
+  campusCityByName,
 }: {
   initialHits: LoaderReturnType['groupHits'];
   initialNbHits: number;
   fromGroupFinderUrl: string;
   isGeoSearch: boolean;
+  campusCityByName: LoaderReturnType['campusCityByName'];
 }) {
   const { items } = useHits<LoaderReturnType['groupHits'][number]>();
   const { nbHits } = useStats();
@@ -543,6 +538,7 @@ function GroupFinderInstantSearchResults({
       fromGroupFinderUrl={fromGroupFinderUrl}
       onPageChange={goToPage}
       isGeoSearch={isGeoSearch}
+      campusCityByName={campusCityByName}
     />
   );
 }
@@ -557,6 +553,7 @@ function GroupFinderInitialResults({
   fromGroupFinderUrl,
   onPageChange,
   isGeoSearch,
+  campusCityByName,
 }: {
   groupHits: LoaderReturnType['groupHits'];
   groupNbHits: number;
@@ -567,6 +564,7 @@ function GroupFinderInitialResults({
   fromGroupFinderUrl: string;
   onPageChange: (nextPage: number) => void;
   isGeoSearch: boolean;
+  campusCityByName: LoaderReturnType['campusCityByName'];
 }) {
   return (
     <GroupFinderResultsLayout
@@ -580,6 +578,7 @@ function GroupFinderInitialResults({
       fromGroupFinderUrl={fromGroupFinderUrl}
       onPageChange={onPageChange}
       isGeoSearch={isGeoSearch}
+      campusCityByName={campusCityByName}
     />
   );
 }
@@ -595,6 +594,7 @@ function GroupFinderResultsLayout({
   fromGroupFinderUrl,
   onPageChange,
   isGeoSearch,
+  campusCityByName,
 }: {
   groupHits: LoaderReturnType['groupHits'];
   groupNbHits: number;
@@ -606,6 +606,7 @@ function GroupFinderResultsLayout({
   fromGroupFinderUrl: string;
   onPageChange: (nextPage: number) => void;
   isGeoSearch: boolean;
+  campusCityByName: LoaderReturnType['campusCityByName'];
 }) {
   return (
     <div className='flex flex-col bg-gray py-8 md:pt-12 md:pb-20 w-full content-padding'>
@@ -629,6 +630,7 @@ function GroupFinderResultsLayout({
                   hit={hit}
                   backUrl={fromGroupFinderUrl}
                   isGeoSearch={isGeoSearch}
+                  campusCityByName={campusCityByName}
                 />
               ))}
             </div>


### PR DESCRIPTION
## Summary

A set of Group Finder UX improvements to reduce confusion around search intent, surface more useful location data on group cards, and reorganize the campus filter for better discoverability:

- **Search bar:** clearer placeholder (`"Find a group"`) and a vertical divider between the keyword field and the filter pills, so users stop typing zip codes into the keyword search.
- **Group cards:** the blue bottom bar now shows the **city where the group meets** (parsed from `meetingLocation`), falling back to the **campus city** when the group has no meeting location set. The associated campus is now visible on the card as a badge next to the group-for tag.
- **Filters:** the Campus filter moved from the "More" dropdown into the "People" section, reworded to *"I want to meet people who attend..."* to better match user intent.

## Screenshots
<img width="1349" height="554" alt="Screenshot 2026-06-12 at 2 13 38 PM" src="https://github.com/user-attachments/assets/a186e6fd-376d-473e-8241-53078deb6039" />

## Testing

- [x] Steps to verify:
  1. Open `/group-finder` — the keyword input reads "Find a group" with a divider before the filter pills.
  2. Cards show the meeting city in the blue bar (campus city when the group has no meeting location) and a campus badge near the top tag. _Easy check is CFE cards no longer say CFE, they just say the city now._
  3. Open the **People** filter — campus dropdown appears as "I want to meet people who attend..."; it's no longer under **More**.
  4. Select a campus — the **People** pill highlights/counts it (the Location pill no longer does).
  5. Zip/distance search still shows "X miles away" / "Location Varies" in the blue bar.
- [x] No new linter errors/warnings.

## Tickets
[CFDP-4040](https://christfellowshipchurch.atlassian.net/browse/CFDP-4040)

## Changes Made

### New Components Added

- None — existing components updated.

### New Utilities

- `groupHitCityLabel()` in `app/routes/group-finder/components/group-hit.component.tsx` — resolves the card's city label: group meeting city → campus city → campus name.

### New Assets

- N/A

### Dependencies

- None.

### Route Implementation

- `app/routes/group-finder/loader.tsx` — fetches the campus list from the locations Algolia index (in parallel with the existing facet query) and exposes a `campusCityByName` map for the campus-city fallback. A failure here degrades gracefully (cards fall back to campus names) without dropping group results.
- `app/routes/group-finder/partials/group-search.partial.tsx` — threads `campusCityByName` to the cards, adds the search-bar divider (both pre- and post-hydration branches), and removes the now-obsolete `selectedLocation` supplemental highlight (campus selection no longer lights up the Location pill).
- `app/routes/group-finder/group-search-filters.data.ts` — moves the campus dropdown from **More** to **People** with the new wording; the Location popup's zip/distance placeholder rows now point at `meetingType` so campus refinements don't count toward (or get cleared by) the Location pill.
- `app/routes/group-finder/components/group-finder-query-input.component.tsx` — placeholder updated to "Find a group".

### Key Features

- Group cards communicate *where* a group actually meets (city) instead of repeating the campus name, with a sensible fallback chain.
- Campus is still identifiable at a glance via the new card badge — no need to click into details.
- Campus filtering now lives where users look for "people" intent, with language matching how users think ("I want to meet people who attend...").
- Mobile/tablet filter panels pick the change up automatically since they derive from the desktop filter config.

[CFDP-4040]: https://christfellowshipchurch.atlassian.net/browse/CFDP-4040?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ