### PR TITLE
Last Minute Changes

### DIFF
--- a/app/routes/about/components/history-tabs/history-tabs.component.tsx
+++ b/app/routes/about/components/history-tabs/history-tabs.component.tsx
@@ -16,7 +16,7 @@ const timelineData: TimelineItem[] = [
     image:
       'https://cloudfront.christfellowship.church/GetImage.ashx?id=3190355',
     imagePosition: 'object-[center_25%]',
-    body: 'Today, Christ Fellowship gathers across 14 locations in South Florida, online through Christ Fellowship Everywhere, and inside # local prison locations. For over 40 years, we’ve helped thousands of people just like you to find people to do life with, break free from the pain of their past, thrive in their marriage, become a better parent, experience financial freedom, and learn how to make a difference.',
+    body: 'Today, Christ Fellowship gathers across 14 locations in South Florida, online through Christ Fellowship Everywhere, and inside local prison locations. For over 40 years, we’ve helped thousands of people just like you to find people to do life with, break free from the pain of their past, thrive in their marriage, become a better parent, experience financial freedom, and learn how to make a difference.',
   },
   {
     year: '2023',

--- a/app/routes/about/components/history-tabs/history-tabs.component.tsx
+++ b/app/routes/about/components/history-tabs/history-tabs.component.tsx
@@ -68,7 +68,7 @@ function HistoryTabs() {
     <div className='pt-6 md:pt-12 pb-12 lg:py-24 w-full relative'>
       <div className='grid grid-cols-1 md:grid-cols-2 gap-2 xl:gap-8 items-center'>
         {/* Image */}
-        <div className='relative mx-auto md:mx-0 h-full min-h-[300px] max-w-full md:max-h-[500px] md:max-w-none lg:min-h-[500px] overflow-hidden z-20 content-padding md:px-0'>
+        <div className='relative mx-auto md:mx-0 h-full min-h-[300px] max-w-full md:max-h-[500px] md:max-w-none lg:min-h-[500px]  z-20 content-padding md:px-0'>
           <img
             src={timelineData[activeTab].image}
             alt={`Christ Fellowship Church History - ${timelineData[activeTab].year}`}
@@ -94,13 +94,13 @@ function HistoryTabs() {
             handleTabChange={handleTabChange}
           />
           <div
-            className={`transition-all duration-300 mt-6 lg:mt-0space-y-4 ${
+            className={`transition-all duration-300 md:mt-6 lg:mt-0space-y-4 ${
               transitioning
                 ? 'opacity-0 translate-y-4'
                 : 'opacity-100 translate-y-0'
             }`}
           >
-            <p className='md:text-lg text-text-secondary w-full sm:w-3/4 md:w-full mt-4'>
+            <p className='md:text-lg text-text-secondary w-full sm:w-3/4 md:w-full md:mt-4'>
               {timelineData[activeTab].body}
             </p>
           </div>

--- a/app/routes/about/components/history-tabs/history-tabs.component.tsx
+++ b/app/routes/about/components/history-tabs/history-tabs.component.tsx
@@ -74,7 +74,7 @@ function HistoryTabs() {
             alt={`Christ Fellowship Church History - ${timelineData[activeTab].year}`}
             className={`w-full h-full object-cover ${
               timelineData[activeTab].imagePosition ?? ''
-            } shadow-xl transition-all duration-300 rounded-2xl md:rounded-none 2xl:rounded-2xl! ${
+            } shadow-xl transition-all duration-300 rounded-2xl md:rounded-l-none 2xl:rounded-l-2xl! ${
               transitioning ? 'opacity-0 scale-95' : 'opacity-100 scale-100'
             }`}
           />

--- a/app/routes/about/components/history-tabs/mobile-timeline-navigation.component.tsx
+++ b/app/routes/about/components/history-tabs/mobile-timeline-navigation.component.tsx
@@ -1,5 +1,3 @@
-import { useEffect, useRef } from 'react';
-
 function MobileTimelineNavigation({
   timelineData,
   activeTab,
@@ -11,38 +9,14 @@ function MobileTimelineNavigation({
   activeTab: number;
   handleTabChange: (index: number) => void;
 }) {
-  const scrollContainerRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (scrollContainerRef.current) {
-      const container = scrollContainerRef.current;
-      const activeButton = container.children[activeTab] as HTMLElement;
-
-      if (activeButton) {
-        const containerWidth = container.offsetWidth;
-        const buttonLeft = activeButton.offsetLeft;
-        const buttonWidth = activeButton.offsetWidth;
-        const scrollLeft = buttonLeft - containerWidth / 2 + buttonWidth / 2;
-
-        container.scrollTo({
-          left: scrollLeft,
-          behavior: 'smooth',
-        });
-      }
-    }
-  }, [activeTab]);
-
   return (
     <div className='my-6 md:hidden'>
-      <div
-        ref={scrollContainerRef}
-        className='flex items-center justify-center gap-[6px] sm:gap-[10px] flex-wrap'
-      >
+      <div className='flex items-stretch gap-1 sm:gap-[6px]'>
         {timelineData.map((item, index) => (
           <button
             key={item.year}
             onClick={() => handleTabChange(index)}
-            className={`px-3 py-2 sm:px-4 sm:py-3 rounded-full font-bold text-sm transition-all duration-300 flex-shrink-0 snap-center whitespace-nowrap flex-grow ${
+            className={`min-w-0 flex-1 px-1 py-2 sm:px-2 sm:py-3 rounded-full font-bold text-xs sm:text-sm text-center transition-all duration-300 whitespace-nowrap ${
               activeTab === index
                 ? 'bg-ocean text-white'
                 : 'border-2 border-neutral-lightest text-text-secondary hover:bg-gray-100'


### PR DESCRIPTION
## Summary

Our History tabs - Remove auto-scroll-to-center behavior from mobile timeline navigation and refactor layout to use equal-width buttons. Update history image border-radius to apply only to left corners on md and 2xl breakpoints. Changes include: removing useEffect/useRef hooks, simplifying flex layout to uniformly distribute buttons, and adjusting Tailwind classes for more consistent styling.


## Screenshots

[Paste your screenshots here]

## Testing

- [ ] Ensure entire `Our History` tabs section in `Home` page (both mobile and desktop) looks and functions as expected.

## Tickets

N/A

## Changes Made

### New Components Added

- List any new React components created
- Include file paths and brief descriptions

### New Utilities

- List any new utility functions or helper components
- Include file paths and descriptions

### New Assets

- List any new images, animations, or other static assets
- Include file paths and descriptions

### Dependencies

- List any new dependencies added to package.json
- Include version numbers

### Route Implementation

- List any new routes or route modifications
- Include file paths and descriptions

### Key Features

- Highlight the main features implemented
- Focus on user-facing functionality
- Include any performance optimizations or accessibility improvements
