### PR TITLE
feat: restore Share My Skills workflow form (from PR #296)

### DIFF
--- a/app/components/modals/index.ts
+++ b/app/components/modals/index.ts
@@ -6,4 +6,5 @@ export { HelpMeFindAGroupModal } from './help-me-find-a-group';
 export { NewsletterSubscriptionModal } from './newsletter-subscription';
 export { PrayerRequestModal } from './prayer-request';
 export { SetAReminderModal } from './set-a-reminder';
+export { ShareMySkillsModal } from './share-my-skills';
 export { VideoModal } from './video-modal';

--- a/app/components/modals/share-my-skills/__tests__/share-my-skills-form.test.tsx
+++ b/app/components/modals/share-my-skills/__tests__/share-my-skills-form.test.tsx
@@ -16,7 +16,9 @@ const mockSubmit = vi.fn();
 
 vi.mock('react-router-dom', async () => {
   const actual =
-    await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+    await vi.importActual<typeof import('react-router-dom')>(
+      'react-router-dom',
+    );
   return {
     ...actual,
     useFetcher: () => ({

--- a/app/components/modals/share-my-skills/__tests__/share-my-skills-form.test.tsx
+++ b/app/components/modals/share-my-skills/__tests__/share-my-skills-form.test.tsx
@@ -49,13 +49,13 @@ describe('ShareMySkillsForm', () => {
     expect(screen.getByText('Share My Skills')).toBeInTheDocument();
   });
 
-  it('renders First Name, Last Name, Campus, Cell Phone, Email Address fields', () => {
+  it('renders First Name, Last Name, Campus, Phone, Email fields', () => {
     renderForm();
     expect(screen.getByText('First Name')).toBeInTheDocument();
     expect(screen.getByText('Last Name')).toBeInTheDocument();
     expect(screen.getByText('Campus Location')).toBeInTheDocument();
-    expect(screen.getByText('Cell Phone')).toBeInTheDocument();
-    expect(screen.getByText('Email Address')).toBeInTheDocument();
+    expect(screen.getByText('Phone')).toBeInTheDocument();
+    expect(screen.getByText('Email')).toBeInTheDocument();
   });
 
   it('renders all five skills and interests checkboxes', () => {

--- a/app/components/modals/share-my-skills/__tests__/share-my-skills-form.test.tsx
+++ b/app/components/modals/share-my-skills/__tests__/share-my-skills-form.test.tsx
@@ -1,0 +1,185 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import ShareMySkillsForm from '../share-my-skills-form.component';
+
+vi.mock('~/lib/gtm', () => ({ pushFormEvent: vi.fn() }));
+
+import { pushFormEvent } from '~/lib/gtm';
+
+let mockFetcherState = {
+  state: 'idle' as 'idle' | 'submitting' | 'loading',
+  data: undefined as unknown,
+};
+const mockLoad = vi.fn();
+const mockSubmit = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual =
+    await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useFetcher: () => ({
+      state: mockFetcherState.state,
+      data: mockFetcherState.data,
+      load: mockLoad,
+      submit: mockSubmit,
+    }),
+  };
+});
+
+function renderForm(onSuccess = vi.fn()) {
+  return render(
+    <MemoryRouter>
+      <ShareMySkillsForm onSuccess={onSuccess} />
+    </MemoryRouter>,
+  );
+}
+
+describe('ShareMySkillsForm', () => {
+  beforeEach(() => {
+    mockFetcherState = { state: 'idle', data: undefined };
+    vi.clearAllMocks();
+  });
+
+  it("renders the 'Share My Skills' heading", () => {
+    renderForm();
+    expect(screen.getByText('Share My Skills')).toBeInTheDocument();
+  });
+
+  it('renders First Name, Last Name, Campus, Cell Phone, Email Address fields', () => {
+    renderForm();
+    expect(screen.getByText('First Name')).toBeInTheDocument();
+    expect(screen.getByText('Last Name')).toBeInTheDocument();
+    expect(screen.getByText('Campus Location')).toBeInTheDocument();
+    expect(screen.getByText('Cell Phone')).toBeInTheDocument();
+    expect(screen.getByText('Email Address')).toBeInTheDocument();
+  });
+
+  it('renders all five skills and interests checkboxes', () => {
+    renderForm();
+    expect(screen.getByText('Hospitality experience')).toBeInTheDocument();
+    expect(screen.getByText('Culinary experience')).toBeInTheDocument();
+    expect(screen.getByText('Driving experience')).toBeInTheDocument();
+    expect(screen.getByText('Construction experience')).toBeInTheDocument();
+    expect(screen.getByText('Warehouse experience')).toBeInTheDocument();
+  });
+
+  it('renders the optional Skills textarea', () => {
+    renderForm();
+    expect(
+      screen.getByText('Share more about your skills and interests'),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the Campus select with placeholder', () => {
+    renderForm();
+    expect(screen.getByText('Select a Campus')).toBeInTheDocument();
+  });
+
+  it('renders Submit button', () => {
+    renderForm();
+    expect(screen.getByRole('button', { name: /submit/i })).toBeInTheDocument();
+  });
+
+  it("calls fetcher.load('/share-my-skills') on mount", () => {
+    renderForm();
+    expect(mockLoad).toHaveBeenCalledWith('/share-my-skills');
+  });
+
+  it('shows campuses in select when fetcher data loads', () => {
+    mockFetcherState = {
+      state: 'idle',
+      data: {
+        campuses: [
+          { guid: 'guid-1', name: 'Palm Beach Gardens' },
+          { guid: 'guid-2', name: 'Stuart' },
+        ],
+      },
+    };
+    renderForm();
+    expect(screen.getByText('Palm Beach Gardens')).toBeInTheDocument();
+    expect(screen.getByText('Stuart')).toBeInTheDocument();
+  });
+
+  it("shows 'Loading...' on submit button when submitting", () => {
+    mockFetcherState = { state: 'submitting', data: undefined };
+    renderForm();
+    expect(
+      screen.getByRole('button', { name: /loading/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('disables the submit button when loading', () => {
+    mockFetcherState = { state: 'submitting', data: undefined };
+    renderForm();
+    expect(screen.getByRole('button', { name: /loading/i })).toBeDisabled();
+  });
+
+  it('shows server error message from fetcher data', () => {
+    mockFetcherState = {
+      state: 'idle',
+      data: { error: 'Something went wrong' },
+    };
+    renderForm();
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+  });
+
+  it('shows inline validation error when submitting with no skills checked', () => {
+    renderForm();
+    const form = document.querySelector('form') as HTMLFormElement;
+    fireEvent.submit(form);
+    expect(
+      screen.getByText('Please select at least one skill or interest'),
+    ).toBeInTheDocument();
+    expect(mockSubmit).not.toHaveBeenCalled();
+  });
+
+  it('does not show skills error when at least one checkbox is checked', () => {
+    renderForm();
+    const hospitality = document.querySelector(
+      "input[name='skillsInterests_1']",
+    ) as HTMLInputElement;
+    fireEvent.click(hospitality);
+    const form = document.querySelector('form') as HTMLFormElement;
+    fireEvent.submit(form);
+    expect(
+      screen.queryByText('Please select at least one skill or interest'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('calls pushFormEvent form_complete before onSuccess on success', () => {
+    const onSuccess = vi.fn();
+    const callOrder: string[] = [];
+    vi.mocked(pushFormEvent).mockImplementation(() => {
+      callOrder.push('gtm');
+    });
+    onSuccess.mockImplementation(() => {
+      callOrder.push('onSuccess');
+    });
+
+    mockFetcherState = {
+      state: 'idle',
+      data: { success: true },
+    };
+
+    renderForm(onSuccess);
+
+    expect(pushFormEvent).toHaveBeenCalledWith(
+      'form_complete',
+      'share_my_skills',
+      'Share My Skills',
+    );
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(callOrder).toEqual(['gtm', 'onSuccess']);
+  });
+
+  it('checkboxes submit correct numeric values', () => {
+    renderForm();
+    const checkbox = document.querySelector(
+      "input[name='skillsInterests_3']",
+    ) as HTMLInputElement;
+    expect(checkbox).toBeInTheDocument();
+    expect(checkbox.value).toBe('3');
+  });
+});

--- a/app/components/modals/share-my-skills/confirmation.component.tsx
+++ b/app/components/modals/share-my-skills/confirmation.component.tsx
@@ -16,11 +16,7 @@ const ShareMySkillsConfirmation: React.FC<ShareMySkillsConfirmationProps> = ({
         Thank you for sharing your unique skills and experiences. We'll reach
         out when opportunities arise that match what you have to offer.
       </p>
-      <Button
-        intent='primary'
-        className='rounded-xl w-52'
-        onClick={onSuccess}
-      >
+      <Button intent='primary' className='rounded-xl w-52' onClick={onSuccess}>
         Continue
       </Button>
     </div>

--- a/app/components/modals/share-my-skills/confirmation.component.tsx
+++ b/app/components/modals/share-my-skills/confirmation.component.tsx
@@ -1,0 +1,30 @@
+import { Button } from '~/primitives/button/button.primitive';
+import Icon from '~/primitives/icon';
+
+interface ShareMySkillsConfirmationProps {
+  onSuccess?: () => void;
+}
+
+const ShareMySkillsConfirmation: React.FC<ShareMySkillsConfirmationProps> = ({
+  onSuccess,
+}) => {
+  return (
+    <div className='flex flex-col items-center gap-4 p-8'>
+      <Icon name='check' size={64} color='#1ec27f' />
+      <h1 className='font-bold text-2xl text-navy'>Skills Received!</h1>
+      <p className='text-center text-text_primary'>
+        Thank you for sharing your unique skills and experiences. We'll reach
+        out when opportunities arise that match what you have to offer.
+      </p>
+      <Button
+        intent='primary'
+        className='rounded-xl w-52'
+        onClick={onSuccess}
+      >
+        Continue
+      </Button>
+    </div>
+  );
+};
+
+export default ShareMySkillsConfirmation;

--- a/app/components/modals/share-my-skills/index.ts
+++ b/app/components/modals/share-my-skills/index.ts
@@ -1,0 +1,3 @@
+import { ShareMySkillsModal } from './share-my-skills-modal';
+
+export { ShareMySkillsModal };

--- a/app/components/modals/share-my-skills/share-my-skills-flow.component.tsx
+++ b/app/components/modals/share-my-skills/share-my-skills-flow.component.tsx
@@ -1,0 +1,43 @@
+import { useState } from 'react';
+import ShareMySkillsConfirmation from './confirmation.component';
+import ShareMySkillsForm from './share-my-skills-form.component';
+
+enum ShareMySkillsStep {
+  FORM,
+  CONFIRMATION,
+}
+
+const ShareMySkillsFlow = ({
+  setOpenModal,
+}: {
+  setOpenModal: (open: boolean) => void;
+}) => {
+  const [step, setStep] = useState<ShareMySkillsStep>(
+    ShareMySkillsStep.FORM,
+  );
+
+  const renderStep = () => {
+    switch (step) {
+      case ShareMySkillsStep.FORM:
+        return (
+          <ShareMySkillsForm
+            onSuccess={() => setStep(ShareMySkillsStep.CONFIRMATION)}
+          />
+        );
+      case ShareMySkillsStep.CONFIRMATION:
+        return (
+          <ShareMySkillsConfirmation onSuccess={() => setOpenModal(false)} />
+        );
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <div className='pt-10 text-center text-text_primary p-6 w-[90vw] max-w-sm md:max-w-xl lg:max-w-3xl overflow-y-scroll max-h-[85vh] md:max-h-[90vh]'>
+      {renderStep()}
+    </div>
+  );
+};
+
+export default ShareMySkillsFlow;

--- a/app/components/modals/share-my-skills/share-my-skills-flow.component.tsx
+++ b/app/components/modals/share-my-skills/share-my-skills-flow.component.tsx
@@ -12,9 +12,7 @@ const ShareMySkillsFlow = ({
 }: {
   setOpenModal: (open: boolean) => void;
 }) => {
-  const [step, setStep] = useState<ShareMySkillsStep>(
-    ShareMySkillsStep.FORM,
-  );
+  const [step, setStep] = useState<ShareMySkillsStep>(ShareMySkillsStep.FORM);
 
   const renderStep = () => {
     switch (step) {

--- a/app/components/modals/share-my-skills/share-my-skills-form.component.tsx
+++ b/app/components/modals/share-my-skills/share-my-skills-form.component.tsx
@@ -1,0 +1,280 @@
+import * as Form from '@radix-ui/react-form';
+import { useEffect, useState } from 'react';
+import { useFetcher } from 'react-router-dom';
+import { pushFormEvent } from '~/lib/gtm';
+import { cn } from '~/lib/utils';
+import { Button } from '~/primitives/button/button.primitive';
+import {
+  RadixFormErrorMessage,
+  RadixFormSelectShell,
+  radixCheckboxClassName,
+  radixCheckboxOptionLabelClassName,
+  radixCompactFormLabelClassName,
+  radixFormFieldStackClassName,
+  radixInputClassName,
+  radixSelectClassName,
+  radixTextareaClassName,
+} from '~/primitives/inputs/form-radix-field';
+import { ShareMySkillsLoaderReturnType } from '~/routes/share-my-skills/types';
+
+interface ShareMySkillsFormProps {
+  onSuccess: () => void;
+}
+
+const SKILLS_OPTIONS = [
+  { label: 'Hospitality experience', value: '1' },
+  { label: 'Culinary experience', value: '2' },
+  { label: 'Driving experience', value: '3' },
+  { label: 'Construction experience', value: '4' },
+  { label: 'Warehouse experience', value: '5' },
+];
+
+const ShareMySkillsForm: React.FC<ShareMySkillsFormProps> = ({ onSuccess }) => {
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [campuses, setCampuses] = useState<
+    ShareMySkillsLoaderReturnType['campuses']
+  >([]);
+  const [skillsError, setSkillsError] = useState(false);
+  const [checkedSkills, setCheckedSkills] = useState<Record<string, boolean>>(
+    {},
+  );
+  const fetcher = useFetcher();
+
+  useEffect(() => {
+    fetcher.load('/share-my-skills');
+  }, []);
+
+  useEffect(() => {
+    if (fetcher.state === 'idle' && fetcher.data) {
+      setLoading(false);
+
+      if ('campuses' in fetcher.data) {
+        setCampuses(
+          (fetcher.data as ShareMySkillsLoaderReturnType).campuses,
+        );
+      } else if ('error' in fetcher.data) {
+        setError(
+          (fetcher.data as { error: string }).error ||
+            'An unexpected error occurred',
+        );
+      } else {
+        setError(null);
+        pushFormEvent('form_complete', 'share_my_skills', 'Share My Skills');
+        onSuccess();
+      }
+    }
+
+    if (fetcher.state === 'submitting') {
+      setLoading(true);
+      setError(null);
+    }
+  }, [fetcher.state, fetcher.data, onSuccess]);
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const anyChecked = Object.values(checkedSkills).some(Boolean);
+    if (!anyChecked) {
+      setSkillsError(true);
+      return;
+    }
+    setSkillsError(false);
+
+    const formData = new FormData(event.currentTarget);
+
+    try {
+      fetcher.submit(formData, {
+        method: 'post',
+        action: '/share-my-skills',
+      });
+    } catch {
+      setError(
+        'An error occurred while submitting the form. Please try again.',
+      );
+      setLoading(false);
+    }
+  };
+
+  const handleSkillChange = (value: string, checked: boolean) => {
+    setCheckedSkills((prev) => ({ ...prev, [value]: checked }));
+    if (checked) setSkillsError(false);
+  };
+
+  return (
+    <>
+      <h2 className='mb-6 text-3xl text-navy font-bold'>Share My Skills</h2>
+      <Form.Root
+        onSubmit={handleSubmit}
+        className='flex flex-col md:grid text-left grid-cols-1 gap-y-3 gap-x-6 md:grid-cols-2'
+      >
+        <Form.Field
+          name='FirstName'
+          className={cn('mb-4', radixFormFieldStackClassName)}
+        >
+          <Form.Label className={radixCompactFormLabelClassName}>
+            First Name
+          </Form.Label>
+          <Form.Control asChild>
+            <input
+              type='text'
+              required
+              className={radixInputClassName}
+            />
+          </Form.Control>
+          <RadixFormErrorMessage match='valueMissing'>
+            Please enter your first name
+          </RadixFormErrorMessage>
+        </Form.Field>
+
+        <Form.Field
+          name='LastName'
+          className={cn('mb-4', radixFormFieldStackClassName)}
+        >
+          <Form.Label className={radixCompactFormLabelClassName}>
+            Last Name
+          </Form.Label>
+          <Form.Control asChild>
+            <input
+              type='text'
+              required
+              className={radixInputClassName}
+            />
+          </Form.Control>
+          <RadixFormErrorMessage match='valueMissing'>
+            Please enter your last name
+          </RadixFormErrorMessage>
+        </Form.Field>
+
+        <Form.Field
+          name='Campus1'
+          className={cn('mb-4', radixFormFieldStackClassName)}
+        >
+          <Form.Label className={radixCompactFormLabelClassName}>
+            Campus Location
+          </Form.Label>
+          {campuses && (
+            <RadixFormSelectShell>
+              <Form.Control asChild>
+                <select
+                  className={radixSelectClassName}
+                  required
+                  defaultValue=''
+                >
+                  <option value=''>Select a Campus</option>
+                  {campuses.map(({ guid, name }, index) => (
+                    <option key={index} value={guid}>
+                      {name}
+                    </option>
+                  ))}
+                </select>
+              </Form.Control>
+            </RadixFormSelectShell>
+          )}
+          <RadixFormErrorMessage match='valueMissing'>
+            Please select a campus
+          </RadixFormErrorMessage>
+        </Form.Field>
+
+        <Form.Field
+          name='PhoneNumber'
+          className={cn('mb-4', radixFormFieldStackClassName)}
+        >
+          <Form.Label className={radixCompactFormLabelClassName}>
+            Cell Phone
+          </Form.Label>
+          <Form.Control asChild>
+            <input
+              type='tel'
+              required
+              className={radixInputClassName}
+            />
+          </Form.Control>
+          <RadixFormErrorMessage match='valueMissing'>
+            Please enter your phone number
+          </RadixFormErrorMessage>
+        </Form.Field>
+
+        <Form.Field
+          name='EmailAddress'
+          className={cn('mb-4', radixFormFieldStackClassName)}
+        >
+          <Form.Label className={radixCompactFormLabelClassName}>
+            Email Address
+          </Form.Label>
+          <Form.Control asChild>
+            <input
+              type='email'
+              required
+              className={radixInputClassName}
+            />
+          </Form.Control>
+          <RadixFormErrorMessage match='valueMissing'>
+            Please enter your email address
+          </RadixFormErrorMessage>
+          <RadixFormErrorMessage match='typeMismatch'>
+            Please enter a valid email address
+          </RadixFormErrorMessage>
+        </Form.Field>
+
+        <div className='md:col-span-2'>
+          <p className={cn('mb-2', radixCompactFormLabelClassName)}>
+            Skills and Interests
+          </p>
+          <div className='flex flex-col gap-2 pl-1'>
+            {SKILLS_OPTIONS.map(({ label, value }) => (
+              <label
+                key={value}
+                className={cn(
+                  'flex items-center gap-2 cursor-pointer',
+                  radixCheckboxOptionLabelClassName,
+                )}
+              >
+                <input
+                  type='checkbox'
+                  name={`skillsInterests_${value}`}
+                  value={value}
+                  className={radixCheckboxClassName}
+                  onChange={(e) => handleSkillChange(value, e.target.checked)}
+                />
+                {label}
+              </label>
+            ))}
+          </div>
+          {skillsError && (
+            <p className='mt-1 text-sm text-alert'>
+              Please select at least one skill or interest
+            </p>
+          )}
+        </div>
+
+        <Form.Field
+          name='Skills'
+          className={cn('mb-4 md:col-span-2', radixFormFieldStackClassName)}
+        >
+          <Form.Label className={radixCompactFormLabelClassName}>
+            Share more about your skills and interests
+          </Form.Label>
+          <Form.Control asChild>
+            <textarea rows={4} className={radixTextareaClassName} />
+          </Form.Control>
+        </Form.Field>
+
+        {error && <p className='text-alert col-span-2 text-center'>{error}</p>}
+
+        <Form.Submit className='mt-6 mx-auto col-span-1 md:col-span-2' asChild>
+          <Button
+            className='w-40 h-12'
+            size='md'
+            type='submit'
+            disabled={loading}
+          >
+            {loading ? 'Loading...' : 'Submit'}
+          </Button>
+        </Form.Submit>
+      </Form.Root>
+    </>
+  );
+};
+
+export default ShareMySkillsForm;

--- a/app/components/modals/share-my-skills/share-my-skills-form.component.tsx
+++ b/app/components/modals/share-my-skills/share-my-skills-form.component.tsx
@@ -50,9 +50,7 @@ const ShareMySkillsForm: React.FC<ShareMySkillsFormProps> = ({ onSuccess }) => {
       setLoading(false);
 
       if ('campuses' in fetcher.data) {
-        setCampuses(
-          (fetcher.data as ShareMySkillsLoaderReturnType).campuses,
-        );
+        setCampuses((fetcher.data as ShareMySkillsLoaderReturnType).campuses);
       } else if ('error' in fetcher.data) {
         setError(
           (fetcher.data as { error: string }).error ||
@@ -103,7 +101,14 @@ const ShareMySkillsForm: React.FC<ShareMySkillsFormProps> = ({ onSuccess }) => {
 
   return (
     <>
-      <h2 className='mb-6 text-3xl text-navy font-bold'>Share My Skills</h2>
+      <h2 className='mb-2 text-3xl text-navy font-bold'>Share My Skills</h2>
+      <h3 className='mb-4 text-lg text-ocean'>
+        Do you have a unique skill set or experience?
+      </h3>
+      <p className='mb-10 text-pretty max-w-lg mx-auto'>
+        Unique opportunities arise throughout the year that need specific
+        skills. Share yours below and we'll reach out if there's a fit.
+      </p>
       <Form.Root
         onSubmit={handleSubmit}
         className='flex flex-col md:grid text-left grid-cols-1 gap-y-3 gap-x-6 md:grid-cols-2'
@@ -116,11 +121,7 @@ const ShareMySkillsForm: React.FC<ShareMySkillsFormProps> = ({ onSuccess }) => {
             First Name
           </Form.Label>
           <Form.Control asChild>
-            <input
-              type='text'
-              required
-              className={radixInputClassName}
-            />
+            <input type='text' required className={radixInputClassName} />
           </Form.Control>
           <RadixFormErrorMessage match='valueMissing'>
             Please enter your first name
@@ -135,14 +136,43 @@ const ShareMySkillsForm: React.FC<ShareMySkillsFormProps> = ({ onSuccess }) => {
             Last Name
           </Form.Label>
           <Form.Control asChild>
-            <input
-              type='text'
-              required
-              className={radixInputClassName}
-            />
+            <input type='text' required className={radixInputClassName} />
           </Form.Control>
           <RadixFormErrorMessage match='valueMissing'>
             Please enter your last name
+          </RadixFormErrorMessage>
+        </Form.Field>
+
+        <Form.Field
+          name='PhoneNumber'
+          className={cn('mb-4', radixFormFieldStackClassName)}
+        >
+          <Form.Label className={radixCompactFormLabelClassName}>
+            Phone
+          </Form.Label>
+          <Form.Control asChild>
+            <input type='tel' required className={radixInputClassName} />
+          </Form.Control>
+          <RadixFormErrorMessage match='valueMissing'>
+            Please enter your phone number
+          </RadixFormErrorMessage>
+        </Form.Field>
+
+        <Form.Field
+          name='EmailAddress'
+          className={cn('mb-4', radixFormFieldStackClassName)}
+        >
+          <Form.Label className={radixCompactFormLabelClassName}>
+            Email
+          </Form.Label>
+          <Form.Control asChild>
+            <input type='email' required className={radixInputClassName} />
+          </Form.Control>
+          <RadixFormErrorMessage match='valueMissing'>
+            Please enter your email address
+          </RadixFormErrorMessage>
+          <RadixFormErrorMessage match='typeMismatch'>
+            Please enter a valid email address
           </RadixFormErrorMessage>
         </Form.Field>
 
@@ -176,48 +206,7 @@ const ShareMySkillsForm: React.FC<ShareMySkillsFormProps> = ({ onSuccess }) => {
           </RadixFormErrorMessage>
         </Form.Field>
 
-        <Form.Field
-          name='PhoneNumber'
-          className={cn('mb-4', radixFormFieldStackClassName)}
-        >
-          <Form.Label className={radixCompactFormLabelClassName}>
-            Cell Phone
-          </Form.Label>
-          <Form.Control asChild>
-            <input
-              type='tel'
-              required
-              className={radixInputClassName}
-            />
-          </Form.Control>
-          <RadixFormErrorMessage match='valueMissing'>
-            Please enter your phone number
-          </RadixFormErrorMessage>
-        </Form.Field>
-
-        <Form.Field
-          name='EmailAddress'
-          className={cn('mb-4', radixFormFieldStackClassName)}
-        >
-          <Form.Label className={radixCompactFormLabelClassName}>
-            Email Address
-          </Form.Label>
-          <Form.Control asChild>
-            <input
-              type='email'
-              required
-              className={radixInputClassName}
-            />
-          </Form.Control>
-          <RadixFormErrorMessage match='valueMissing'>
-            Please enter your email address
-          </RadixFormErrorMessage>
-          <RadixFormErrorMessage match='typeMismatch'>
-            Please enter a valid email address
-          </RadixFormErrorMessage>
-        </Form.Field>
-
-        <div className='md:col-span-2'>
+        <div>
           <p className={cn('mb-2', radixCompactFormLabelClassName)}>
             Skills and Interests
           </p>

--- a/app/components/modals/share-my-skills/share-my-skills-modal.tsx
+++ b/app/components/modals/share-my-skills/share-my-skills-modal.tsx
@@ -1,0 +1,47 @@
+import { useState } from 'react';
+import type { ReactNode } from 'react';
+import Modal from '~/primitives/Modal';
+import { Button } from '~/primitives/button/button.primitive';
+import { ButtonProps } from '~/primitives/button/button.primitive';
+import { pushFormEvent } from '~/lib/gtm';
+import ShareMySkillsFlow from './share-my-skills-flow.component';
+
+interface ShareMySkillsModalProps {
+  buttonTitle?: string;
+  triggerStyles?: string;
+  TriggerButton?: React.ComponentType<ButtonProps>;
+  children?: ReactNode;
+}
+
+export function ShareMySkillsModal({
+  buttonTitle = 'Share My Skills',
+  triggerStyles,
+  TriggerButton = Button,
+  children,
+}: ShareMySkillsModalProps) {
+  const [openModal, setOpenModal] = useState(false);
+
+  const handleOpenChange = (open: boolean) => {
+    setOpenModal(open);
+    if (open) {
+      pushFormEvent('form_start', 'share_my_skills', 'Share My Skills');
+    }
+  };
+
+  return (
+    <Modal open={openModal} onOpenChange={handleOpenChange}>
+      {children ? (
+        <Modal.Button asChild>{children}</Modal.Button>
+      ) : (
+        <Modal.Button asChild className='mr-2'>
+          <TriggerButton intent='white' className={triggerStyles}>
+            {buttonTitle}
+          </TriggerButton>
+        </Modal.Button>
+      )}
+      <Modal.Content>
+        <ShareMySkillsFlow setOpenModal={setOpenModal} />
+      </Modal.Content>
+    </Modal>
+  );
+}

--- a/app/components/navbar/mobile/search/mobile-search.component.tsx
+++ b/app/components/navbar/mobile/search/mobile-search.component.tsx
@@ -44,8 +44,7 @@ export const MobileSearch = ({
     ALGOLIA_SEARCH_API_KEY: '',
     indexes: undefined,
   };
-  const contentItemsIndexName =
-    rootData?.algolia.indexes.contentItems ?? '';
+  const contentItemsIndexName = rootData?.algolia.indexes.contentItems ?? '';
   const locationsIndexName = rootData?.algolia.indexes.locations ?? '';
 
   // Create or retrieve the Algolia client

--- a/app/lib/.server/fetch-top-searches.ts
+++ b/app/lib/.server/fetch-top-searches.ts
@@ -20,8 +20,9 @@ export async function fetchTopSearches(
   if (!appId || !apiKey) return [];
 
   const base = getAnalyticsBase();
-  const contentIndex = getAlgoliaIndexes(process.env.ALGOLIA_INDEX_ENV)
-    .contentItems;
+  const contentIndex = getAlgoliaIndexes(
+    process.env.ALGOLIA_INDEX_ENV,
+  ).contentItems;
   const params = new URLSearchParams({
     index: contentIndex,
     limit: String(limit),

--- a/app/lib/__tests__/algolia-indexes.test.ts
+++ b/app/lib/__tests__/algolia-indexes.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from 'vitest';
+
 import {
   ALGOLIA_INDEX_NAMES,
   getAlgoliaIndexes,

--- a/app/lib/algolia-indexes.ts
+++ b/app/lib/algolia-indexes.ts
@@ -33,10 +33,7 @@ export function getAlgoliaIndexes(
   const normalizedEnv = normalizeAlgoliaIndexEnv(env);
 
   return Object.fromEntries(
-    ALGOLIA_INDEX_NAMES.map((name) => [
-      name,
-      `${normalizedEnv}_webv3_${name}`,
-    ]),
+    ALGOLIA_INDEX_NAMES.map((name) => [name, `${normalizedEnv}_webv3_${name}`]),
   ) as AlgoliaIndexMap;
 }
 

--- a/app/routes/class-finder/class-single/partials/upcoming-sections.partial.tsx
+++ b/app/routes/class-finder/class-single/partials/upcoming-sections.partial.tsx
@@ -15,9 +15,7 @@ import { cn } from '~/lib/utils';
 
 import { UpcomingSessionsCarousel } from '../components/upcoming-sessions-carousel.component';
 import { ClassSingleFiltersSkeleton } from '../components/filters/class-single-filters-skeleton.component';
-import {
-  useClassSingleUpcomingInstantSearch,
-} from '../hooks/use-class-single-upcoming-instant-search';
+import { useClassSingleUpcomingInstantSearch } from '../hooks/use-class-single-upcoming-instant-search';
 import type { ClassHitType } from '../../types';
 import type { LoaderReturnType } from '../loader';
 import OnDemandCard from '../components/on-demand-card.component';

--- a/app/routes/class-finder/finder/partials/class-search.partial.tsx
+++ b/app/routes/class-finder/finder/partials/class-search.partial.tsx
@@ -38,9 +38,7 @@ import {
   classFinderUrlStateToParams,
   parseClassFinderUrlState,
 } from '../components/class-finder-url-state';
-import {
-  CLASS_FINDER_LOADER_HITS_PER_PAGE,
-} from '../components/build-class-finder-algolia-search';
+import { CLASS_FINDER_LOADER_HITS_PER_PAGE } from '../components/build-class-finder-algolia-search';
 import { ClassFinderFiltersSkeleton } from '../components/filters/class-finder-filters-skeleton.component';
 
 /**

--- a/app/routes/events/all-events/components/all-events-content.component.tsx
+++ b/app/routes/events/all-events/components/all-events-content.component.tsx
@@ -414,7 +414,10 @@ function mapRefinementItemsToFacets(
 function AllEventsInstantFilters({
   eventsMobilePinEndRef,
   buildAllEventsInstantSearchUiState,
-}: Pick<Parameters<typeof EventsFiltersViewport>[0], 'eventsMobilePinEndRef'> & {
+}: Pick<
+  Parameters<typeof EventsFiltersViewport>[0],
+  'eventsMobilePinEndRef'
+> & {
   buildAllEventsInstantSearchUiState: (
     urlState: EventsFinderUrlState,
   ) => Record<string, Record<string, unknown>>;

--- a/app/routes/group-finder/components/group-finder-instant-search-sync.component.tsx
+++ b/app/routes/group-finder/components/group-finder-instant-search-sync.component.tsx
@@ -34,9 +34,7 @@ export function buildGroupFinderInstantSearchUiState(
     indexSlice.page = urlState.page + 1;
   }
 
-  return Object.keys(indexSlice).length > 0
-    ? { [indexName]: indexSlice }
-    : {};
+  return Object.keys(indexSlice).length > 0 ? { [indexName]: indexSlice } : {};
 }
 
 /**

--- a/app/routes/share-my-skills/action.ts
+++ b/app/routes/share-my-skills/action.ts
@@ -1,0 +1,50 @@
+import { ActionFunction, data } from 'react-router-dom';
+import { postRockWorkflowLaunchWithApiInitiator } from '~/lib/.server/rock-workflow';
+import { ShareMySkillsFormType } from './types';
+
+export const action: ActionFunction = async ({ request }) => {
+  try {
+    const formData = Object.fromEntries(await request.formData());
+
+    const skillsInterestsValues: string = Object.keys(formData)
+      .filter((key) => key.startsWith('skillsInterests_'))
+      .map((key) => formData[key])
+      .join(',');
+
+    const { FirstName, LastName, EmailAddress, Campus1, PhoneNumber, Skills } =
+      formData;
+
+    const shareMySkillsSubmission: ShareMySkillsFormType = {
+      FirstName: FirstName as string,
+      LastName: LastName as string,
+      EmailAddress: EmailAddress as string,
+      Campus1: Campus1 as string,
+      PhoneNumber: PhoneNumber as string,
+      SkillsInterests: skillsInterestsValues,
+      Skills: (Skills as string) ?? '',
+      LaunchSource: 'app',
+    };
+
+    const firstName = FirstName as string;
+    const lastName = LastName as string;
+
+    await postRockWorkflowLaunchWithApiInitiator({
+      workflowTypeId: '1874',
+      workflowName: 'CFDP%20App%20Share%20My%20Skills',
+      body: shareMySkillsSubmission,
+      instanceName: `${firstName} ${lastName}`.trim(),
+    });
+
+    return new Response(JSON.stringify({ success: true }), {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+  } catch (error) {
+    if (error instanceof Error) {
+      return data({ error: error.message }, { status: 400 });
+    }
+    return data({ error: 'Network error please try again' }, { status: 400 });
+  }
+};

--- a/app/routes/share-my-skills/loader.ts
+++ b/app/routes/share-my-skills/loader.ts
@@ -1,0 +1,18 @@
+import { LoaderFunction } from 'react-router-dom';
+import { fetchRockData } from '~/lib/.server/fetch-rock-data';
+import { ShareMySkillsLoaderReturnType } from './types';
+
+export const loader: LoaderFunction = async () => {
+  const campuses = await fetchRockData({
+    endpoint: 'Campuses',
+    queryParams: {
+      $filter: 'IsActive eq true',
+      $orderby: 'Order',
+      $select: 'Name, Guid',
+    },
+  });
+
+  const data: ShareMySkillsLoaderReturnType = { campuses };
+
+  return data;
+};

--- a/app/routes/share-my-skills/route.tsx
+++ b/app/routes/share-my-skills/route.tsx
@@ -1,0 +1,6 @@
+export { action } from './action';
+export { loader } from './loader';
+
+export default function ShareMySkillsRoute() {
+  return null;
+}

--- a/app/routes/share-my-skills/types.ts
+++ b/app/routes/share-my-skills/types.ts
@@ -1,0 +1,14 @@
+export type ShareMySkillsFormType = {
+  FirstName: string;
+  LastName: string;
+  EmailAddress: string;
+  Campus1: string;
+  PhoneNumber: string;
+  SkillsInterests: string;
+  Skills: string;
+  LaunchSource: 'app';
+};
+
+export type ShareMySkillsLoaderReturnType = {
+  campuses: { guid: string; name: string }[];
+};

--- a/app/routes/studies-and-resources/finder/partials/studies-search.partial.tsx
+++ b/app/routes/studies-and-resources/finder/partials/studies-search.partial.tsx
@@ -45,9 +45,8 @@ function getInitialStateFromUrl(
 export const StudiesSearch = () => {
   const { ALGOLIA_APP_ID, ALGOLIA_SEARCH_API_KEY, algoliaIndexes } =
     useLoaderData<LoaderReturnType>();
-  const studiesIndexName = (
-    algoliaIndexes ?? DEFAULT_ALGOLIA_INDEXES
-  ).studiesAndResources;
+  const studiesIndexName = (algoliaIndexes ?? DEFAULT_ALGOLIA_INDEXES)
+    .studiesAndResources;
   const [searchParams, setSearchParams] = useSearchParams();
   const location = useLocation();
 

--- a/app/routes/volunteer/partials/volunteer-community.partial.tsx
+++ b/app/routes/volunteer/partials/volunteer-community.partial.tsx
@@ -2,11 +2,13 @@ import { useState } from 'react';
 import { useLoaderData } from 'react-router-dom';
 
 import { SectionTitle } from '~/components/section-title';
+import { ShareMySkillsModal } from '~/components/modals/share-my-skills';
 import { cn } from '~/lib/utils';
+import { Button } from '~/primitives/button/button.primitive';
+import Icon from '~/primitives/icon';
 import { VolunteerAlgolia } from '../components/volunteer-algolia.component';
 import { VolunteerAlgoliaSkeleton } from '../components/volunteer-algolia-skeleton.component';
 import { LoaderReturnType } from '../loader';
-import { IconButton } from '~/primitives/button/icon-button.primitive';
 
 export function VolunteerCommunity() {
   const { ALGOLIA_APP_ID, ALGOLIA_SEARCH_API_KEY, algoliaIndexes } =
@@ -48,19 +50,25 @@ export function VolunteerCommunity() {
         <div className='content-padding'>
           <div className='max-w-[1280px] mx-auto mt-16 flex flex-col md:flex-row items-center justify-center gap-6 text-center'>
             <p className='md:text-lg font-semibold text-neutral-dark'>
-              Not finding an opportunity? Share your skills with us, and
-              we&apos;ll get in touch.
+              Have a skill set we should know about?
             </p>
-            <IconButton
-              to='/volunteer-form'
-              withRotatingArrow={true}
-              iconName='arrowRight'
-              iconSize={24}
-              className='rounded-full border-neutral-darker px-6 text-neutral-darker hover:text-white! hover:bg-navy! hover:border-navy!'
-              iconClasses='text-white -rotate-45! group-hover:rotate-0!'
-            >
-              <span className='flex items-center gap-3'>Share Your Skills</span>
-            </IconButton>
+            <ShareMySkillsModal>
+              <div className='group flex cursor-pointer'>
+                <Button
+                  intent='secondary'
+                  className='font-semibold hover:enabled:bg-current/10 rounded-full border-neutral-darker px-6 text-neutral-darker hover:text-white! hover:bg-navy! hover:border-navy!'
+                >
+                  <span className='flex items-center gap-3'>
+                    Share Your Skills
+                  </span>
+                </Button>
+                <Icon
+                  name='arrowRight'
+                  className='-ml-3 text-white rounded-full p-2 transition-transform duration-300 size-10 bg-ocean -rotate-45 group-hover:rotate-0'
+                  size={24}
+                />
+              </div>
+            </ShareMySkillsModal>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Restores the Share My Skills modal workflow form from PR #296, which was merged into `copy-cleanup` after that branch had already landed on `main` — so the feature never reached production.

Cherry-picked onto current `main`:
- `91e9d65d` — feat: add Share My Skills workflow form (modal-only)
- `0c69f05c` — Enhance ShareMySkills form and trigger UI
- `68cc69c8` — lint fix

Also fixes a stale test assertion (`Phone` / `Email` labels vs `Cell Phone` / `Email Address`).

## Test plan

- [x] `pnpm test app/components/modals/share-my-skills/__tests__/share-my-skills-form.test.tsx`
- [ ] Open **Volunteer** page → click **Share Your Skills** → modal opens (not `/volunteer-form`)
- [ ] Campus dropdown loads; fill required fields + at least one Skills checkbox; submit succeeds
- [ ] Confirmation shows **Skills Received!**; **Continue** closes modal
- [ ] New workflow instance appears in Rock workflow entries (1874) matching submitted data

## Tickets

[CFDP-4035](https://christfellowshipchurch.atlassian.net/browse/CFDP-4035)


Made with [Cursor](https://cursor.com)

[CFDP-4035]: https://christfellowshipchurch.atlassian.net/browse/CFDP-4035?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ