### PR TITLE
Filter related groups by language + locations tab anchoring

### DIFF
--- a/app/components/modals/help-me-find-a-group/__tests__/help-me-find-a-group-form.test.tsx
+++ b/app/components/modals/help-me-find-a-group/__tests__/help-me-find-a-group-form.test.tsx
@@ -67,10 +67,10 @@ function fillRequiredFields() {
   fireEvent.change(screen.getByLabelText('Campus'), {
     target: { value: 'campus-guid-1' },
   });
-  fireEvent.change(screen.getByLabelText('Cell Phone'), {
+  fireEvent.change(screen.getByLabelText('Phone'), {
     target: { value: '5615551234' },
   });
-  fireEvent.change(screen.getByLabelText('Email Address'), {
+  fireEvent.change(screen.getByLabelText('Email'), {
     target: { value: 'ada@example.com' },
   });
   fireEvent.click(screen.getByLabelText('In Person'));
@@ -149,10 +149,10 @@ describe('HelpMeFindAGroupForm', () => {
     fireEvent.change(screen.getByLabelText('Campus'), {
       target: { value: 'campus-guid-1' },
     });
-    fireEvent.change(screen.getByLabelText('Cell Phone'), {
+    fireEvent.change(screen.getByLabelText('Phone'), {
       target: { value: '5615551234' },
     });
-    fireEvent.change(screen.getByLabelText('Email Address'), {
+    fireEvent.change(screen.getByLabelText('Email'), {
       target: { value: 'ada@example.com' },
     });
     fireEvent.click(screen.getByLabelText('In Person'));

--- a/app/routes/class-finder/finder/class-finder.tsx
+++ b/app/routes/class-finder/finder/class-finder.tsx
@@ -12,9 +12,9 @@ export function ClassFinderPage() {
           sectionTitle='learn together'
           sectionTitleColor='#004F71'
           title={`<span className='hidden md:inline'>Discover ${' '}</span>Classes For You`}
-          mobileDescription='From topics like building your faith, growing your marriage, finances, and more–there’s a class for you!'
+          mobileDescription='From topics like building your faith, growing your marriage, finances, finding Freedom, and more–there’s a class for you!'
           desktopDescription='Discover a class that will help give you practical steps to grow in your journey with God.
-From topics like building your faith, growing your marriage, managing your finances, and more–there’s a class for you!'
+From topics like building your faith, growing your marriage, managing your finances, finding Freedom, and more–there’s a class for you!'
         />
       </div>
       <div className='flex flex-col flex-1 w-full'>

--- a/app/routes/group-single/components/faq.component.tsx
+++ b/app/routes/group-single/components/faq.component.tsx
@@ -10,12 +10,12 @@ const faqData = [
   {
     question: 'Where Do Small Groups Meet?',
     answer:
-      'Most groups meet in homes, parks, or restaurants—usually based on the leader’s location and often near a church campus.',
+      'Most groups meet in homes, parks, restaurants, or online—usually based on the leader’s location and often near a church campus.',
   },
   {
     question: 'What Types of Small Groups Are Available?',
     answer:
-      'We offer Bible study, activity, and Freedom groups for men, women, and married couples. Groups are available for all life stages, with both morning and evening options.',
+      'We offer Bible study, activity, and social groups for men, women, and married couples. Groups are available for all life stages, with both morning and evening options.',
   },
   {
     question: 'Is Childcare Provided During Group Meetings?',

--- a/app/routes/group-single/group-single-page.tsx
+++ b/app/routes/group-single/group-single-page.tsx
@@ -54,7 +54,11 @@ export const GroupSingleContent = ({ hit }: { hit: GroupType }) => {
           <GroupSingleBasicContent summary={hit.summary} />
         </div>
       </div>
-      <RelatedGroupsPartial topics={hit.topics} currentGroupName={hit.title} />
+      <RelatedGroupsPartial
+        topics={hit.topics}
+        language={hit.language}
+        currentGroupName={hit.title}
+      />
 
       <GroupSingleMobileBottomBar
         copied={copied}

--- a/app/routes/group-single/partials/related-groups.partial.tsx
+++ b/app/routes/group-single/partials/related-groups.partial.tsx
@@ -5,6 +5,7 @@ import { useLoaderData } from 'react-router-dom';
 import { LoaderReturnType } from '../loader';
 import { CardCarousel } from '~/components/resource-carousel';
 import {
+  GroupLanguage,
   GroupType,
   GROUPS_ALGOLIA_INDEX_NAME,
   splitGroupTopics,
@@ -47,14 +48,27 @@ function RelatedGroupsHits({
 
 export function RelatedGroupsPartial({
   topics,
+  language,
   currentGroupName,
 }: {
   /** Raw `topics` field from the group Algolia record (comma-separated or empty). */
   topics: string;
+  /** Current group's language; used to keep related groups in the same language. */
+  language?: GroupLanguage | '';
   currentGroupName?: string;
 }) {
   const [hits, setHits] = useState<GroupType[]>([]);
   const topicTags = splitGroupTopics(topics);
+
+  // Filter related groups by topic and (when set) language. Groups without a
+  // language attribute fall back to topic-only matching.
+  const filters =
+    [
+      topicTags[0] && `topics:"${escapeAlgoliaFilterString(topicTags[0])}"`,
+      language && `language:"${escapeAlgoliaFilterString(language)}"`,
+    ]
+      .filter(Boolean)
+      .join(' AND ') || undefined;
 
   const { ALGOLIA_APP_ID, ALGOLIA_SEARCH_API_KEY } =
     useLoaderData<LoaderReturnType>();
@@ -72,14 +86,7 @@ export function RelatedGroupsPartial({
         preserveSharedStateOnUnmount: true,
       }}
     >
-      <Configure
-        filters={
-          topicTags[0]
-            ? `topics:"${escapeAlgoliaFilterString(topicTags[0])}"`
-            : undefined
-        }
-        hitsPerPage={6}
-      />
+      <Configure filters={filters} hitsPerPage={6} />
       <GetHits setHits={setHits} />
       {hits.length > 1 ? (
         <div className='mt-20 w-full flex flex-col items-center bg-linear-to-b from-white to-[#EEE] pb-24'>

--- a/app/routes/locations/location-single/components/tabs-component/campus-tabs.component.tsx
+++ b/app/routes/locations/location-single/components/tabs-component/campus-tabs.component.tsx
@@ -1,4 +1,4 @@
-import { ComponentType, Fragment, useMemo } from 'react';
+import { ComponentType, Fragment, useMemo, useRef } from 'react';
 import { cn } from '~/lib/utils';
 import {
   englishTabData,
@@ -55,6 +55,15 @@ export const CampusTabs = ({
     data[activeIndex]?.value ?? data[0]?.value ?? activeTab;
   const ActiveTabComponent = tabs[activeIndex];
 
+  const tablistRef = useRef<HTMLDivElement>(null);
+
+  // Switch tabs and anchor the section into view, so tabs clicked from higher
+  // up the page (e.g. the hero) scroll the user down to the tab content.
+  const handleTabClick = (value: string) => {
+    setActiveTab(value);
+    tablistRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  };
+
   const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
     const isHorizontal =
       event.key === 'ArrowLeft' || event.key === 'ArrowRight';
@@ -83,10 +92,11 @@ export const CampusTabs = ({
   return (
     <div className={cn('w-full flex flex-col justify-center items-center')}>
       <div
+        ref={tablistRef}
         role='tablist'
         aria-orientation='horizontal'
         className={cn(
-          'flex max-w-[90vw] md:max-w-none lg:w-auto md:gap-4 md:border border-neutral-lighter px-3 py-2 md:py-4 relative mt-15 md:mt-0',
+          'flex max-w-[90vw] md:max-w-none lg:w-auto md:gap-4 md:border border-neutral-lighter px-3 py-2 md:py-4 relative mt-15 md:mt-0 scroll-mt-28',
           isSpanish ? 'gap-0 text-[14.5px] sm:text-base' : 'gap-2',
           tasListStyle,
           activeTab === 'sunday-details' && 'absolute! -top-9 left-1/2',
@@ -112,7 +122,7 @@ export const CampusTabs = ({
                     aria-controls={panelId}
                     data-state={isActive ? 'active' : 'inactive'}
                     tabIndex={isActive ? 0 : -1}
-                    onClick={() => setActiveTab(tab.value)}
+                    onClick={() => handleTabClick(tab.value)}
                     className='hidden lg:flex px-6 py-2 text-text-secondary font-bold data-[state=active]:bg-ocean data-[state=active]:text-white rounded-[12px] transition-all duration-300 hover:bg-neutral-lightest cursor-pointer'
                   >
                     {tab.label}
@@ -127,7 +137,7 @@ export const CampusTabs = ({
                     aria-controls={panelId}
                     data-state={isActive ? 'active' : 'inactive'}
                     tabIndex={isActive ? 0 : -1}
-                    onClick={() => setActiveTab(tab.value)}
+                    onClick={() => handleTabClick(tab.value)}
                     className='lg:hidden px-4 md:px-6 py-2 font-bold data-[state=active]:bg-navy-subdued rounded-[12px] transition-all duration-300 hover:bg-neutral-lightest cursor-pointer'
                   >
                     {tab.mobileLabel}

--- a/app/routes/locations/location-single/components/tabs-component/campus-tabs.component.tsx
+++ b/app/routes/locations/location-single/components/tabs-component/campus-tabs.component.tsx
@@ -96,7 +96,7 @@ export const CampusTabs = ({
         role='tablist'
         aria-orientation='horizontal'
         className={cn(
-          'flex max-w-[90vw] md:max-w-none lg:w-auto md:gap-4 md:border border-neutral-lighter px-3 py-2 md:py-4 relative mt-15 md:mt-0 scroll-mt-28',
+          'flex max-w-[90vw] md:max-w-none lg:w-auto md:gap-4 md:border border-neutral-lighter px-3 py-2 md:py-4 relative mt-15 md:mt-0 scroll-mt-4 lg:scroll-mt-28',
           isSpanish ? 'gap-0 text-[14.5px] sm:text-base' : 'gap-2',
           tasListStyle,
           activeTab === 'sunday-details' && 'absolute! -top-9 left-1/2',


### PR DESCRIPTION
## Summary

Two small UX improvements on the new site:

1. **Locations – tab anchoring (CFDP-4045):** Clicking a tab ("Sunday Details", "About Us", "For Families") on a Location single page now smooth-scrolls the page so the tab strip anchors near the top of the viewport. This brings the freshly-switched content into view, which matters when the tab is clicked from higher up the page (e.g. after the hero).

2. **Groups – related groups by language (CFDP-4051):** The "Related Groups" section on the Group single page now filters by both **Topic** and **Language**, so a Spanish group surfaces other Spanish groups and an English group surfaces English groups. Previously it filtered by topic only.

## Screenshots


## Testing

- [x] What steps can someone follow to verify functionality?
  - Location: open `/locations/palm-beach-gardens`, scroll to top, click any tab → page scrolls down to anchor the tab content.
  - Group: open any Group single page (`/group-finder/<guid>`); the Related Groups carousel should only show groups matching both the current group's topic and its language. Compare an English group vs a Spanish group.
- [x] No new lint warnings or errors.

## Tickets
[CFDP-4045]( https://christfellowshipchurch.atlassian.net/browse/CFDP-4045)
[CFDP-4051]( https://christfellowshipchurch.atlassian.net/browse/CFDP-4051)

## Changes Made

### New Components Added

- None.

### New Utilities

- None. Reuses the existing `escapeAlgoliaFilterString` helper (`app/components/finders/finder-algolia.utils.ts`) and `splitGroupTopics` (`app/routes/group-finder/types.ts`).

### New Assets

- None.

### Dependencies

- None.

### Route Implementation

- `app/routes/locations/location-single/components/tabs-component/campus-tabs.component.tsx`
  - Added a `tablistRef` and a `handleTabClick` handler that calls `setActiveTab` then `scrollIntoView({ behavior: 'smooth', block: 'start' })`.
  - Added `scroll-mt-28` to the tablist so it anchors below the header instead of flush to the top.
  - Wired both desktop and mobile tab buttons to `handleTabClick`.
- `app/routes/group-single/partials/related-groups.partial.tsx`
  - Added an optional `language` prop and build the Algolia filter as `topics:"…" AND language:"…"`, joined via `.filter(Boolean)` so a group with no language (or no topic) gracefully falls back to whatever filters exist.
- `app/routes/group-single/group-single-page.tsx`
  - Passes `language={hit.language}` through to `RelatedGroupsPartial`.

### Key Features

- Tab clicks on the Locations page now anchor/scroll the active section into view (accessibility/UX), keeping existing ARIA roles and keyboard navigation untouched.
- Related Groups results are more relevant: matched on topic **and** language.
- Edge cases handled: groups missing a language attribute fall back to topic-only matching (no empty results).

## Notes

- These are two independent features that happen to live on the same branch.
- Pre-existing behavior preserved: the related-groups filter still uses only the **first** topic (`topicTags[0]`); language was layered on top without broadening topic matching. Flagging in case we want to widen that separately.

[CFDP-4045]: https://christfellowshipchurch.atlassian.net/browse/CFDP-4045?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ