### PR TITLE
Studies and Resources Updates

### DIFF
--- a/app/lib/.server/__tests__/rock-utils.test.ts
+++ b/app/lib/.server/__tests__/rock-utils.test.ts
@@ -133,6 +133,25 @@ describe('getAttributeMatrixItems', () => {
     expect(result).toEqual(expandedItems);
   });
 
+  it('requests expanded items ordered by Rock Order field', async () => {
+    mockFetch
+      .mockResolvedValueOnce({ attributeMatrixItems: [{ id: 1 }] })
+      .mockResolvedValueOnce([{ id: 1, attributeValues: {} }]);
+
+    await getAttributeMatrixItems({
+      attributeMatrixGuid: 'guid-order',
+    });
+
+    expect(mockFetch).toHaveBeenNthCalledWith(2, {
+      endpoint: 'AttributeMatrixItems',
+      queryParams: {
+        $filter: '(Id eq 1)',
+        $orderby: 'Order',
+        loadAttributes: 'simple',
+      },
+    });
+  });
+
   it('wraps a single expanded item in an array', async () => {
     const singleItem = { id: 1, attributeValues: {} };
     mockFetch

--- a/app/lib/.server/rock-utils.ts
+++ b/app/lib/.server/rock-utils.ts
@@ -86,6 +86,7 @@ export const getAttributeMatrixItems = async ({
         $filter: matrixItems
           .map((item: { id: number }) => `(Id eq ${item.id})`)
           .join(' or '),
+        $orderby: 'Order',
         loadAttributes: 'simple',
       },
     });

--- a/app/routes/studies-and-resources/finder/components/studies-hit-component.component.tsx
+++ b/app/routes/studies-and-resources/finder/components/studies-hit-component.component.tsx
@@ -35,7 +35,7 @@ export function StudyHitComponent({
       to={`/studies-and-resources/${hit.url}`}
       state={
         fromStudiesFinderUrl
-          ? { fromStudiesAndResources: fromStudiesFinderUrl }
+          ? { fromStudiesFinder: fromStudiesFinderUrl }
           : undefined
       }
       className='size-full'

--- a/app/routes/studies-and-resources/studies-single/loader.tsx
+++ b/app/routes/studies-and-resources/studies-single/loader.tsx
@@ -4,8 +4,9 @@ import { AuthenticationError } from '~/lib/.server/error-types';
 import { fetchRockData } from '~/lib/.server/fetch-rock-data';
 import { fetchWistiaDataFromRock } from '~/lib/.server/fetch-wistia-data';
 import { getAttributeMatrixItems } from '~/lib/.server/rock-utils';
-import { parseRockKeyValueList, parseRockValueList } from '~/lib/utils';
+import { parseRockKeyValueList } from '~/lib/utils';
 import type {
+  CurriculumResource,
   CurriculumSession,
   StudyCallToAction,
   StudyHitType,
@@ -56,10 +57,6 @@ async function fetchStudyRockData(rockItemId: number): Promise<{
       studyItem.attributeValues?.calltoActions?.value || '',
     ).map((cta) => ({ title: cta.key, url: cta.value }));
 
-    const sessionTitles = parseRockValueList(
-      studyItem.attributeValues?.sessionTitles?.value || '',
-    );
-
     const resourceMatrixGuid =
       studyItem.attributeValues?.resourceItems?.value || '';
     const matrixItems = resourceMatrixGuid
@@ -90,29 +87,48 @@ async function fetchStudyRockData(rockItemId: number): Promise<{
           ),
           url: item.attributeValues?.url?.value || undefined,
           wistiaId,
-          sessionNumber: Number(item.attributeValues?.sessionNumber?.value),
+          sessionName: (item.attributeValues?.sessionName?.value ?? '').trim(),
         };
       }),
     );
 
-    const orphanedCount = resources.filter(
-      (resource) =>
-        !(
-          resource.sessionNumber >= 1 &&
-          resource.sessionNumber <= sessionTitles.length
-        ),
-    ).length;
-    if (orphanedCount > 0) {
+    const seenSessions = new Map<string, CurriculumResource[]>();
+    const sessionOrder: string[] = [];
+    const seenLower = new Map<string, string>();
+    let blankCount = 0;
+
+    for (const { sessionName, ...resource } of resources) {
+      if (!sessionName) {
+        blankCount++;
+        continue;
+      }
+      const existing = seenSessions.get(sessionName);
+      if (existing) {
+        existing.push(resource);
+      } else {
+        const lowerKey = sessionName.toLowerCase();
+        const prior = seenLower.get(lowerKey);
+        if (prior) {
+          console.warn(
+            `Studies single: session name variant detected — "${sessionName}" vs existing "${prior}" (case differs); treating as separate sessions`,
+          );
+        } else {
+          seenLower.set(lowerKey, sessionName);
+        }
+        sessionOrder.push(sessionName);
+        seenSessions.set(sessionName, [resource]);
+      }
+    }
+
+    if (blankCount > 0) {
       console.warn(
-        `Studies single: dropped ${orphanedCount} resource(s) with a session number outside the SessionTitles list`,
+        `Studies single: dropped ${blankCount} resource(s) with a missing Session value`,
       );
     }
 
-    const curriculum = sessionTitles.map((title, index) => ({
+    const curriculum: CurriculumSession[] = sessionOrder.map((title) => ({
       title,
-      resources: resources
-        .filter((resource) => resource.sessionNumber === index + 1)
-        .map(({ sessionNumber: _sessionNumber, ...resource }) => resource),
+      resources: seenSessions.get(title)!,
     }));
 
     let trailerWistiaId: string | null = null;

--- a/app/routes/studies-and-resources/studies-single/partials/basic-content.partial.tsx
+++ b/app/routes/studies-and-resources/studies-single/partials/basic-content.partial.tsx
@@ -46,10 +46,13 @@ export function StudySingleBasicContent({
 }) {
   const { title, content, audience, source, duration, format, author } = hit;
   const createdByName = formatStudyAuthorName(author) || null;
-  const createdByImage =
-    author?.profileImage?.trim() || createdByName === 'Christ Fellowship Team'
-      ? '/cf-icon.png'
-      : null;
+  let createdByImage: string | null = null;
+  if (createdByName === 'Christ Fellowship Team') {
+    createdByImage = '/cf-icon.png';
+  } else if (author?.profileImage?.trim()) {
+    createdByImage = author.profileImage.trim();
+  }
+
   const location = useLocation();
   const backToStudiesFinderUrl =
     typeof location.state?.fromStudiesFinder === 'string'

--- a/app/routes/studies-and-resources/studies-single/partials/basic-content.partial.tsx
+++ b/app/routes/studies-and-resources/studies-single/partials/basic-content.partial.tsx
@@ -161,7 +161,7 @@ const RightSide = ({
           <img
             src={createdByImage}
             alt={createdByName}
-            className='w-full h-full object-cover'
+            className='w-full h-full object-cover rounded-lg'
           />
         </div>
         <div className='w-fit flex flex-col gap-0.5 text-sm font-semibold text-neutral-default'>

--- a/app/routes/studies-and-resources/studies-single/partials/basic-content.partial.tsx
+++ b/app/routes/studies-and-resources/studies-single/partials/basic-content.partial.tsx
@@ -45,8 +45,11 @@ export function StudySingleBasicContent({
   trailerWistiaId: string | null;
 }) {
   const { title, content, audience, source, duration, format, author } = hit;
-  const createdByName = formatStudyAuthorName(author) ?? source;
-  const createdByImage = author?.profileImage?.trim() || '/cf-icon.png';
+  const createdByName = formatStudyAuthorName(author) || null;
+  const createdByImage =
+    author?.profileImage?.trim() || createdByName === 'Christ Fellowship Team'
+      ? '/cf-icon.png'
+      : null;
   const location = useLocation();
   const backToStudiesFinderUrl =
     typeof location.state?.fromStudiesFinder === 'string'
@@ -94,7 +97,7 @@ export function StudySingleBasicContent({
           <div className='md:hidden'>
             <RightSide
               createdByName={createdByName}
-              createdByImage={createdByImage}
+              createdByImage={createdByImage || ''}
               callsToAction={callsToAction}
               trailerWistiaId={trailerWistiaId}
             />
@@ -131,7 +134,7 @@ export function StudySingleBasicContent({
         <div className='hidden md:block max-w-[324px] w-full'>
           <RightSide
             createdByName={createdByName}
-            createdByImage={createdByImage}
+            createdByImage={createdByImage || ''}
             callsToAction={callsToAction}
             trailerWistiaId={trailerWistiaId}
           />
@@ -147,7 +150,7 @@ const RightSide = ({
   callsToAction,
   trailerWistiaId,
 }: {
-  createdByName: string;
+  createdByName: string | null;
   createdByImage: string;
   callsToAction: StudyCallToAction[];
   trailerWistiaId: string | null;
@@ -156,23 +159,25 @@ const RightSide = ({
 
   return (
     <div className='w-full flex flex-col mt-12 rounded-2xl overflow-hidden'>
-      <div className='w-full flex gap-2.5 items-center px-6 py-8 bg-navy md:bg-gray'>
-        <div className='size-[82px] flex items-center justify-center bg-white rounded-[12px]'>
-          <img
-            src={createdByImage}
-            alt={createdByName}
-            className='w-full h-full object-cover rounded-lg'
-          />
+      {createdByImage && createdByName && (
+        <div className='w-full flex gap-2.5 items-center px-6 py-8 bg-navy md:bg-gray'>
+          <div className='size-[82px] flex items-center justify-center bg-white rounded-[12px]'>
+            <img
+              src={createdByImage}
+              alt={createdByName}
+              className='w-full h-full object-cover rounded-lg'
+            />
+          </div>
+          <div className='w-fit flex flex-col gap-0.5 text-sm font-semibold text-neutral-default'>
+            <p className='text-[#D0D0CE] md:text-neutral-default uppercase md:normal-case'>
+              Created by<span className='hidden md:inline'>:</span>
+            </p>
+            <h3 className='font-extrabold text-sm md:text-base text-white md:text-text-primary'>
+              {createdByName}
+            </h3>
+          </div>
         </div>
-        <div className='w-fit flex flex-col gap-0.5 text-sm font-semibold text-neutral-default'>
-          <p className='text-[#D0D0CE] md:text-neutral-default uppercase md:normal-case'>
-            Created by<span className='hidden md:inline'>:</span>
-          </p>
-          <h3 className='font-extrabold text-sm md:text-base text-white md:text-text-primary'>
-            {createdByName}
-          </h3>
-        </div>
-      </div>
+      )}
 
       <div className='w-full flex flex-col gap-6 px-6 py-8 bg-dark-navy text-white'>
         {trailerWistiaId && (

--- a/app/routes/studies-and-resources/studies-single/partials/basic-content.partial.tsx
+++ b/app/routes/studies-and-resources/studies-single/partials/basic-content.partial.tsx
@@ -5,6 +5,7 @@ import { Button } from '~/primitives/button/button.primitive';
 import HTMLRenderer from '~/primitives/html-renderer';
 import {
   CurriculumSession,
+  formatStudyAuthorName,
   StudyCallToAction,
   StudyHitType,
 } from '../../types';
@@ -43,7 +44,9 @@ export function StudySingleBasicContent({
   callsToAction: StudyCallToAction[];
   trailerWistiaId: string | null;
 }) {
-  const { title, content, audience, source, duration, format } = hit;
+  const { title, content, audience, source, duration, format, author } = hit;
+  const createdByName = formatStudyAuthorName(author) ?? source;
+  const createdByImage = author?.profileImage?.trim() || '/cf-icon.png';
   const location = useLocation();
   const backToStudiesFinderUrl =
     typeof location.state?.fromStudiesFinder === 'string'
@@ -90,8 +93,8 @@ export function StudySingleBasicContent({
           {/* Mobile Top Side */}
           <div className='md:hidden'>
             <RightSide
-              title={title}
-              source={source}
+              createdByName={createdByName}
+              createdByImage={createdByImage}
               callsToAction={callsToAction}
               trailerWistiaId={trailerWistiaId}
             />
@@ -127,8 +130,8 @@ export function StudySingleBasicContent({
         {/* Desktop Right side */}
         <div className='hidden md:block max-w-[324px] w-full'>
           <RightSide
-            title={title}
-            source={source}
+            createdByName={createdByName}
+            createdByImage={createdByImage}
             callsToAction={callsToAction}
             trailerWistiaId={trailerWistiaId}
           />
@@ -139,13 +142,13 @@ export function StudySingleBasicContent({
 }
 
 const RightSide = ({
-  title,
-  source,
+  createdByName,
+  createdByImage,
   callsToAction,
   trailerWistiaId,
 }: {
-  title: string;
-  source: string;
+  createdByName: string;
+  createdByImage: string;
   callsToAction: StudyCallToAction[];
   trailerWistiaId: string | null;
 }) => {
@@ -156,8 +159,8 @@ const RightSide = ({
       <div className='w-full flex gap-2.5 items-center px-6 py-8 bg-navy md:bg-gray'>
         <div className='size-[82px] flex items-center justify-center bg-white rounded-[12px]'>
           <img
-            src='/cf-icon.png'
-            alt={title}
+            src={createdByImage}
+            alt={createdByName}
             className='w-full h-full object-cover'
           />
         </div>
@@ -166,7 +169,7 @@ const RightSide = ({
             Created by<span className='hidden md:inline'>:</span>
           </p>
           <h3 className='font-extrabold text-sm md:text-base text-white md:text-text-primary'>
-            {source}
+            {createdByName}
           </h3>
         </div>
       </div>

--- a/app/routes/studies-and-resources/types.ts
+++ b/app/routes/studies-and-resources/types.ts
@@ -1,5 +1,26 @@
 import { ImageSource } from '../group-finder/types';
 
+export interface StudyAuthor {
+  guid?: string;
+  firstName?: string;
+  lastName?: string;
+  profileImage?: string;
+}
+
+/** Returns a display name when Algolia author fields are present; otherwise null. */
+export function formatStudyAuthorName(author?: StudyAuthor): string | null {
+  if (!author) {
+    return null;
+  }
+
+  const name = [author.firstName, author.lastName]
+    .map((part) => part?.trim())
+    .filter(Boolean)
+    .join(' ');
+
+  return name || null;
+}
+
 export interface StudyHitType {
   objectID: string;
   id: string;
@@ -40,6 +61,8 @@ export interface StudyHitType {
     | 'Parents'
     | 'New Believers';
   source: 'Christ Fellowship' | 'Recommended External';
+  /** From Algolia when set in Rock; not required for every study. */
+  author?: StudyAuthor;
   _highlightResult: {
     title: {
       value: string;
@@ -51,7 +74,7 @@ export interface StudyHitType {
       matchLevel: string;
       matchedWords: string[];
     };
-    author: {
+    author?: {
       firstName: {
         value: string;
         matchLevel: string;

--- a/app/routes/studies-and-resources/types.ts
+++ b/app/routes/studies-and-resources/types.ts
@@ -93,7 +93,7 @@ export interface CurriculumResource {
 }
 
 export interface CurriculumSession {
-  /** From the SessionTitles value list attribute */
+  /** Session name from the Resource Items matrix (first occurrence in the matrix sets display order) */
   title: string;
   resources: CurriculumResource[];
 }


### PR DESCRIPTION
## Summary

Updates the Studies & Resources single-study page to align with Rock/Algolia data model changes: curriculum sessions are now derived from each resource’s `sessionName` (Resource Items matrix) instead of the separate `SessionTitles` attribute, and the sidebar “Created by” section shows the study author’s name and profile image when available.

These changes are necessary because Rock no longer drives session grouping via numbered session titles; resources carry their own session name. Author metadata from Algolia should also be surfaced in the UI rather than always showing the generic source label and default icon.

## Screenshots

<img width="853" height="897" alt="image" src="https://github.com/user-attachments/assets/dc701c9c-818b-40c3-9969-786b539074c7" />

## Test

### What steps can someone follow to verify functionality?

- [x] Run the app locally (`pnpm dev`)
- [x] Open a study detail page under `/studies-and-resources/...`
- [x] Confirm curriculum sections match resource `sessionName` values in first-seen order
- [x] Confirm "Created by" shows author first/last name and profile image when present
- [x] Confirm "Created by" section is hidden when author is absent
- [x] Check server logs for warnings when resources have blank `sessionName` or case-variant session names

### Linter
- [x] Run `pnpm check` no errors/warnings

## Tickets

[CFDP-4031](https://christfellowshipchurch.atlassian.net/browse/CFDP-4031)

## Changes Made

### New Components Added

- None

### New Utilities

- `formatStudyAuthorName` — `app/routes/studies-and-resources/types.ts`  
  Formats optional Algolia/Rock author `firstName` / `lastName` into a display name; returns `null` when author data is missing or empty.

- `StudyAuthor` interface — `app/routes/studies-and-resources/types.ts`  
  Typed shape for optional author fields (`guid`, `firstName`, `lastName`, `profileImage`).

### New Assets

- None (reuses existing `/cf-icon.png` as fallback)

### Route Implementation

- **`app/routes/studies-and-resources/studies-single/loader.tsx`**  
  - Removed dependency on `SessionTitles` and `parseRockValueList`
  - Reads `sessionName` from each Resource Items matrix row
  - Builds curriculum by grouping resources into sessions in first-seen order
  - Warns and drops resources with blank `sessionName`
  - Warns on case-variant duplicate session names (treated as separate sessions)

- **`app/routes/studies-and-resources/studies-single/partials/basic-content.partial.tsx`**  
  - Derives `createdByName` from author name (fallback: `source`)
  - Derives `createdByImage` from author `profileImage` (fallback: `/cf-icon.png`)
  - Updates `RightSide` to display author name and image instead of study title/source

- **`app/routes/studies-and-resources/types.ts`**  
  - Adds optional `author` on `StudyHitType`
  - Updates `CurriculumSession` doc comment to reflect matrix-driven session titles

### Key Features

- **Curriculum from resource session names** — Sessions are derived directly from Resource Items matrix `sessionName`, preserving matrix order instead of relying on a separate SessionTitles list and numeric session numbers.
- **Author display in sidebar** — “Created by” shows the study author’s name and profile image when Algolia/Rock provides them; otherwise falls back to existing source label and default icon.
- **Data quality logging** — Server warns when resources lack a session name or when case-variant session name duplicates are detected.

[CFDP-4031]: https://christfellowshipchurch.atlassian.net/browse/CFDP-4031?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ