### PR TITLE
Remove campus badge and adjust header layout

### DIFF
--- a/app/routes/group-finder/components/group-hit.component.tsx
+++ b/app/routes/group-finder/components/group-hit.component.tsx
@@ -61,9 +61,6 @@ export function GroupHit({
 }) {
   const coverImage = hit.coverImage?.sources?.[0]?.uri || '';
   const preference = hit.groupFor?.trim() || 'Anyone';
-  const campusBadge = hit.campusName?.trim()
-    ? formatGroupHitCampusName(hit.campusName)
-    : '';
   const topicTags = splitGroupTopics(hit.topics);
 
   const formatTime = (timeString: string) => {
@@ -178,7 +175,7 @@ export function GroupHit({
 
           <div className='flex min-h-0 flex-1 flex-col gap-3 pt-[10px]'>
             <div className='flex flex-col px-6 gap-3'>
-              <div className='flex flex-wrap items-center gap-2'>
+              <div className='flex flex-col gap-[10px]'>
                 <div
                   className={`${
                     preference === 'Women'
@@ -193,11 +190,6 @@ export function GroupHit({
                 >
                   {preference}
                 </div>
-                {campusBadge && (
-                  <div className='bg-navy-subdued text-dark-navy w-fit flex rounded-sm text-xs font-semibold px-2 py-1'>
-                    {campusBadge}
-                  </div>
-                )}
               </div>
 
               <div className='flex flex-col gap-1'>


### PR DESCRIPTION
## Summary
Removes the campus tag/badge that was recently added to the Group Finder group cards. The blue bottom bar (meeting city / campus-city fallback) is unchanged — only the campus badge that sat next to the group-for tag is removed.

## Screenshots
<img width="335" height="405" alt="Screenshot 2026-06-15 at 10 38 11 AM" src="https://github.com/user-attachments/assets/f43dd7c2-62c8-4c7e-a747-b42ed1fabac0" />

## Testing
- [x] Open `/group-finder` — group cards no longer show the campus badge next to the "Anyone/Men/Women/Couples" tag.
- [x] Blue bottom bar still shows the meeting city (and distance label during zip/distance searches).
- [x] No new linter errors/warnings.

## Tickets

[CFDP-4050](https://christfellowshipchurch.atlassian.net/browse/CFDP-4050)

## Changes Made

### New Components Added

- None.

### New Utilities

- None. Removed the now-unused `campusBadge` variable in `app/routes/group-finder/components/group-hit.component.tsx`.

### New Assets

- N/A

### Dependencies

- None.

### Route Implementation

- `app/routes/group-finder/components/group-hit.component.tsx` — removed the campus badge element and reverted the tag wrapper back to its original layout (`flex flex-col gap-[10px]`).

### Key Features

- Cleaner group card: campus tag removed per request.

[CFDP-4050]: https://christfellowshipchurch.atlassian.net/browse/CFDP-4050?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ