### PR TITLE
Fix site banner

### DIFF
--- a/app/lib/rock-config.ts
+++ b/app/lib/rock-config.ts
@@ -11,6 +11,7 @@ export const ContentChannelIds = {
   events: 78,
   locations: 88,
   messages: 63,
+  siteBanner: 100,
   studies: [79, 80],
   soGoodSisterhood: 95,
   keepTalking: 96,

--- a/app/routes/navbar/__tests__/site-banner.test.ts
+++ b/app/routes/navbar/__tests__/site-banner.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { mapSiteBannerFromRockItem } from '../loader';
+
+describe('mapSiteBannerFromRockItem', () => {
+  it('maps banner content and the first CTA link from Rock key-value format', () => {
+    const result = mapSiteBannerFromRockItem({
+      id: '1',
+      contentChannelId: '100',
+      title: 'Crisis Fund',
+      name: 'Crisis Fund',
+      content: '<p>Venezuela Earthquake Relief</p>',
+      attributeValues: {
+        callsToAction: {
+          value: 'GIVE NOW^https://pushpay.com/g/christfellowship',
+          valueFormatted: '',
+        },
+      },
+      attributes: {},
+      startDateTime: '2026-06-30T00:59:00',
+      expireDateTime: '',
+    });
+
+    expect(result).toEqual({
+      content: '<p>Venezuela Earthquake Relief</p>',
+      link: 'https://pushpay.com/g/christfellowship',
+    });
+  });
+
+  it('returns empty banner data when Rock returns no active item', () => {
+    expect(mapSiteBannerFromRockItem(null)).toEqual({
+      content: '',
+      link: '',
+    });
+  });
+});

--- a/app/routes/navbar/loader.tsx
+++ b/app/routes/navbar/loader.tsx
@@ -4,11 +4,13 @@ import type { LoaderFunctionArgs } from 'react-router-dom';
 import { fetchRockData } from '~/lib/.server/fetch-rock-data';
 // import { fetchTopSearches } from "~/lib/.server/fetch-top-searches";
 import type { FeatureCard } from '~/components/navbar/types';
-import { createImageUrlFromGuid } from '~/lib/utils';
+import { createImageUrlFromGuid, parseRockKeyValueList } from '~/lib/utils';
 import { getUserFromRequest } from '~/lib/.server/authentication/get-user-from-request';
 import type { User } from '~/providers/auth-provider';
 import { getServerAlgoliaIndexes } from '~/lib/.server/algolia-indexes.server';
 import type { AlgoliaIndexMap } from '~/lib/algolia-indexes';
+import { ContentChannelIds } from '~/lib/rock-config';
+import type { RockContentChannelItem } from '~/lib/types/rock-types';
 
 // Define the return type for the loader
 export interface RootLoaderData {
@@ -35,6 +37,23 @@ export interface RootLoaderData {
     }[];
   };
 }
+
+const EMPTY_SITE_BANNER = { content: '', link: '' };
+
+export const mapSiteBannerFromRockItem = (
+  rawSiteBanner: RockContentChannelItem | null | undefined,
+) => {
+  const siteBannerContent =
+    typeof rawSiteBanner?.content === 'string' ? rawSiteBanner.content : '';
+  const callsToActions = parseRockKeyValueList(
+    rawSiteBanner?.attributeValues?.callsToAction?.value ?? '',
+  );
+
+  return {
+    content: siteBannerContent,
+    link: callsToActions[0]?.value ?? '',
+  };
+};
 
 const fetchFeatureCards = async () => {
   try {
@@ -77,28 +96,28 @@ const fetchFeatureCards = async () => {
   }
 };
 
-const fetchSiteBanner = async () => {
-  const now = new Date();
-  // Format date to ISO 8601 to remove milliseconds and timezone
-  const formattedDate = now.toISOString().split('.')[0] + 'Z';
-
+const fetchSiteBanner = async (): Promise<RockContentChannelItem | null> => {
   try {
     const siteBanner = await fetchRockData({
       endpoint: 'ContentChannelItems',
       queryParams: {
-        $filter: `ContentChannelId eq 100 and Status eq '2' and ExpireDateTime gt datetime'${formattedDate}'`,
+        $filter: `ContentChannelId eq ${ContentChannelIds.siteBanner}`,
+        $orderby: 'StartDateTime desc',
+        $top: '1',
         loadAttributes: 'simple',
       },
+      filterByDateRange: true,
+      filterByStatusApproved: true,
     });
 
-    if (Array.isArray(siteBanner) && siteBanner.length > 0) {
-      return siteBanner[0];
-    } else {
-      return siteBanner;
+    if (Array.isArray(siteBanner)) {
+      return siteBanner[0] ?? null;
     }
+
+    return siteBanner ?? null;
   } catch (error) {
     console.error('Error fetching site banner:', error);
-    return [];
+    return null;
   }
 };
 
@@ -144,7 +163,11 @@ export async function loader({
       parsedUserData = userData as User;
     }
 
-    const rawFeatureCards = await fetchFeatureCards();
+    const [rawFeatureCards, rawSiteBanner] = await Promise.all([
+      fetchFeatureCards(),
+      fetchSiteBanner(),
+    ]);
+    const siteBanner = mapSiteBannerFromRockItem(rawSiteBanner);
 
     // If the API call failed, return empty arrays
     if (
@@ -169,11 +192,7 @@ export async function loader({
           indexes: algoliaIndexes,
         },
         popularResults: [],
-        // Site Banner Data
-        siteBanner: {
-          content: '',
-          link: '',
-        },
+        siteBanner,
       };
     }
 
@@ -208,22 +227,6 @@ export async function loader({
     const mediaCards = mappedFeatureCards.filter(
       (card) => card.navMenu.toLowerCase() === 'media',
     );
-
-    // Site Banner Data
-    const rawSiteBanner = await fetchSiteBanner();
-    const siteBannerContent =
-      typeof rawSiteBanner?.content === 'string' ? rawSiteBanner.content : '';
-    const callsToActionValue =
-      rawSiteBanner?.attributeValues?.callsToAction?.value;
-    const siteBannerLink =
-      typeof callsToActionValue === 'string' && callsToActionValue.includes('^')
-        ? (callsToActionValue.split('^').pop()?.trim() ?? '')
-        : '';
-
-    const siteBanner = {
-      content: siteBannerContent,
-      link: typeof siteBannerLink === 'string' ? siteBannerLink : '',
-    };
 
     // TODO: uncomment this once we have the real data for the popular searches
     // const popularSearches = await fetchTopSearches(
@@ -265,11 +268,7 @@ export async function loader({
         indexes: algoliaIndexes,
       },
       popularResults: [],
-      // Site Banner Data
-      siteBanner: {
-        content: '',
-        link: '',
-      },
+      siteBanner: EMPTY_SITE_BANNER,
     };
   }
 }


### PR DESCRIPTION
## Summary

The global site banner (Rock Content Channel 100) was not appearing because the root loader query used an invalid OData filter (`Status eq '2'`), which returns zero results from Rock. This PR fixes the fetch logic, centralizes the channel ID in `rock-config.ts`, and ensures the banner loads even when navbar feature cards fail.

## Screenshots

N/A — verify the blue site banner appears at the top of the site when an approved, in-date banner exists in Rock (e.g. "Crisis Fund / Venezuela Earthquake Relief").

## Testing

- [x] Load any page and confirm the site banner renders when Rock has an active approved item in channel 100
- [x] Confirm the banner CTA link resolves to the first `CallsToAction` URL (not the label)
- [x] Confirm expired banners do not appear
- [x] `pnpm check` passes (lint, typecheck, prettier)
- [x] `pnpm test` passes, including `app/routes/navbar/__tests__/site-banner.test.ts`

## Tickets

N/A

## Changes Made

### New Components Added

- None

### New Utilities

- `mapSiteBannerFromRockItem` in `app/routes/navbar/loader.tsx` — maps a Rock content item to `{ content, link }` using `parseRockKeyValueList` for CTA parsing

### New Assets

- None

### Dependencies

- None

### Route Implementation

- `app/routes/navbar/loader.tsx` — fixed site banner Rock query, parallel fetch with feature cards, and resilient early-return path
- `app/lib/rock-config.ts` — added `ContentChannelIds.siteBanner: 100`

### Key Features

- Site banner now uses `Status eq 'Approved'` and shared `filterByDateRange` / `filterByStatusApproved` helpers (replacing broken `Status eq '2'` filter)
- Fetches the most recent active banner (`$orderby: StartDateTime desc`, `$top: 1`)
- Banner fetch runs in parallel with navbar feature cards and is no longer skipped when feature cards fail
- CTA links parsed correctly via `parseRockKeyValueList` instead of fragile string splitting

Made with [Cursor](https://cursor.com)