### PR TITLE
Support multi-date event finder

### DIFF
--- a/app/routes/events/event-single/components/clickthrough-registration.component.tsx
+++ b/app/routes/events/event-single/components/clickthrough-registration.component.tsx
@@ -19,6 +19,13 @@ import {
   isSpanishCampusLabel,
 } from '../registration.data';
 import { scrollToAnchor } from '~/lib/scroll-to-anchor';
+import {
+  eventFinderDatesMatch,
+  formatEventFinderDatesDisplay,
+  normalizeEventFinderDates,
+  parseSerializedEventFinderDates,
+  serializeEventFinderDates,
+} from '../event-finder-dates';
 
 interface ClickThroughRegistrationProps {
   title: string;
@@ -181,9 +188,10 @@ export const ClickThroughRegistration = ({
       filter += ` AND subGroupType:"${selectedSubGroupType.trim()}"`;
     }
     if (selectedDate) {
-      // Ensure date format matches exactly (YYYY-MM-DD)
-      const trimmedDate = selectedDate.trim();
-      filter += ` AND date:"${trimmedDate}"`;
+      const trimmedDates = parseSerializedEventFinderDates(selectedDate);
+      trimmedDates.forEach((date) => {
+        filter += ` AND date:"${date}"`;
+      });
     }
     return filter;
   };
@@ -293,7 +301,9 @@ export const ClickThroughRegistration = ({
                     {selectedDate && (
                       <SelectedBar
                         icon='calendarAlt'
-                        text={formatDateDisplay(selectedDate)}
+                        text={formatEventFinderDatesDisplay(
+                          parseSerializedEventFinderDates(selectedDate),
+                        )}
                         onClick={() => navigateToStep(hasSubGroups ? 3 : 2)}
                       />
                     )}
@@ -473,7 +483,7 @@ const StepContent = ({
         hit.campus.name &&
         hit.campus.name === selectedCampus &&
         hit.time === selectedTime &&
-        hit.date === selectedDate;
+        eventFinderDatesMatch(hit.date, selectedDate);
       if (hasSubGroups) {
         return campusMatch && hit.subGroupType === selectedSubGroupType;
       }
@@ -668,7 +678,7 @@ const DateStep = ({
 }: DateStepProps) => {
   // Get unique dates for selected campus and subGroupType (if applicable)
   const uniqueDates = useMemo(() => {
-    const dateMap = new Map<string, { date: string; day: string }>();
+    const dateMap = new Map<string, { dates: string[]; day: string }>();
     hits
       .filter((hit) => {
         const campusMatch =
@@ -685,30 +695,39 @@ const DateStep = ({
         return campusMatch;
       })
       .forEach((hit) => {
-        if (!dateMap.has(hit.date)) {
-          dateMap.set(hit.date, {
-            date: hit.date,
+        const dates = normalizeEventFinderDates(hit.date);
+        if (dates.length === 0) return;
+
+        const dateKey = serializeEventFinderDates(dates);
+        if (!dateMap.has(dateKey)) {
+          dateMap.set(dateKey, {
+            dates,
             day: hit.day,
           });
         }
       });
     return Array.from(dateMap.values()).sort((a, b) =>
-      a.date.localeCompare(b.date),
+      a.dates[0].localeCompare(b.dates[0]),
     );
   }, [hits, selectedCampus, selectedSubGroupType, hasSubGroups]);
 
   return (
     <div className='flex flex-wrap justify-center gap-4'>
-      {uniqueDates.map((dateInfo) => (
-        <ClickableCard
-          key={dateInfo.date}
-          variant='date'
-          icon='calendarAlt'
-          title={formatDateDisplay(dateInfo.date, dateInfo.day)}
-          subtitle={dateInfo.day}
-          onClick={() => onSelect(dateInfo.date)}
-        />
-      ))}
+      {uniqueDates.map((dateInfo) => {
+        const dateKey = serializeEventFinderDates(dateInfo.dates);
+        return (
+          <ClickableCard
+            key={dateKey}
+            variant='date'
+            icon='calendarAlt'
+            title={formatEventFinderDatesDisplay(dateInfo.dates, dateInfo.day)}
+            subtitle={
+              dateInfo.dates.length === 1 ? dateInfo.day : undefined
+            }
+            onClick={() => onSelect(dateKey)}
+          />
+        );
+      })}
     </div>
   );
 };
@@ -742,7 +761,7 @@ const TimeStep = ({
         hit.campus &&
         hit.campus.name &&
         hit.campus.name.trim() === selectedCampus.trim();
-      const dateMatch = hit.date && hit.date.trim() === selectedDate.trim();
+      const dateMatch = eventFinderDatesMatch(hit.date, selectedDate);
       if (hasSubGroups) {
         return (
           campusMatch &&
@@ -890,7 +909,9 @@ const FormStep = ({
             details={{
               title: 'Journey Details',
               campus: selectedCampus,
-              date: formatDateDisplay(selectedDate),
+              date: formatEventFinderDatesDisplay(
+                parseSerializedEventFinderDates(selectedDate),
+              ),
               time: `${selectedTime} ET`,
               name:
                 nativeSuccessDetails?.firstName ||
@@ -986,35 +1007,3 @@ const RegistrationSkeleton = ({ totalSteps }: { totalSteps: number }) => (
     </div>
   </section>
 );
-
-// Helper Functions
-const formatDateDisplay = (dateString: string, dayName?: string): string => {
-  // Parse date string manually to avoid timezone issues
-  // Date format is YYYY-MM-DD
-  const [year, month, day] = dateString.split('-').map(Number);
-  const date = new Date(year, month - 1, day); // month is 0-indexed in Date constructor
-
-  const monthName = date.toLocaleDateString('en-US', { month: 'short' });
-  const dayNum = date.getDate();
-  const suffix = getDaySuffix(dayNum);
-
-  // Use provided dayName if available, otherwise calculate it
-  const weekday =
-    dayName || date.toLocaleDateString('en-US', { weekday: 'short' });
-
-  return `${weekday} ${monthName} ${dayNum}${suffix}`;
-};
-
-const getDaySuffix = (day: number): string => {
-  if (day > 3 && day < 21) return 'th';
-  switch (day % 10) {
-    case 1:
-      return 'st';
-    case 2:
-      return 'nd';
-    case 3:
-      return 'rd';
-    default:
-      return 'th';
-  }
-};

--- a/app/routes/events/event-single/components/clickthrough-registration.component.tsx
+++ b/app/routes/events/event-single/components/clickthrough-registration.component.tsx
@@ -21,6 +21,7 @@ import {
 import { scrollToAnchor } from '~/lib/scroll-to-anchor';
 import {
   eventFinderDatesMatch,
+  formatEventFinderDateLabel,
   formatEventFinderDatesDisplay,
   normalizeEventFinderDates,
   parseSerializedEventFinderDates,
@@ -76,6 +77,7 @@ export const ClickThroughRegistration = ({
   const [selectedCampus, setSelectedCampus] = useState<string>('');
   const [selectedSubGroupType, setSelectedSubGroupType] = useState<string>('');
   const [selectedDate, setSelectedDate] = useState<string>('');
+  const [selectedDay, setSelectedDay] = useState<string>('');
   const [selectedTime, setSelectedTime] = useState<string>('');
   const [campusSearchQuery, setCampusSearchQuery] = useState<string>('');
   const [pendingRegisterScroll, setPendingRegisterScroll] = useState(false);
@@ -86,6 +88,7 @@ export const ClickThroughRegistration = ({
     setSelectedCampus('');
     setSelectedSubGroupType('');
     setSelectedDate('');
+    setSelectedDay('');
     setSelectedTime('');
     setCampusSearchQuery('');
     previousStepRef.current = 1;
@@ -118,11 +121,13 @@ export const ClickThroughRegistration = ({
         setSelectedTime('');
       } else if (step === 4) {
         setSelectedDate('');
+        setSelectedDay('');
       } else if (step === 3) {
         if (hasSubGroups) {
           setSelectedSubGroupType('');
         } else {
           setSelectedDate('');
+          setSelectedDay('');
         }
       } else if (step === 2) {
         if (hasSubGroups) {
@@ -144,6 +149,7 @@ export const ClickThroughRegistration = ({
     }
     if (targetActualStep < 4) {
       setSelectedDate('');
+      setSelectedDay('');
     }
     if (targetActualStep < 3) {
       setSelectedSubGroupType('');
@@ -303,6 +309,7 @@ export const ClickThroughRegistration = ({
                         icon='calendarAlt'
                         text={formatEventFinderDatesDisplay(
                           parseSerializedEventFinderDates(selectedDate),
+                          selectedDay,
                         )}
                         onClick={() => navigateToStep(hasSubGroups ? 3 : 2)}
                       />
@@ -323,6 +330,7 @@ export const ClickThroughRegistration = ({
                   selectedCampus={selectedCampus}
                   selectedSubGroupType={selectedSubGroupType}
                   selectedDate={selectedDate}
+                  selectedDay={selectedDay}
                   selectedTime={selectedTime}
                   campusSearchQuery={campusSearchQuery}
                   groupType={extractedGroupType}
@@ -336,8 +344,9 @@ export const ClickThroughRegistration = ({
                     previousStepRef.current = 2;
                     setStep(3);
                   }}
-                  onDateSelect={(date) => {
+                  onDateSelect={(date, day) => {
                     setSelectedDate(date);
+                    setSelectedDay(day);
                     previousStepRef.current = hasSubGroups ? 3 : 3;
                     setStep(4);
                   }}
@@ -388,13 +397,14 @@ interface StepContentProps {
   selectedCampus: string;
   selectedSubGroupType: string;
   selectedDate: string;
+  selectedDay: string;
   selectedTime: string;
   campusSearchQuery: string;
   groupType: string;
   hasSubGroups: boolean;
   onCampusSelect: (campus: string) => void;
   onSubGroupTypeSelect: (subGroupType: string) => void;
-  onDateSelect: (date: string) => void;
+  onDateSelect: (date: string, day: string) => void;
   onTimeSelect: (time: string) => void;
   onCampusSearchChange: (query: string) => void;
   onResetRegistration: () => void;
@@ -405,6 +415,7 @@ const StepContent = ({
   selectedCampus,
   selectedSubGroupType,
   selectedDate,
+  selectedDay,
   selectedTime,
   campusSearchQuery,
   groupType,
@@ -495,6 +506,7 @@ const StepContent = ({
         groupType={groupType}
         selectedCampus={selectedCampus}
         selectedDate={selectedDate}
+        selectedDay={selectedDay}
         selectedTime={selectedTime}
         onResetRegistration={onResetRegistration}
       />
@@ -666,7 +678,7 @@ interface DateStepProps {
   selectedCampus: string;
   selectedSubGroupType: string;
   hasSubGroups: boolean;
-  onSelect: (date: string) => void;
+  onSelect: (date: string, day: string) => void;
 }
 
 const DateStep = ({
@@ -676,7 +688,6 @@ const DateStep = ({
   hasSubGroups,
   onSelect,
 }: DateStepProps) => {
-  // Get unique dates for selected campus and subGroupType (if applicable)
   const uniqueDates = useMemo(() => {
     const dateMap = new Map<string, { dates: string[]; day: string }>();
     hits
@@ -715,14 +726,16 @@ const DateStep = ({
     <div className='flex flex-wrap justify-center gap-4'>
       {uniqueDates.map((dateInfo) => {
         const dateKey = serializeEventFinderDates(dateInfo.dates);
+        const title = dateInfo.dates.map(formatEventFinderDateLabel).join(' & ');
+
         return (
           <ClickableCard
             key={dateKey}
             variant='date'
             icon='calendarAlt'
-            title={formatEventFinderDatesDisplay(dateInfo.dates, dateInfo.day)}
-            subtitle={dateInfo.dates.length === 1 ? dateInfo.day : undefined}
-            onClick={() => onSelect(dateKey)}
+            title={title}
+            subtitle={dateInfo.day}
+            onClick={() => onSelect(dateKey, dateInfo.day)}
           />
         );
       })}
@@ -849,6 +862,7 @@ interface FormStepProps {
   groupType: string;
   selectedCampus: string;
   selectedDate: string;
+  selectedDay: string;
   selectedTime: string;
   onResetRegistration: () => void;
 }
@@ -858,6 +872,7 @@ const FormStep = ({
   groupType,
   selectedCampus,
   selectedDate,
+  selectedDay,
   selectedTime,
   onResetRegistration,
 }: FormStepProps) => {
@@ -909,6 +924,7 @@ const FormStep = ({
               campus: selectedCampus,
               date: formatEventFinderDatesDisplay(
                 parseSerializedEventFinderDates(selectedDate),
+                selectedDay,
               ),
               time: `${selectedTime} ET`,
               name:

--- a/app/routes/events/event-single/components/clickthrough-registration.component.tsx
+++ b/app/routes/events/event-single/components/clickthrough-registration.component.tsx
@@ -721,9 +721,7 @@ const DateStep = ({
             variant='date'
             icon='calendarAlt'
             title={formatEventFinderDatesDisplay(dateInfo.dates, dateInfo.day)}
-            subtitle={
-              dateInfo.dates.length === 1 ? dateInfo.day : undefined
-            }
+            subtitle={dateInfo.dates.length === 1 ? dateInfo.day : undefined}
             onClick={() => onSelect(dateKey)}
           />
         );

--- a/app/routes/events/event-single/event-finder-dates.ts
+++ b/app/routes/events/event-single/event-finder-dates.ts
@@ -1,0 +1,72 @@
+const getDaySuffix = (day: number): string => {
+  if (day > 3 && day < 21) return 'th';
+  switch (day % 10) {
+    case 1:
+      return 'st';
+    case 2:
+      return 'nd';
+    case 3:
+      return 'rd';
+    default:
+      return 'th';
+  }
+};
+
+export const formatEventFinderDate = (
+  dateString: string,
+  dayName?: string,
+): string => {
+  const [year, month, day] = dateString.split('-').map(Number);
+  const date = new Date(year, month - 1, day);
+
+  const monthName = date.toLocaleDateString('en-US', { month: 'short' });
+  const dayNum = date.getDate();
+  const suffix = getDaySuffix(dayNum);
+  const weekday =
+    dayName || date.toLocaleDateString('en-US', { weekday: 'short' });
+
+  return `${weekday} ${monthName} ${dayNum}${suffix}`;
+};
+
+export const normalizeEventFinderDates = (
+  date: string | string[] | undefined | null,
+): string[] => {
+  if (!date) return [];
+  const dates = Array.isArray(date) ? date : [date];
+  return dates.map((value) => value.trim()).filter(Boolean).sort();
+};
+
+export const serializeEventFinderDates = (dates: string[]): string => {
+  return normalizeEventFinderDates(dates).join('|');
+};
+
+export const parseSerializedEventFinderDates = (
+  serializedDates: string,
+): string[] => {
+  if (!serializedDates.trim()) return [];
+  return normalizeEventFinderDates(serializedDates.split('|'));
+};
+
+export const formatEventFinderDatesDisplay = (
+  dates: string[],
+  dayName?: string,
+): string => {
+  const normalizedDates = normalizeEventFinderDates(dates);
+  if (normalizedDates.length === 0) return '';
+  if (normalizedDates.length === 1) {
+    return formatEventFinderDate(normalizedDates[0], dayName);
+  }
+  return normalizedDates
+    .map((date) => formatEventFinderDate(date))
+    .join(' & ');
+};
+
+export const eventFinderDatesMatch = (
+  hitDates: string | string[] | undefined | null,
+  selectedSerializedDates: string,
+): boolean => {
+  return (
+    serializeEventFinderDates(normalizeEventFinderDates(hitDates)) ===
+    selectedSerializedDates.trim()
+  );
+};

--- a/app/routes/events/event-single/event-finder-dates.ts
+++ b/app/routes/events/event-single/event-finder-dates.ts
@@ -12,22 +12,6 @@ const getDaySuffix = (day: number): string => {
   }
 };
 
-export const formatEventFinderDate = (
-  dateString: string,
-  dayName?: string,
-): string => {
-  const [year, month, day] = dateString.split('-').map(Number);
-  const date = new Date(year, month - 1, day);
-
-  const monthName = date.toLocaleDateString('en-US', { month: 'short' });
-  const dayNum = date.getDate();
-  const suffix = getDaySuffix(dayNum);
-  const weekday =
-    dayName || date.toLocaleDateString('en-US', { weekday: 'short' });
-
-  return `${weekday} ${monthName} ${dayNum}${suffix}`;
-};
-
 export const normalizeEventFinderDates = (
   date: string | string[] | undefined | null,
 ): string[] => {
@@ -50,18 +34,6 @@ export const parseSerializedEventFinderDates = (
   return normalizeEventFinderDates(serializedDates.split('|'));
 };
 
-export const formatEventFinderDatesDisplay = (
-  dates: string[],
-  dayName?: string,
-): string => {
-  const normalizedDates = normalizeEventFinderDates(dates);
-  if (normalizedDates.length === 0) return '';
-  if (normalizedDates.length === 1) {
-    return formatEventFinderDate(normalizedDates[0], dayName);
-  }
-  return normalizedDates.map((date) => formatEventFinderDate(date)).join(' & ');
-};
-
 export const eventFinderDatesMatch = (
   hitDates: string | string[] | undefined | null,
   selectedSerializedDates: string,
@@ -70,4 +42,26 @@ export const eventFinderDatesMatch = (
     serializeEventFinderDates(normalizeEventFinderDates(hitDates)) ===
     selectedSerializedDates.trim()
   );
+};
+
+export const formatEventFinderDateLabel = (dateString: string): string => {
+  const [year, month, day] = dateString.split('-').map(Number);
+  const date = new Date(year, month - 1, day);
+
+  const monthName = date.toLocaleDateString('en-US', { month: 'short' });
+  const dayNum = date.getDate();
+  const suffix = getDaySuffix(dayNum);
+
+  return `${monthName} ${dayNum}${suffix}`;
+};
+
+export const formatEventFinderDatesDisplay = (
+  dates: string[],
+  day?: string,
+): string => {
+  const normalizedDates = normalizeEventFinderDates(dates);
+  if (normalizedDates.length === 0) return '';
+
+  const dateLabels = normalizedDates.map(formatEventFinderDateLabel).join(' & ');
+  return day ? `${day} ${dateLabels}` : dateLabels;
 };

--- a/app/routes/events/event-single/event-finder-dates.ts
+++ b/app/routes/events/event-single/event-finder-dates.ts
@@ -33,7 +33,10 @@ export const normalizeEventFinderDates = (
 ): string[] => {
   if (!date) return [];
   const dates = Array.isArray(date) ? date : [date];
-  return dates.map((value) => value.trim()).filter(Boolean).sort();
+  return dates
+    .map((value) => value.trim())
+    .filter(Boolean)
+    .sort();
 };
 
 export const serializeEventFinderDates = (dates: string[]): string => {
@@ -56,9 +59,7 @@ export const formatEventFinderDatesDisplay = (
   if (normalizedDates.length === 1) {
     return formatEventFinderDate(normalizedDates[0], dayName);
   }
-  return normalizedDates
-    .map((date) => formatEventFinderDate(date))
-    .join(' & ');
+  return normalizedDates.map((date) => formatEventFinderDate(date)).join(' & ');
 };
 
 export const eventFinderDatesMatch = (

--- a/app/routes/events/event-single/types.ts
+++ b/app/routes/events/event-single/types.ts
@@ -62,6 +62,6 @@ export interface EventFinderHit {
   location: string;
   day: string;
   time: string;
-  date: string;
+  date: string[];
   subGroupType: string;
 }


### PR DESCRIPTION
## Summary

The event finder's registration flow previously assumed each event hit had a single `date` (string). Some events span multiple dates, but the UI could only filter, display, and match on one. This PR adds first-class support for multi-date events end to end: the Algolia filter, the date-selection step, the selected-bar/journey-details display, and hit-matching logic now all handle one-or-many dates.

Date formatting/serialization logic was extracted out of the component into a dedicated, reusable utility module so it can be shared across the registration steps.

## Screenshots

N/A

## Testing

- [ ] Open an event with a single date — verify the date card, selected bar, and journey details render exactly as before (e.g. `Sun Jun 28th`).
- [ ] Open an event with multiple dates — verify the date card shows the combined display (e.g. `Jun 28th & Jul 5th`), the day subtitle is hidden for multi-date cards, and selecting it correctly filters subsequent time/form steps.
- [ ] Confirm the Algolia filter includes an `AND date:"…"` clause for each selected date and returns the expected results.
- [ ] Confirm no new linter errors/warnings.

## Tickets
[CFDP-4019](https://christfellowshipchurch.atlassian.net/browse/CFDP-4019)

## Changes Made

### New Utilities

- `app/routes/events/event-single/event-finder-dates.ts` — new module with helpers for normalizing, serializing, parsing, matching, and formatting event finder dates:
  - `normalizeEventFinderDates` — coerces a string / string[] / null into a trimmed, sorted, de-blanked array.
  - `serializeEventFinderDates` / `parseSerializedEventFinderDates` — round-trip a date array through a `|`-delimited string (used as a selection key).
  - `formatEventFinderDate` / `formatEventFinderDatesDisplay` — human-readable formatting (`Sun Jun 28th`), joining multiple dates with `&`.
  - `eventFinderDatesMatch` — compares a hit's date(s) against the selected serialized value.
  - `formatDateDisplay` / `getDaySuffix` were moved here out of the component (no behavior change for the single-date path).

### Route Implementation

- `app/routes/events/event-single/components/clickthrough-registration.component.tsx` — updated the filter builder, `DateStep`, `TimeStep`, `StepContent`, and `FormStep` to use the new utilities and operate on multiple dates; removed the inline `formatDateDisplay`/`getDaySuffix` helpers.
- `app/routes/events/event-single/types.ts` — `EventFinderHit.date` changed from `string` to `string[]`.

### Key Features

- Multi-date events are now selectable as a single combined option and correctly drive downstream filtering and display.
- Single-date events behave exactly as before.

[CFDP-4019]: https://christfellowshipchurch.atlassian.net/browse/CFDP-4019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ