### PR TITLE
Removing date from Article cards in collections | Articles Newsletter

### DIFF
--- a/app/components/modals/group-finder-notify/__tests__/group-finder-notify-form.test.tsx
+++ b/app/components/modals/group-finder-notify/__tests__/group-finder-notify-form.test.tsx
@@ -83,6 +83,26 @@ describe('GroupFinderNotifyForm', () => {
     ).toBeInTheDocument();
   });
 
+  it('renders the terms and email consent checkbox', () => {
+    renderForm();
+
+    expect(
+      screen.getByRole('checkbox', {
+        name: /by submitting, you agree to our terms of use and privacy policy/i,
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Terms of Use' })).toHaveAttribute(
+      'href',
+      'https://www.christfellowship.church/terms-of-use',
+    );
+    expect(
+      screen.getByRole('link', { name: 'Privacy Policy' }),
+    ).toHaveAttribute(
+      'href',
+      'https://www.christfellowship.church/privacy-policy',
+    );
+  });
+
   it('submits to the notify resource route', async () => {
     const user = userEvent.setup();
     mockFetcherState = {
@@ -105,6 +125,11 @@ describe('GroupFinderNotifyForm', () => {
     await user.type(screen.getByLabelText('Email Address'), 'test@example.com');
     await user.type(screen.getByLabelText('Phone'), '5555555555');
     await user.selectOptions(screen.getByLabelText('Campus'), 'campus-guid-10');
+    await user.click(
+      screen.getByRole('checkbox', {
+        name: /by submitting, you agree to our terms of use and privacy policy/i,
+      }),
+    );
     await user.click(screen.getByRole('button', { name: 'Submit' }));
 
     await waitFor(() => {

--- a/app/components/modals/group-finder-notify/group-finder-notify-form.component.tsx
+++ b/app/components/modals/group-finder-notify/group-finder-notify-form.component.tsx
@@ -5,6 +5,7 @@ import { pushFormEvent } from '~/lib/gtm';
 import { cn } from '~/lib/utils';
 import { Button } from '~/primitives/button/button.primitive';
 import {
+  radixCheckboxClassName,
   radixFormFieldStackClassName,
   radixFormLabelClassName,
   radixSelectClassName,
@@ -140,6 +141,46 @@ const GroupFinderNotifyForm: React.FC<GroupFinderNotifyFormProps> = ({
           </Form.Control>
           <RadixFormErrorMessage match='valueMissing'>
             Please select a campus
+          </RadixFormErrorMessage>
+        </Form.Field>
+
+        <Form.Field
+          name='smsConsent'
+          className={cn('mt-2 md:col-span-2', radixFormFieldStackClassName)}
+        >
+          <div className='flex gap-2 items-start'>
+            <Form.Control asChild>
+              <input
+                type='checkbox'
+                required
+                className={radixCheckboxClassName}
+              />
+            </Form.Control>
+            <Form.Label className='text-sm text-text-secondary leading-5'>
+              By submitting, you agree to our{' '}
+              <a
+                href='https://www.christfellowship.church/terms-of-use'
+                target='_blank'
+                rel='noopener noreferrer'
+                className='underline'
+              >
+                Terms of Use
+              </a>{' '}
+              and{' '}
+              <a
+                href='https://www.christfellowship.church/privacy-policy'
+                target='_blank'
+                rel='noopener noreferrer'
+                className='underline'
+              >
+                Privacy Policy
+              </a>
+              , and consent to receive email communications from Christ
+              Fellowship Church.
+            </Form.Label>
+          </div>
+          <RadixFormErrorMessage match='valueMissing'>
+            You must agree to continue
           </RadixFormErrorMessage>
         </Form.Field>
 

--- a/app/components/modals/newsletter-subscription/__tests__/newsletter-subscription-form.test.tsx
+++ b/app/components/modals/newsletter-subscription/__tests__/newsletter-subscription-form.test.tsx
@@ -102,6 +102,26 @@ describe('NewsletterSubscriptionForm', () => {
     expect(mockLoad).toHaveBeenCalledWith('/newsletter-subscription');
   });
 
+  it('renders the terms and sms consent checkbox', () => {
+    renderForm();
+
+    expect(
+      screen.getByRole('checkbox', {
+        name: /by submitting, you agree to our terms of use and privacy policy/i,
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Terms of Use' })).toHaveAttribute(
+      'href',
+      'https://www.christfellowship.church/terms-of-use',
+    );
+    expect(
+      screen.getByRole('link', { name: 'Privacy Policy' }),
+    ).toHaveAttribute(
+      'href',
+      'https://www.christfellowship.church/privacy-policy',
+    );
+  });
+
   it('prefills the email field when initialEmail is provided', () => {
     renderForm(vi.fn(), 'reader@example.com');
 

--- a/app/components/modals/newsletter-subscription/__tests__/newsletter-subscription-form.test.tsx
+++ b/app/components/modals/newsletter-subscription/__tests__/newsletter-subscription-form.test.tsx
@@ -29,10 +29,13 @@ vi.mock('react-router-dom', async () => {
   };
 });
 
-function renderForm(onSuccess = vi.fn()) {
+function renderForm(onSuccess = vi.fn(), initialEmail?: string) {
   return render(
     <MemoryRouter>
-      <NewsletterSubscriptionForm onSuccess={onSuccess} />
+      <NewsletterSubscriptionForm
+        onSuccess={onSuccess}
+        initialEmail={initialEmail}
+      />
     </MemoryRouter>,
   );
 }
@@ -97,6 +100,14 @@ describe('NewsletterSubscriptionForm', () => {
     renderForm();
 
     expect(mockLoad).toHaveBeenCalledWith('/newsletter-subscription');
+  });
+
+  it('prefills the email field when initialEmail is provided', () => {
+    renderForm(vi.fn(), 'reader@example.com');
+
+    expect(screen.getByLabelText('Email Address')).toHaveValue(
+      'reader@example.com',
+    );
   });
 
   it('fires the GTM event before calling onSuccess after a successful submission', () => {

--- a/app/components/modals/newsletter-subscription/newsletter-subscription-flow.component.tsx
+++ b/app/components/modals/newsletter-subscription/newsletter-subscription-flow.component.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import NewsletterSubscriptionConfirmation from './confirmation.component';
 import NewsletterSubscriptionForm from './newsletter-subscription-form.component';
 
@@ -9,19 +9,31 @@ enum NewsletterSubscriptionStep {
 
 const NewsletterSubscriptionFlow = ({
   setOpenModal,
+  initialEmail,
+  isOpen,
 }: {
   setOpenModal: (open: boolean) => void;
+  initialEmail?: string;
+  isOpen: boolean;
 }) => {
   const [step, setStep] = useState<NewsletterSubscriptionStep>(
     NewsletterSubscriptionStep.FORM,
   );
+
+  useEffect(() => {
+    if (!isOpen) {
+      setStep(NewsletterSubscriptionStep.FORM);
+    }
+  }, [isOpen]);
 
   const renderStep = () => {
     switch (step) {
       case NewsletterSubscriptionStep.FORM:
         return (
           <NewsletterSubscriptionForm
+            key={initialEmail ?? 'no-email'}
             onSuccess={() => setStep(NewsletterSubscriptionStep.CONFIRMATION)}
+            initialEmail={initialEmail}
           />
         );
       case NewsletterSubscriptionStep.CONFIRMATION:

--- a/app/components/modals/newsletter-subscription/newsletter-subscription-form.component.tsx
+++ b/app/components/modals/newsletter-subscription/newsletter-subscription-form.component.tsx
@@ -15,12 +15,14 @@ import { NewsletterSubscriptionLoaderReturnType } from '~/routes/newsletter-subs
 
 interface NewsletterSubscriptionFormProps {
   onSuccess: () => void;
+  initialEmail?: string;
 }
 
 export const renderInputField = renderRadixInputField;
 
 const NewsletterSubscriptionForm: React.FC<NewsletterSubscriptionFormProps> = ({
   onSuccess,
+  initialEmail,
 }) => {
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -109,6 +111,7 @@ const NewsletterSubscriptionForm: React.FC<NewsletterSubscriptionFormProps> = ({
           'Email Address',
           'email',
           'Please enter your email address',
+          initialEmail,
         )}
 
         <Form.Field

--- a/app/components/modals/newsletter-subscription/newsletter-subscription-form.component.tsx
+++ b/app/components/modals/newsletter-subscription/newsletter-subscription-form.component.tsx
@@ -5,6 +5,7 @@ import { pushFormEvent } from '~/lib/gtm';
 import { cn } from '~/lib/utils';
 import { Button } from '~/primitives/button/button.primitive';
 import {
+  radixCheckboxClassName,
   radixFormFieldStackClassName,
   radixFormLabelClassName,
   radixSelectClassName,
@@ -135,6 +136,46 @@ const NewsletterSubscriptionForm: React.FC<NewsletterSubscriptionFormProps> = ({
           </Form.Control>
           <RadixFormErrorMessage match='valueMissing'>
             Please select a campus
+          </RadixFormErrorMessage>
+        </Form.Field>
+
+        <Form.Field
+          name='smsConsent'
+          className={cn('mt-2 md:col-span-2', radixFormFieldStackClassName)}
+        >
+          <div className='flex gap-2 items-start'>
+            <Form.Control asChild>
+              <input
+                type='checkbox'
+                required
+                className={radixCheckboxClassName}
+              />
+            </Form.Control>
+            <Form.Label className='text-sm text-text-secondary leading-5'>
+              By submitting, you agree to our{' '}
+              <a
+                href='https://www.christfellowship.church/terms-of-use'
+                target='_blank'
+                rel='noopener noreferrer'
+                className='underline'
+              >
+                Terms of Use
+              </a>{' '}
+              and{' '}
+              <a
+                href='https://www.christfellowship.church/privacy-policy'
+                target='_blank'
+                rel='noopener noreferrer'
+                className='underline'
+              >
+                Privacy Policy
+              </a>
+              , and consent to receive email communications from Christ
+              Fellowship Church.
+            </Form.Label>
+          </div>
+          <RadixFormErrorMessage match='valueMissing'>
+            You must agree to continue
           </RadixFormErrorMessage>
         </Form.Field>
 

--- a/app/components/modals/newsletter-subscription/newsletter-subscription-modal.tsx
+++ b/app/components/modals/newsletter-subscription/newsletter-subscription-modal.tsx
@@ -11,6 +11,9 @@ interface NewsletterSubscriptionModalProps {
   triggerStyles?: string;
   TriggerButton?: React.ComponentType<ButtonProps>;
   children?: ReactNode;
+  initialEmail?: string;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
 }
 
 export function NewsletterSubscriptionModal({
@@ -18,11 +21,21 @@ export function NewsletterSubscriptionModal({
   triggerStyles,
   TriggerButton = Button,
   children,
+  initialEmail,
+  open: controlledOpen,
+  onOpenChange: controlledOnOpenChange,
 }: NewsletterSubscriptionModalProps) {
-  const [openModal, setOpenModal] = useState(false);
+  const [internalOpen, setInternalOpen] = useState(false);
+  const isControlled = controlledOpen !== undefined;
+  const openModal = isControlled ? controlledOpen : internalOpen;
 
   const handleOpenChange = (open: boolean) => {
-    setOpenModal(open);
+    if (isControlled) {
+      controlledOnOpenChange?.(open);
+    } else {
+      setInternalOpen(open);
+    }
+
     if (open) {
       pushFormEvent(
         'form_start',
@@ -32,19 +45,28 @@ export function NewsletterSubscriptionModal({
     }
   };
 
+  const setOpenModal = (open: boolean) => {
+    handleOpenChange(open);
+  };
+
   return (
     <Modal open={openModal} onOpenChange={handleOpenChange}>
-      {children ? (
-        <Modal.Button asChild>{children}</Modal.Button>
-      ) : (
-        <Modal.Button asChild className='mr-2'>
-          <TriggerButton intent='white' className={triggerStyles}>
-            {buttonTitle}
-          </TriggerButton>
-        </Modal.Button>
-      )}
+      {!isControlled &&
+        (children ? (
+          <Modal.Button asChild>{children}</Modal.Button>
+        ) : (
+          <Modal.Button asChild className='mr-2'>
+            <TriggerButton intent='white' className={triggerStyles}>
+              {buttonTitle}
+            </TriggerButton>
+          </Modal.Button>
+        ))}
       <Modal.Content>
-        <NewsletterSubscriptionFlow setOpenModal={setOpenModal} />
+        <NewsletterSubscriptionFlow
+          setOpenModal={setOpenModal}
+          initialEmail={initialEmail}
+          isOpen={openModal}
+        />
       </Modal.Content>
     </Modal>
   );

--- a/app/routes/about/partials/leadership.partial.tsx
+++ b/app/routes/about/partials/leadership.partial.tsx
@@ -30,7 +30,7 @@ export function LeadershipSection({
               layout === 'vertical' ? 'flex-col gap-8' : 'gap-24 items-center',
             )}
           >
-            <SectionTitle sectionTitle='Meet the Team' />
+            <SectionTitle sectionTitle='meet the team' />
             <h3 className='text-5xl font-extrabold leading-none max-w-3xl'>
               Our Leadership
             </h3>
@@ -38,7 +38,7 @@ export function LeadershipSection({
 
           {/* Mobile title */}
           <div className='lg:hidden'>
-            <SectionTitle className='mb-6' sectionTitle='Meet the Team' />
+            <SectionTitle className='mb-6' sectionTitle='meet the team' />
             <h3 className='text-2xl md:text-4xl font-extrabold leading-tight mb-4 md:mb-8 max-w-3xl'>
               Our Leadership
             </h3>

--- a/app/routes/articles/article-single/partials/newsletter.partial.tsx
+++ b/app/routes/articles/article-single/partials/newsletter.partial.tsx
@@ -1,6 +1,23 @@
+import { useState } from 'react';
+import { NewsletterSubscriptionModal } from '~/components/modals/newsletter-subscription';
 import { Button } from '~/primitives/button/button.primitive';
 
 export const ArticleNewsletter = () => {
+  const [email, setEmail] = useState('');
+  const [open, setOpen] = useState(false);
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const form = event.currentTarget;
+    if (!form.checkValidity()) {
+      form.reportValidity();
+      return;
+    }
+
+    setOpen(true);
+  };
+
   return (
     <div className='bg-navy content-padding py-12 text-white lg:py-24'>
       <div className='max-w-screen-content mx-auto w-full'>
@@ -17,17 +34,23 @@ export const ArticleNewsletter = () => {
           </div>
           {/* Right / Bottom */}
           <div className='flex flex-col gap-4 lg:max-w-1/2'>
-            {/* Form */}
-            <form className='flex w-full flex-col xl:justify-end gap-4 xl:flex-row'>
+            <form
+              className='flex w-full flex-col xl:justify-end gap-4 xl:flex-row'
+              onSubmit={handleSubmit}
+            >
               <input
                 className='w-full xl:max-w-96 p-3 bg-white text-base text-text-secondary rounded-lg xl:rounded-none'
                 type='email'
+                name='email'
                 placeholder='Enter your email'
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+                required
               />
               <Button
                 className='w-full xl:max-w-96 xl:w-auto rounded-lg xl:rounded-none font-normal xl:text-xl'
                 intent='primary'
-                href='#testing'
+                type='submit'
               >
                 Subscribe
               </Button>
@@ -41,6 +64,12 @@ export const ArticleNewsletter = () => {
           </div>
         </div>
       </div>
+
+      <NewsletterSubscriptionModal
+        open={open}
+        onOpenChange={setOpen}
+        initialEmail={email.trim()}
+      />
     </div>
   );
 };

--- a/app/routes/articles/article-single/partials/newsletter.partial.tsx
+++ b/app/routes/articles/article-single/partials/newsletter.partial.tsx
@@ -21,7 +21,7 @@ export const ArticleNewsletter = () => {
   return (
     <div className='bg-navy content-padding py-12 text-white lg:py-24'>
       <div className='max-w-screen-content mx-auto w-full'>
-        <div className='flex flex-col gap-6 lg:gap-20 xl:gap-36 w-full lg:flex-row lg:justify-between'>
+        <div className='flex flex-col gap-6 lg:gap-20 xl:gap-36 w-full lg:flex-row lg:justify-between lg:items-stretch'>
           {/* Left / Top*/}
           <div className='flex flex-col gap-3 lg:gap-4'>
             <div className='text-3xl font-semibold'>
@@ -33,7 +33,7 @@ export const ArticleNewsletter = () => {
             </div>
           </div>
           {/* Right / Bottom */}
-          <div className='flex flex-col gap-4 lg:max-w-1/2'>
+          <div className='flex flex-col gap-4 lg:max-w-1/2 lg:justify-end'>
             <form
               className='flex w-full flex-col xl:justify-end gap-4 xl:flex-row'
               onSubmit={handleSubmit}
@@ -55,12 +55,6 @@ export const ArticleNewsletter = () => {
                 Subscribe
               </Button>
             </form>
-            <div className='text-sm font-light'>
-              By clicking Sign Up you{`'`}re confirming that you agree with our{' '}
-              <a href='#blank' className='underline'>
-                Terms and Conditions.
-              </a>
-            </div>
           </div>
         </div>
       </div>

--- a/app/routes/events/all-events/partials/featured-events.partial.tsx
+++ b/app/routes/events/all-events/partials/featured-events.partial.tsx
@@ -4,7 +4,10 @@ import { Link } from 'react-router-dom';
 import { Icon } from '~/primitives/icon/icon';
 import { ResourceCard } from '~/primitives/cards/resource-card';
 import { ContentItemHit } from '~/routes/search/types';
-import { FeaturedEventCard, getEventCardDisplayDate } from '../components/featured-card.component';
+import {
+  FeaturedEventCard,
+  getEventCardDisplayDate,
+} from '../components/featured-card.component';
 
 export function FeaturedEventsSectionLayout({
   children,

--- a/app/routes/locations/location-search/location-search-page.tsx
+++ b/app/routes/locations/location-search/location-search-page.tsx
@@ -316,8 +316,7 @@ export function LocationSearchPage() {
     };
   }, [ALGOLIA_APP_ID, ALGOLIA_SEARCH_API_KEY, locationIndexName]);
 
-  const hasCoordinates =
-    coordinates?.lat != null && coordinates?.lng != null;
+  const hasCoordinates = coordinates?.lat != null && coordinates?.lng != null;
 
   return (
     <div className='flex w-full flex-col min-h-screen'>

--- a/app/routes/page-builder/__tests__/loader.test.ts
+++ b/app/routes/page-builder/__tests__/loader.test.ts
@@ -86,6 +86,7 @@ function makeCollectionItem(
   id: string,
   channelId: string,
   attrs: Record<string, string> = {},
+  startDateTime?: string,
 ) {
   return {
     id,
@@ -93,6 +94,7 @@ function makeCollectionItem(
     title: `Item ${id}`,
     content: `Content ${id}`,
     contentChannelId: channelId,
+    ...(startDateTime ? { startDateTime } : {}),
     attributeValues: Object.fromEntries(
       Object.entries(attrs).map(([k, v]) => [k, { value: v }]),
     ),
@@ -112,6 +114,52 @@ function indexWith(episodeChannelId: string, showPath: string) {
     ]),
   };
 }
+
+// ---------------------------------------------------------------------------
+// mapPageBuilderChildItems – collection startDate
+// ---------------------------------------------------------------------------
+
+describe('mapPageBuilderChildItems – collection startDate', () => {
+  it('omits startDate for article collection items', async () => {
+    const section = makeSection('article-section');
+    const articleItem = makeCollectionItem(
+      'article-1',
+      '43',
+      { pathname: '/articles/test-article' },
+      '2025-06-15T10:00:00',
+    );
+
+    mockBuildPodcastRoutingIndex.mockResolvedValueOnce(emptyIndex());
+    mockFetchRockData
+      .mockResolvedValueOnce([{ childContentChannelItemId: 'article-1' }])
+      .mockResolvedValueOnce(articleItem);
+
+    const sections = await mapPageBuilderChildItems([section]);
+
+    expect(sections[0].collection![0].contentType).toBe('ARTICLES');
+    expect(sections[0].collection![0].startDate).toBe('');
+  });
+
+  it('includes startDate for event collection items', async () => {
+    const section = makeSection('event-section');
+    const eventItem = makeCollectionItem(
+      'event-1',
+      '186',
+      { url: '/events/test-event' },
+      '2025-06-15T10:00:00',
+    );
+
+    mockBuildPodcastRoutingIndex.mockResolvedValueOnce(emptyIndex());
+    mockFetchRockData
+      .mockResolvedValueOnce([{ childContentChannelItemId: 'event-1' }])
+      .mockResolvedValueOnce(eventItem);
+
+    const sections = await mapPageBuilderChildItems([section]);
+
+    expect(sections[0].collection![0].contentType).toBe('EVENTS');
+    expect(sections[0].collection![0].startDate).toBe('Sun 15 Jun 2025');
+  });
+});
 
 // ---------------------------------------------------------------------------
 // mapPageBuilderChildItems – podcast routing

--- a/app/routes/page-builder/loader.tsx
+++ b/app/routes/page-builder/loader.tsx
@@ -382,12 +382,13 @@ export const mapPageBuilderChildItems = async (
               }
 
               // Generate the start date for the item.
-              // Page Builder items have no meaningful start date in a
-              // collection context, so skip it (same as REDIRECT_CARD).
+              // Page Builder, Redirect Card, and Article items have no meaningful
+              // start date in a collection context, so skip it.
               let startDate = '';
               if (
                 contentType !== 'REDIRECT_CARD' &&
-                contentType !== 'PAGE_BUILDER'
+                contentType !== 'PAGE_BUILDER' &&
+                contentType !== 'ARTICLES'
               ) {
                 const startDateTime = item.startDateTime || '';
                 if (startDateTime) {

--- a/app/routes/page-builder/types.ts
+++ b/app/routes/page-builder/types.ts
@@ -80,7 +80,7 @@ export type CollectionItem = {
   description?: string;
   image: string;
   pathname: string;
-  startDate?: string; // for Events, Sermons, Articles, Devotionals, Podcasts
+  startDate?: string; // for Events, Sermons, Devotionals, Podcasts
   author?: string; // for Sermons, Articles, Devotionals, Podcasts
   location?: string; // for Events
   /** Redirect Card only (Rock `disableCard`). When true, carousel renders static content without link/card chrome. */


### PR DESCRIPTION
## Summary
This PR removes date from Articles in collections. It also sets up Newsletter in the articles pages.

## Screenshots

[Paste your screenshots here]

## Testing

- [ ] Ensure dates are not showing in Resource Collection, such as [this one](https://remix-web-app-git-locations-sorting-christ-fellowship-church.vercel.app/ministries/students#parenting-resources)
- [ ] Ensure Newsletter form opens and email is prefilled, [example](https://remix-web-app-git-locations-sorting-christ-fellowship-church.vercel.app/articles/verses-to-reflect-on-during-election-season).

## Tickets

[insert Jira ticket reference here]

## Changes Made

### New Components Added

- List any new React components created
- Include file paths and brief descriptions

### New Utilities

- List any new utility functions or helper components
- Include file paths and descriptions

### New Assets

- List any new images, animations, or other static assets
- Include file paths and descriptions

### Dependencies

- List any new dependencies added to package.json
- Include version numbers

### Route Implementation

- List any new routes or route modifications
- Include file paths and descriptions

### Key Features

- Highlight the main features implemented
- Focus on user-facing functionality
- Include any performance optimizations or accessibility improvements
