### PR TITLE
fix(author): fix share link copy URL on author pages

### DIFF
--- a/.cursor/commands/create-pr.md
+++ b/.cursor/commands/create-pr.md
@@ -1,1 +1,1 @@
-Please write out a PR based on @Branch (Diff with Main Branch) using @PULL_REQUEST_TEMPLATE.md format. Return in raw markdown
+Please write out a PR based on @Branch (Diff with Main Branch) using @PULL_REQUEST_TEMPLATE.md format. Return in raw markdown. Also note in the template we use `pnpm check` which combines our linter/type/prettier formatting checks. If you see an error please fix it. Eg. if prettier format error, just run `pnpm format` that will update the files.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,9 +8,8 @@ Provide a summary of the changes. Why are these changes necessary?
 
 ## Testing
 
-- [ ] How were these changes tested?
-- [ ] What steps can someone follow to verify functionality?
-- [ ] Was any new linter errors/warnings?
+- [ ] What steps can someone follow to verify functionality? (Write out checklist of steps to test)
+- [ ] Was any new linter/type/test errors/warnings(run `pnpm check` for linter/type/prettier check and `pnpm test` for running tests)?
 
 ## Tickets
 

--- a/app/routes/author/author-page.tsx
+++ b/app/routes/author/author-page.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import { Author } from './types';
+import { AuthorLoaderData } from './types';
 import { useLoaderData } from 'react-router-dom';
 import BackButton from './components/back-button';
 import AuthorTabs from './components/author-tabs';
 import { AuthorBio } from './partials/author-bio';
 
 export const AuthorPage: React.FC = () => {
-  const data = useLoaderData<Author>();
+  const data = useLoaderData<AuthorLoaderData>();
 
   return (
     <div className='relative'>

--- a/app/routes/author/loader.ts
+++ b/app/routes/author/loader.ts
@@ -1,7 +1,7 @@
 import { LoaderFunction } from 'react-router-dom';
 import { createImageUrlFromGuid } from '~/lib/utils';
 import { format } from 'date-fns';
-import { Author } from './types';
+import { AuthorLoaderData } from './types';
 import {
   fetchAuthorData,
   fetchPersonAliasGuid,
@@ -276,7 +276,7 @@ export const getAuthorDetails = async (personId: string) => {
   }
 };
 
-export const loader: LoaderFunction = async ({ params }) => {
+export const loader: LoaderFunction = async ({ request, params }) => {
   const authorPathname = params?.authorId || '';
 
   // Use the new pathname-based approach
@@ -290,12 +290,15 @@ export const loader: LoaderFunction = async ({ params }) => {
     });
   }
 
-  const authorData: Author = {
+  const origin = new URL(request.url).origin;
+
+  const authorData: AuthorLoaderData = {
     id: data.id,
     fullName: data.fullName,
     profilePhoto: data.photo.uri ?? '',
     authorAttributes: data.authorAttributes,
+    hostUrl: origin,
   };
 
-  return <Author>authorData;
+  return authorData;
 };

--- a/app/routes/author/partials/author-bio.tsx
+++ b/app/routes/author/partials/author-bio.tsx
@@ -6,34 +6,17 @@ import { AuthorBioProps } from '../types';
 
 export function AuthorBio({
   author,
-  homeUrl,
   variant = 'default',
   hideSocialLinks = false,
 }: AuthorBioProps) {
-  const { id, fullName, profilePhoto, authorAttributes } = author;
-  const { bio, jobTitle, socialLinks, pathname } = authorAttributes;
+  const { fullName, profilePhoto, authorAttributes } = author;
+  const { bio, jobTitle, socialLinks } = authorAttributes;
 
   // Determine styling based on variant
   const isLeadersVariant = variant === 'leaders';
   const avatarRounded = isLeadersVariant ? 'rounded-[32px]' : 'rounded-full';
   const shareLinksSize = isLeadersVariant ? 10 : 8;
   const circleLoaderSize = isLeadersVariant ? 32 : 20;
-
-  // ShareLinks props based on variant
-  const authorUrl = pathname || id;
-  const shareLinksProps =
-    isLeadersVariant && authorUrl && homeUrl
-      ? {
-          overrideCopyUrl: `${homeUrl}/author/${authorUrl}`,
-          size: shareLinksSize,
-          socialMedia: socialLinks,
-        }
-      : {
-          url:
-            authorUrl && homeUrl ? `${homeUrl}/author/${authorUrl}` : undefined,
-          size: shareLinksSize,
-          socialMedia: socialLinks,
-        };
 
   return (
     <div className='flex flex-col gap-5 md:gap-8 font-light text-neutral-700 w-full'>
@@ -56,7 +39,13 @@ export function AuthorBio({
         {bio && <HTMLRenderer html={bio} />}
         {!hideSocialLinks && (
           <div className='flex gap-2'>
-            {socialLinks && <ShareLinks {...shareLinksProps} />}
+            {socialLinks && (
+              <ShareLinks
+                size={shareLinksSize}
+                socialMedia={socialLinks}
+                title={fullName}
+              />
+            )}
           </div>
         )}
       </div>
@@ -81,7 +70,13 @@ export function AuthorBio({
         </div>
         {!hideSocialLinks && (
           <div className='flex gap-2'>
-            {socialLinks && <ShareLinks {...shareLinksProps} />}
+            {socialLinks && (
+              <ShareLinks
+                size={shareLinksSize}
+                socialMedia={socialLinks}
+                title={fullName}
+              />
+            )}
           </div>
         )}
         {bio && <HTMLRenderer html={bio} />}

--- a/app/routes/author/types.ts
+++ b/app/routes/author/types.ts
@@ -20,9 +20,12 @@ export type Author = {
   };
 };
 
+export type AuthorLoaderData = Author & {
+  hostUrl: string;
+};
+
 export type AuthorBioProps = {
   author: Author;
-  homeUrl?: string;
   variant?: 'default' | 'leaders';
   hideSocialLinks?: boolean;
 };


### PR DESCRIPTION
## Summary

Fix broken share/copy links on author pages by aligning with the existing `ShareLinks` pattern used on articles and messages. The author loader now provides `hostUrl`, and `AuthorBio` no longer manually builds URLs via the unused `homeUrl` prop (which produced `undefined/author/...` copy links). Also fixes a loader bug where `return <Author>authorData` was invalid syntax.

## Screenshots

<img width="1394" height="823" alt="image" src="https://github.com/user-attachments/assets/c05cb7cf-1d16-48a4-ad16-5e8be8703bb6" />

## Testing

  - [x] Navigate to any author page (e.g. `/author/{pathname}`).
  - [x] Click the link/copy icon in the social links row.
  - [x] Confirm the clipboard contains the full canonical URL (e.g. `https://christfellowship.church/author/{pathname}`), not `undefined/author/...`.
  - [x] Confirm author social icons (Twitter, Facebook, etc.) still link to the author's personal profiles from Rock.
  - [x] Spot-check an article page share links — unchanged, should still work.
  - [x] `pnpm test`
  - [x] `pnpm check` 

## Tickets

[CFDP-4072](https://christfellowship.atlassian.net/browse/CFDP-4072)

## Changes Made

### New Components Added

- None

### New Utilities

- None

### New Assets

- None

### Dependencies

- None

### Route Implementation

- **`app/routes/author/loader.ts`** — Adds `hostUrl` from `new URL(request.url).origin`; fixes invalid `return <Author>authorData` to `return authorData`.
- **`app/routes/author/types.ts`** — Adds `AuthorLoaderData` type (`Author & { hostUrl: string }`); removes unused `homeUrl` from `AuthorBioProps`.
- **`app/routes/author/author-page.tsx`** — Uses `AuthorLoaderData` for `useLoaderData`.
- **`app/routes/author/partials/author-bio.tsx`** — Removes manual URL construction and `homeUrl` prop; delegates to `ShareLinks` with `size`, `socialMedia`, and `title={fullName}`.

### Key Features

- Author page copy-link now shares the current page URL via `ShareLinks` (`hostUrl` + `useLocation().pathname`), matching article and message pages.
- Removes dead code: `homeUrl` was never passed, and the `leaders` variant URL override path was unused.
- `ShareLinks` consumers outside author routes are unaffected (only `article-single/hero.partial.tsx` and `author-bio.tsx` use it).

[CFDP-4072]: https://christfellowshipchurch.atlassian.net/browse/CFDP-4072?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ