### PR TITLE
CFDP-4058 Add Group Finder Get Notified form

### DIFF
--- a/app/components/modals/group-finder-notify/__tests__/group-finder-notify-form.test.tsx
+++ b/app/components/modals/group-finder-notify/__tests__/group-finder-notify-form.test.tsx
@@ -1,0 +1,161 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { pushFormEvent } from '~/lib/gtm';
+import GroupFinderNotifyForm from '../group-finder-notify-form.component';
+
+vi.mock('~/lib/gtm', () => ({ pushFormEvent: vi.fn() }));
+
+let mockFetcherState = {
+  state: 'idle' as 'idle' | 'submitting' | 'loading',
+  data: undefined as unknown,
+};
+const mockSubmit = vi.fn();
+const mockLoad = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual =
+    await vi.importActual<typeof import('react-router-dom')>(
+      'react-router-dom',
+    );
+  return {
+    ...actual,
+    useFetcher: () => ({
+      state: mockFetcherState.state,
+      data: mockFetcherState.data,
+      submit: mockSubmit,
+      load: mockLoad,
+    }),
+  };
+});
+
+function renderForm(onSuccess = vi.fn()) {
+  return render(
+    <MemoryRouter>
+      <GroupFinderNotifyForm onSuccess={onSuccess} />
+    </MemoryRouter>,
+  );
+}
+
+describe('GroupFinderNotifyForm', () => {
+  beforeEach(() => {
+    mockFetcherState = { state: 'idle', data: undefined };
+    vi.clearAllMocks();
+  });
+
+  it('renders notify fields', () => {
+    renderForm();
+
+    expect(screen.getByText('Get Notified')).toBeInTheDocument();
+    expect(screen.getByText('First Name')).toBeInTheDocument();
+    expect(screen.getByText('Last Name')).toBeInTheDocument();
+    expect(screen.getByText('Email Address')).toBeInTheDocument();
+    expect(screen.getByText('Phone')).toBeInTheDocument();
+    expect(screen.getByText('Campus')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Submit' })).toBeInTheDocument();
+  });
+
+  it('loads campus options from the notify resource route', () => {
+    renderForm();
+
+    expect(mockLoad).toHaveBeenCalledWith('/group-finder-notify');
+  });
+
+  it('shows campuses in the select when fetcher data loads', async () => {
+    mockFetcherState = {
+      state: 'idle',
+      data: {
+        campuses: [
+          {
+            id: 10,
+            guid: 'campus-guid-10',
+            name: 'Palm Beach Gardens',
+          },
+        ],
+      },
+    };
+
+    renderForm();
+
+    expect(
+      await screen.findByRole('option', { name: 'Palm Beach Gardens' }),
+    ).toBeInTheDocument();
+  });
+
+  it('submits to the notify resource route', async () => {
+    const user = userEvent.setup();
+    mockFetcherState = {
+      state: 'idle',
+      data: {
+        campuses: [
+          {
+            id: 10,
+            guid: 'campus-guid-10',
+            name: 'Palm Beach Gardens',
+          },
+        ],
+      },
+    };
+    renderForm();
+
+    await screen.findByRole('option', { name: 'Palm Beach Gardens' });
+    await user.type(screen.getByLabelText('First Name'), 'Test');
+    await user.type(screen.getByLabelText('Last Name'), 'Person');
+    await user.type(
+      screen.getByLabelText('Email Address'),
+      'test@example.com',
+    );
+    await user.type(screen.getByLabelText('Phone'), '5555555555');
+    await user.selectOptions(screen.getByLabelText('Campus'), 'campus-guid-10');
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+    await waitFor(() => {
+      expect(mockSubmit).toHaveBeenCalledWith(expect.any(FormData), {
+        method: 'post',
+        action: '/group-finder-notify',
+      });
+    });
+  });
+
+  it('shows Loading... on submit button when submitting', () => {
+    mockFetcherState = { state: 'submitting', data: undefined };
+
+    renderForm();
+
+    const button = screen.getByRole('button', { name: /loading/i });
+    expect(button).toBeInTheDocument();
+    expect(button).toBeDisabled();
+  });
+
+  it('shows error message from fetcher data', () => {
+    mockFetcherState = {
+      state: 'idle',
+      data: { error: 'Something went wrong' },
+    };
+
+    renderForm();
+
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+  });
+
+  it('fires the GTM event before calling onSuccess after a successful submission', () => {
+    const onSuccess = vi.fn();
+    mockFetcherState = {
+      state: 'idle',
+      data: { success: true },
+    };
+
+    renderForm(onSuccess);
+
+    expect(pushFormEvent).toHaveBeenCalledWith(
+      'form_complete',
+      'group_finder_notify',
+      'Group Finder Notify Me',
+    );
+    expect(onSuccess).toHaveBeenCalled();
+    expect(vi.mocked(pushFormEvent).mock.invocationCallOrder[0]).toBeLessThan(
+      onSuccess.mock.invocationCallOrder[0],
+    );
+  });
+});

--- a/app/components/modals/group-finder-notify/__tests__/group-finder-notify-form.test.tsx
+++ b/app/components/modals/group-finder-notify/__tests__/group-finder-notify-form.test.tsx
@@ -102,10 +102,7 @@ describe('GroupFinderNotifyForm', () => {
     await screen.findByRole('option', { name: 'Palm Beach Gardens' });
     await user.type(screen.getByLabelText('First Name'), 'Test');
     await user.type(screen.getByLabelText('Last Name'), 'Person');
-    await user.type(
-      screen.getByLabelText('Email Address'),
-      'test@example.com',
-    );
+    await user.type(screen.getByLabelText('Email Address'), 'test@example.com');
     await user.type(screen.getByLabelText('Phone'), '5555555555');
     await user.selectOptions(screen.getByLabelText('Campus'), 'campus-guid-10');
     await user.click(screen.getByRole('button', { name: 'Submit' }));

--- a/app/components/modals/group-finder-notify/confirmation.component.tsx
+++ b/app/components/modals/group-finder-notify/confirmation.component.tsx
@@ -1,0 +1,23 @@
+import { Button } from '~/primitives/button/button.primitive';
+
+interface GroupFinderNotifyConfirmationProps {
+  onSuccess: () => void;
+}
+
+const GroupFinderNotifyConfirmation: React.FC<
+  GroupFinderNotifyConfirmationProps
+> = ({ onSuccess }) => {
+  return (
+    <div className='flex flex-col items-center gap-4 p-8'>
+      <h1 className='font-bold text-2xl text-navy'>Thanks!</h1>
+      <p className='text-text_primary'>
+        We will let you know when more groups are available.
+      </p>
+      <Button intent='primary' className='rounded-xl w-52' onClick={onSuccess}>
+        Done
+      </Button>
+    </div>
+  );
+};
+
+export default GroupFinderNotifyConfirmation;

--- a/app/components/modals/group-finder-notify/group-finder-notify-flow.component.tsx
+++ b/app/components/modals/group-finder-notify/group-finder-notify-flow.component.tsx
@@ -1,0 +1,45 @@
+import { useState } from 'react';
+import GroupFinderNotifyConfirmation from './confirmation.component';
+import GroupFinderNotifyForm from './group-finder-notify-form.component';
+
+enum GroupFinderNotifyStep {
+  FORM,
+  CONFIRMATION,
+}
+
+const GroupFinderNotifyFlow = ({
+  setOpenModal,
+}: {
+  setOpenModal: (open: boolean) => void;
+}) => {
+  const [step, setStep] = useState<GroupFinderNotifyStep>(
+    GroupFinderNotifyStep.FORM,
+  );
+
+  const renderStep = () => {
+    switch (step) {
+      case GroupFinderNotifyStep.FORM:
+        return (
+          <GroupFinderNotifyForm
+            onSuccess={() => setStep(GroupFinderNotifyStep.CONFIRMATION)}
+          />
+        );
+      case GroupFinderNotifyStep.CONFIRMATION:
+        return (
+          <GroupFinderNotifyConfirmation
+            onSuccess={() => setOpenModal(false)}
+          />
+        );
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <div className='pt-10 text-center text-text_primary p-6 w-[90vw] max-w-sm md:max-w-xl overflow-y-scroll max-h-[85vh] md:max-h-[90vh]'>
+      {renderStep()}
+    </div>
+  );
+};
+
+export default GroupFinderNotifyFlow;

--- a/app/components/modals/group-finder-notify/group-finder-notify-form.component.tsx
+++ b/app/components/modals/group-finder-notify/group-finder-notify-form.component.tsx
@@ -51,9 +51,7 @@ const GroupFinderNotifyForm: React.FC<GroupFinderNotifyFormProps> = ({
         fetcher.data !== null &&
         'error' in fetcher.data
       ) {
-        setError(
-          String(fetcher.data.error) || 'An unexpected error occurred',
-        );
+        setError(String(fetcher.data.error) || 'An unexpected error occurred');
       } else {
         setError(null);
         pushFormEvent(

--- a/app/components/modals/group-finder-notify/group-finder-notify-form.component.tsx
+++ b/app/components/modals/group-finder-notify/group-finder-notify-form.component.tsx
@@ -1,0 +1,165 @@
+import * as Form from '@radix-ui/react-form';
+import { useEffect, useState } from 'react';
+import { useFetcher } from 'react-router-dom';
+import { pushFormEvent } from '~/lib/gtm';
+import { cn } from '~/lib/utils';
+import { Button } from '~/primitives/button/button.primitive';
+import {
+  radixFormFieldStackClassName,
+  radixFormLabelClassName,
+  radixSelectClassName,
+  RadixFormErrorMessage,
+  renderRadixInputField,
+} from '~/primitives/inputs/form-radix-field';
+
+const RESOURCE_ROUTE = '/group-finder-notify';
+
+type CampusOption = {
+  id: number;
+  guid: string;
+  name: string;
+};
+
+interface GroupFinderNotifyFormProps {
+  onSuccess: () => void;
+}
+
+const GroupFinderNotifyForm: React.FC<GroupFinderNotifyFormProps> = ({
+  onSuccess,
+}) => {
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [campuses, setCampuses] = useState<CampusOption[]>([]);
+  const fetcher = useFetcher();
+
+  useEffect(() => {
+    fetcher.load(RESOURCE_ROUTE);
+  }, []);
+
+  useEffect(() => {
+    if (fetcher.state === 'idle' && fetcher.data) {
+      setLoading(false);
+
+      if (
+        typeof fetcher.data === 'object' &&
+        fetcher.data !== null &&
+        'campuses' in fetcher.data
+      ) {
+        setCampuses(fetcher.data.campuses as CampusOption[]);
+      } else if (
+        typeof fetcher.data === 'object' &&
+        fetcher.data !== null &&
+        'error' in fetcher.data
+      ) {
+        setError(
+          String(fetcher.data.error) || 'An unexpected error occurred',
+        );
+      } else {
+        setError(null);
+        pushFormEvent(
+          'form_complete',
+          'group_finder_notify',
+          'Group Finder Notify Me',
+        );
+        onSuccess();
+      }
+    }
+
+    if (fetcher.state === 'submitting') {
+      setLoading(true);
+      setError(null);
+    }
+  }, [fetcher.state, fetcher.data, onSuccess]);
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+
+    try {
+      fetcher.submit(formData, {
+        method: 'post',
+        action: RESOURCE_ROUTE,
+      });
+    } catch {
+      setError(
+        'An error occurred while submitting the form. Please try again.',
+      );
+      setLoading(false);
+    }
+  };
+
+  return (
+    <>
+      <h2 className='mb-6 text-3xl text-navy font-bold'>Get Notified</h2>
+      <p className='mb-6 text-base leading-6 text-text_primary'>
+        We will be launching a new semester with a larger selection of groups in
+        the coming months. Submit your contact information and campus to receive
+        a reminder before the next launch!
+      </p>
+      <Form.Root
+        onSubmit={handleSubmit}
+        className='flex flex-col md:grid text-left grid-cols-1 gap-y-3 gap-x-6 md:grid-cols-2'
+      >
+        {renderRadixInputField(
+          'FirstName',
+          'First Name',
+          'text',
+          'Please enter your first name',
+        )}
+        {renderRadixInputField(
+          'LastName',
+          'Last Name',
+          'text',
+          'Please enter your last name',
+        )}
+        {renderRadixInputField(
+          'EmailAddress',
+          'Email Address',
+          'email',
+          'Please enter your email address',
+        )}
+        {renderRadixInputField(
+          'PhoneNumber',
+          'Phone',
+          'tel',
+          'Please enter your phone number',
+        )}
+
+        <Form.Field
+          name='Campus'
+          className={cn('mb-4 md:col-span-2', radixFormFieldStackClassName)}
+        >
+          <Form.Label className={radixFormLabelClassName}>Campus</Form.Label>
+          <Form.Control asChild>
+            <select className={radixSelectClassName} required>
+              <option value=''>Select a Campus</option>
+              {campuses.map(({ guid, name }) => (
+                <option key={guid} value={guid}>
+                  {name}
+                </option>
+              ))}
+            </select>
+          </Form.Control>
+          <RadixFormErrorMessage match='valueMissing'>
+            Please select a campus
+          </RadixFormErrorMessage>
+        </Form.Field>
+
+        {error && <p className='text-alert col-span-2 text-center'>{error}</p>}
+
+        <Form.Submit className='mt-6 mx-auto col-span-1 md:col-span-2' asChild>
+          <Button
+            className='w-40 h-12'
+            size='md'
+            type='submit'
+            disabled={loading}
+          >
+            {loading ? 'Loading...' : 'Submit'}
+          </Button>
+        </Form.Submit>
+      </Form.Root>
+    </>
+  );
+};
+
+export default GroupFinderNotifyForm;

--- a/app/components/modals/group-finder-notify/index.tsx
+++ b/app/components/modals/group-finder-notify/index.tsx
@@ -1,0 +1,49 @@
+import { useState, type ReactNode } from 'react';
+import { pushFormEvent } from '~/lib/gtm';
+import Modal from '~/primitives/Modal';
+import { Button, type ButtonProps } from '~/primitives/button/button.primitive';
+import GroupFinderNotifyFlow from './group-finder-notify-flow.component';
+
+interface GroupFinderNotifyModalProps {
+  buttonTitle?: string;
+  triggerStyles?: string;
+  TriggerButton?: React.ComponentType<ButtonProps>;
+  children?: ReactNode;
+}
+
+export function GroupFinderNotifyModal({
+  buttonTitle = 'Get Notified',
+  triggerStyles,
+  TriggerButton = Button,
+  children,
+}: GroupFinderNotifyModalProps) {
+  const [openModal, setOpenModal] = useState(false);
+
+  const handleOpenChange = (open: boolean) => {
+    setOpenModal(open);
+    if (open) {
+      pushFormEvent(
+        'form_start',
+        'group_finder_notify',
+        'Group Finder Notify Me',
+      );
+    }
+  };
+
+  return (
+    <Modal open={openModal} onOpenChange={handleOpenChange}>
+      {children ? (
+        <Modal.Button asChild>{children}</Modal.Button>
+      ) : (
+        <Modal.Button asChild className='mr-2'>
+          <TriggerButton intent='white' className={triggerStyles}>
+            {buttonTitle}
+          </TriggerButton>
+        </Modal.Button>
+      )}
+      <Modal.Content>
+        <GroupFinderNotifyFlow setOpenModal={setOpenModal} />
+      </Modal.Content>
+    </Modal>
+  );
+}

--- a/app/components/modals/index.ts
+++ b/app/components/modals/index.ts
@@ -1,6 +1,7 @@
 export { AuthModal } from './auth';
 export { ConnectCardModal } from './connect-card';
 export { GroupConnectModal } from './group-connect';
+export { GroupFinderNotifyModal } from './group-finder-notify';
 export { HelpMeFindAGroupModal } from './help-me-find-a-group';
 export { NewsletterSubscriptionModal } from './newsletter-subscription';
 export { PrayerRequestModal } from './prayer-request';

--- a/app/routes/group-finder-notify/action.test.ts
+++ b/app/routes/group-finder-notify/action.test.ts
@@ -1,0 +1,168 @@
+import type { ActionFunctionArgs } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchRockData, postRockData } from '~/lib/.server/fetch-rock-data';
+import { findOrCreateRockPersonForSignup } from '~/lib/.server/rock-signup';
+import { action } from './action';
+
+vi.mock('~/lib/.server/fetch-rock-data', () => ({
+  fetchRockData: vi.fn(),
+  postRockData: vi.fn(),
+  TTL: { NONE: 0 },
+}));
+
+vi.mock('~/lib/.server/rock-signup', () => ({
+  findOrCreateRockPersonForSignup: vi.fn(),
+}));
+
+vi.mock('~/lib/.server/rock-utils', () => ({
+  escapeOData: vi.fn((value: string) => value),
+}));
+
+const mockFetchRockData = vi.mocked(fetchRockData);
+const mockPostRockData = vi.mocked(postRockData);
+const mockFindOrCreateRockPersonForSignup = vi.mocked(
+  findOrCreateRockPersonForSignup,
+);
+
+const createRequest = ({
+  firstName = 'Test',
+  lastName = 'Person',
+  email = 'test@example.com',
+  phone = '5555555555',
+  campus = 'campus-guid-10',
+}: {
+  firstName?: string;
+  lastName?: string;
+  email?: string;
+  phone?: string;
+  campus?: string;
+} = {}) => {
+  const formData = new FormData();
+  if (firstName) formData.set('FirstName', firstName);
+  if (lastName) formData.set('LastName', lastName);
+  if (email) formData.set('EmailAddress', email);
+  if (phone) formData.set('PhoneNumber', phone);
+  if (campus) formData.set('Campus', campus);
+
+  return new Request('http://localhost/group-finder-notify', {
+    method: 'POST',
+    body: formData,
+  });
+};
+
+describe('group finder notify action', () => {
+  beforeEach(() => {
+    mockFetchRockData.mockReset();
+    mockPostRockData.mockReset();
+    mockFindOrCreateRockPersonForSignup.mockReset();
+    mockFetchRockData
+      .mockResolvedValueOnce({ id: 10 })
+      .mockResolvedValueOnce([]);
+    mockFindOrCreateRockPersonForSignup.mockResolvedValue('123');
+    mockPostRockData.mockResolvedValue({});
+  });
+
+  it('rejects missing required fields', async () => {
+    const response = (await action({
+      request: createRequest({ firstName: '' }),
+    } as ActionFunctionArgs)) as Response;
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: 'Please fill in all required fields.',
+    });
+    expect(mockFindOrCreateRockPersonForSignup).not.toHaveBeenCalled();
+    expect(mockPostRockData).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid campus guids', async () => {
+    mockFetchRockData.mockReset();
+    mockFetchRockData.mockResolvedValueOnce([]);
+
+    const response = (await action({
+      request: createRequest(),
+    } as ActionFunctionArgs)) as Response;
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: 'Please select a valid campus.',
+    });
+    expect(mockPostRockData).not.toHaveBeenCalled();
+  });
+
+  it('rejects unmapped campus ids', async () => {
+    mockFetchRockData.mockReset();
+    mockFetchRockData.mockResolvedValueOnce({ id: 999 });
+
+    const response = (await action({
+      request: createRequest(),
+    } as ActionFunctionArgs)) as Response;
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: 'This campus is not available for group notifications.',
+    });
+    expect(mockPostRockData).not.toHaveBeenCalled();
+  });
+
+  it('finds or creates the submitted person', async () => {
+    await action({ request: createRequest() } as ActionFunctionArgs);
+
+    expect(mockFindOrCreateRockPersonForSignup).toHaveBeenCalledWith({
+      firstName: 'Test',
+      lastName: 'Person',
+      email: 'test@example.com',
+      phoneNumber: '5555555555',
+    });
+  });
+
+  it('does not create a duplicate group member', async () => {
+    mockFetchRockData.mockReset();
+    mockFetchRockData
+      .mockResolvedValueOnce({ id: 10 })
+      .mockResolvedValueOnce({ id: 222 });
+
+    const response = (await action({
+      request: createRequest(),
+    } as ActionFunctionArgs)) as Response;
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ success: true });
+    expect(mockPostRockData).not.toHaveBeenCalled();
+  });
+
+  it('creates a group member for the selected campus group', async () => {
+    const response = (await action({
+      request: createRequest(),
+    } as ActionFunctionArgs)) as Response;
+
+    expect(response.status).toBe(200);
+    expect(mockFetchRockData).toHaveBeenNthCalledWith(1, {
+      endpoint: 'Campuses',
+      queryParams: {
+        $filter: "Guid eq guid'campus-guid-10'",
+        $select: 'Id',
+      },
+      ttl: 0,
+    });
+    expect(mockFetchRockData).toHaveBeenNthCalledWith(2, {
+      endpoint: 'GroupMembers',
+      queryParams: {
+        $filter: 'GroupId eq 1098441 and PersonId eq 123',
+        $select: 'Id',
+      },
+      ttl: 0,
+    });
+    expect(mockPostRockData).toHaveBeenCalledWith({
+      endpoint: 'GroupMembers',
+      body: {
+        GroupId: 1098441,
+        PersonId: '123',
+        GroupRoleId: 359,
+        GroupMemberStatus: 1,
+        IsArchived: false,
+      },
+    });
+    expect(await response.json()).toEqual({ success: true });
+  });
+});

--- a/app/routes/group-finder-notify/action.ts
+++ b/app/routes/group-finder-notify/action.ts
@@ -1,5 +1,9 @@
 import type { ActionFunction } from 'react-router-dom';
-import { fetchRockData, postRockData, TTL } from '~/lib/.server/fetch-rock-data';
+import {
+  fetchRockData,
+  postRockData,
+  TTL,
+} from '~/lib/.server/fetch-rock-data';
 import { findOrCreateRockPersonForSignup } from '~/lib/.server/rock-signup';
 import { escapeOData } from '~/lib/.server/rock-utils';
 
@@ -28,7 +32,7 @@ type CampusLookupResult = {
   id?: number;
 };
 
-const getFirstRecord = <T,>(result: T | T[] | null | undefined): T | null => {
+const getFirstRecord = <T>(result: T | T[] | null | undefined): T | null => {
   if (Array.isArray(result)) {
     return result[0] ?? null;
   }

--- a/app/routes/group-finder-notify/action.ts
+++ b/app/routes/group-finder-notify/action.ts
@@ -1,0 +1,122 @@
+import type { ActionFunction } from 'react-router-dom';
+import { fetchRockData, postRockData, TTL } from '~/lib/.server/fetch-rock-data';
+import { findOrCreateRockPersonForSignup } from '~/lib/.server/rock-signup';
+import { escapeOData } from '~/lib/.server/rock-utils';
+
+const GROUP_ROLE_ID = 359;
+const ACTIVE_GROUP_MEMBER_STATUS = 1;
+
+const CAMPUS_UPDATES_GROUPS: Record<number, number> = {
+  10: 1098441,
+  17: 1098646,
+  6: 1098647,
+  9: 1098648,
+  4: 1098649,
+  7: 1098650,
+  8: 1098651,
+  14: 1098652,
+  12: 1098653,
+  2: 1098654,
+  13: 1098655,
+  20: 1098656,
+  3: 1098657,
+  5: 1098658,
+  1: 1098659,
+};
+
+type CampusLookupResult = {
+  id?: number;
+};
+
+const getFirstRecord = <T,>(result: T | T[] | null | undefined): T | null => {
+  if (Array.isArray(result)) {
+    return result[0] ?? null;
+  }
+
+  return result ?? null;
+};
+
+export const action: ActionFunction = async ({ request }) => {
+  try {
+    const formData = await request.formData();
+
+    const FirstName = formData.get('FirstName')?.toString().trim();
+    const LastName = formData.get('LastName')?.toString().trim();
+    const EmailAddress = formData.get('EmailAddress')?.toString().trim();
+    const PhoneNumber = formData.get('PhoneNumber')?.toString().trim();
+    const Campus = formData.get('Campus')?.toString().trim();
+
+    if (!FirstName || !LastName || !EmailAddress || !PhoneNumber || !Campus) {
+      return Response.json(
+        { error: 'Please fill in all required fields.' },
+        { status: 400 },
+      );
+    }
+
+    const campusResult = await fetchRockData({
+      endpoint: 'Campuses',
+      queryParams: {
+        $filter: `Guid eq guid'${escapeOData(Campus)}'`,
+        $select: 'Id',
+      },
+      ttl: TTL.NONE,
+    });
+    const campus = getFirstRecord<CampusLookupResult>(campusResult);
+
+    if (!campus?.id) {
+      return Response.json(
+        { error: 'Please select a valid campus.' },
+        { status: 400 },
+      );
+    }
+
+    const groupId = CAMPUS_UPDATES_GROUPS[campus.id];
+
+    if (!groupId) {
+      return Response.json(
+        { error: 'This campus is not available for group notifications.' },
+        { status: 400 },
+      );
+    }
+
+    const personId = await findOrCreateRockPersonForSignup({
+      firstName: FirstName,
+      lastName: LastName,
+      email: EmailAddress,
+      phoneNumber: PhoneNumber,
+    });
+
+    const existingMembership = await fetchRockData({
+      endpoint: 'GroupMembers',
+      queryParams: {
+        $filter: `GroupId eq ${groupId} and PersonId eq ${personId}`,
+        $select: 'Id',
+      },
+      ttl: TTL.NONE,
+    });
+
+    if (!getFirstRecord(existingMembership)) {
+      await postRockData({
+        endpoint: 'GroupMembers',
+        body: {
+          GroupId: groupId,
+          PersonId: personId,
+          GroupRoleId: GROUP_ROLE_ID,
+          GroupMemberStatus: ACTIVE_GROUP_MEMBER_STATUS,
+          IsArchived: false,
+        },
+      });
+    }
+
+    return Response.json({ success: true });
+  } catch (error) {
+    if (error instanceof Error) {
+      return Response.json({ error: error.message }, { status: 400 });
+    }
+
+    return Response.json(
+      { error: 'Network error please try again' },
+      { status: 400 },
+    );
+  }
+};

--- a/app/routes/group-finder-notify/loader.test.ts
+++ b/app/routes/group-finder-notify/loader.test.ts
@@ -1,0 +1,39 @@
+import type { LoaderFunctionArgs } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchRockData } from '~/lib/.server/fetch-rock-data';
+import { loader } from './loader';
+
+vi.mock('~/lib/.server/fetch-rock-data', () => ({
+  fetchRockData: vi.fn(),
+}));
+
+const mockFetchRockData = vi.mocked(fetchRockData);
+
+describe('group finder notify loader', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns active campuses for the notify form', async () => {
+    const campuses = [
+      {
+        id: 10,
+        guid: 'campus-guid-10',
+        name: 'Palm Beach Gardens',
+      },
+    ];
+    mockFetchRockData.mockResolvedValue(campuses);
+
+    const result = await loader({} as LoaderFunctionArgs);
+
+    expect(mockFetchRockData).toHaveBeenCalledWith({
+      endpoint: 'Campuses',
+      queryParams: {
+        $filter: 'IsActive eq true',
+        $orderby: 'Order',
+        $select: 'Id, Name, Guid',
+      },
+    });
+    expect(result).toEqual({ campuses });
+  });
+});

--- a/app/routes/group-finder-notify/loader.ts
+++ b/app/routes/group-finder-notify/loader.ts
@@ -1,0 +1,27 @@
+import type { LoaderFunction } from 'react-router-dom';
+import { fetchRockData } from '~/lib/.server/fetch-rock-data';
+
+export type GroupFinderNotifyCampus = {
+  id: number;
+  guid: string;
+  name: string;
+};
+
+export type GroupFinderNotifyLoaderData = {
+  campuses: GroupFinderNotifyCampus[];
+};
+
+export const loader: LoaderFunction = async () => {
+  const campuses = await fetchRockData({
+    endpoint: 'Campuses',
+    queryParams: {
+      $filter: 'IsActive eq true',
+      $orderby: 'Order',
+      $select: 'Id, Name, Guid',
+    },
+  });
+
+  return {
+    campuses,
+  } satisfies GroupFinderNotifyLoaderData;
+};

--- a/app/routes/group-finder-notify/route.tsx
+++ b/app/routes/group-finder-notify/route.tsx
@@ -1,0 +1,6 @@
+export { action } from './action';
+export { loader } from './loader';
+
+export default function GroupFinderNotifyRoute() {
+  return null;
+}

--- a/app/routes/group-finder/partials/group-search.partial.tsx
+++ b/app/routes/group-finder/partials/group-search.partial.tsx
@@ -11,6 +11,7 @@ import {
 
 import { FinderResultsStats } from '~/components/finders/finder-results-stats.component';
 import { FinderStickyBar } from '~/components/finders/finder-sticky-bar.component';
+import { GroupFinderNotifyModal } from '~/components/modals';
 import { useResponsive } from '~/hooks/use-responsive';
 import { cn } from '~/lib/utils';
 import { Icon } from '~/primitives/icon/icon';
@@ -609,9 +610,9 @@ function GroupFinderResultsLayout({
   campusCityByName: LoaderReturnType['campusCityByName'];
 }) {
   return (
-    <div className='flex flex-col bg-gray py-8 md:pt-12 md:pb-20 w-full content-padding'>
+    <div className='flex flex-col bg-gray pt-4 pb-8 md:pt-12 md:pb-20 w-full content-padding'>
       <div className='max-w-screen-content mx-auto md:w-full'>
-        <FinderResultsStats hitCount={groupNbHits} />
+        <GroupFinderResultsHeader hitCount={groupNbHits} />
         <div className='min-h-[320px]'>
           {groupHits.length === 0 && !isLoading ? (
             <p className='text-text-secondary text-center py-8'>
@@ -665,6 +666,62 @@ function GroupFinderResultsLayout({
         )}
       </div>
     </div>
+  );
+}
+
+function GroupFinderResultsHeader({ hitCount }: { hitCount: number }) {
+  const formattedHitCount = hitCount.toLocaleString();
+
+  return (
+    <div className='mb-4 md:mb-6'>
+      <div className='hidden md:flex md:items-center md:justify-between md:gap-6'>
+        <FinderResultsStats hitCount={hitCount} />
+        <div className='flex items-center gap-6 text-base text-text-primary'>
+          <p>More groups available at our next launch.</p>
+          <GroupFinderNotifyTrigger variant='desktop' />
+        </div>
+      </div>
+
+      <div className='flex flex-col items-start gap-1 md:hidden'>
+        <p className='text-sm leading-5 text-text-primary'>
+          {formattedHitCount} Results - More available at our next groups
+          launch.
+        </p>
+        <GroupFinderNotifyTrigger variant='mobile' />
+      </div>
+    </div>
+  );
+}
+
+function GroupFinderNotifyTrigger({
+  variant,
+}: {
+  variant: 'desktop' | 'mobile';
+}) {
+  if (variant === 'mobile') {
+    return (
+      <GroupFinderNotifyModal>
+        <button
+          type='button'
+          className='inline-flex items-center gap-2 text-sm leading-none text-ocean'
+        >
+          <Icon name='bell' size={18} color='currentColor' />
+          <span>Get Notified</span>
+        </button>
+      </GroupFinderNotifyModal>
+    );
+  }
+
+  return (
+    <GroupFinderNotifyModal>
+      <button
+        type='button'
+        className='inline-flex min-h-10 items-center gap-2 rounded-[8px] bg-[#DAEAF1] px-4 text-base font-semibold text-ocean transition-colors hover:bg-[#CDE7F1]'
+      >
+        <Icon name='bell' size={18} color='currentColor' />
+        <span>Get Notified</span>
+      </button>
+    </GroupFinderNotifyModal>
   );
 }
 


### PR DESCRIPTION
## Summary
Adds a “Get Notified” callout and modal flow to Group Finder so users can submit contact information and campus preference for the next group launch. The form uses a folder-based resource route at `/group-finder-notify` to load campus options and add the resolved/created Rock person to a campus-specific updates group.

## Screenshots

<img width="1105" height="846" alt="image" src="https://github.com/user-attachments/assets/552458b7-9f76-4537-8fc3-e08fb056d96d" />


## Testing

- [x] Open `/group-finder`.
- [x] Click the “Get Notified” button between filters and results.
- [x] Confirm the modal renders first name, last name, email, phone, and campus fields.
- [x] Submit the form and confirm the success state appears.
- [x] Verify Rock receives a `GroupMembers` insert for the campus-mapped group when the person is not already a member.
- [x] No new test/type/format errors

## Tickets

[CFDP-4058](https://christfellowshipchurch.atlassian.net/browse/CFDP-4058)

## Changes Made

### New Components Added

- `app/components/modals/group-finder-notify/`
  - Adds the Group Finder notify modal flow, form step, and confirmation step.
  - Form collects first name, last name, email, phone, and campus.

### Route Implementation

- `app/routes/group-finder-notify/`
  - Adds folder-based resource route with `loader.ts`, `action.ts`, and `route.tsx`.
  - Loader fetches active Rock campuses with `Id`, `Name`, and `Guid`.
  - Action validates required fields, resolves campus Guid to campus Id, maps campus Id to the updates group, finds or creates the Rock person, checks for an existing group membership, and posts to `GroupMembers` when needed.
- Removes the temporary `/api/group-finder-notify` workflow route in favor of `/group-finder-notify`.

### Key Features

- Adds desktop and mobile “Get Notified” callout placement between Group Finder filters and result cards.
- Opens a modal form from the callout trigger.
- Loads campus options from Rock.
- Adds users to campus-specific Rock update groups using `GroupRoleId: 359`.
- Treats existing group membership as a successful submission to avoid duplicate records.
- Preserves GTM `form_start` and `form_complete` events for `group_finder_notify`.

[CFDP-4058]: https://christfellowshipchurch.atlassian.net/browse/CFDP-4058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ