### PR TITLE
[codex] Add Journey signup reason field

### DIFF
--- a/app/components/modals/journey-finder-sign-up/journey-finder-sign-up-form.component.tsx
+++ b/app/components/modals/journey-finder-sign-up/journey-finder-sign-up-form.component.tsx
@@ -10,9 +10,11 @@ import {
   radixFormFieldStackClassName,
   radixFormLabelClassName,
   radixRadioClassName,
+  radixSelectClassName,
   radixTextareaClassName,
   renderRadixInputField,
   RadixFormErrorMessage,
+  RadixFormSelectShell,
 } from '~/primitives/inputs/form-radix-field';
 
 export type JourneyFinderSignUpSuccessDetails = {
@@ -44,6 +46,22 @@ const SPANISH_AT_CF_OPTIONS: { value: string; label: string }[] = [
   { value: '5', label: 'Más de 5 años' },
 ];
 
+const REASON_OPTIONS: { value: string; label: string }[] = [
+  { value: '1', label: 'Learn more about Christ Fellowship Church' },
+  { value: '2', label: 'Find community and build relationships' },
+  { value: '3', label: 'Grow in my faith' },
+  { value: '4', label: 'Join the Dream Team and start serving' },
+  { value: '5', label: 'Get more involved at Christ Fellowship' },
+];
+
+const SPANISH_REASON_OPTIONS: { value: string; label: string }[] = [
+  { value: '1', label: 'Conocer más acerca de la Iglesia Christ Fellowship' },
+  { value: '2', label: 'Encontrar comunidad y construir relaciones' },
+  { value: '3', label: 'Crecer en mi fe' },
+  { value: '4', label: 'Unirme al Dream Team y comenzar a servir' },
+  { value: '5', label: 'Involucrarme más en Christ Fellowship' },
+];
+
 const FORM_COPY = {
   English: {
     cardHeading: 'Personal Information',
@@ -52,6 +70,8 @@ const FORM_COPY = {
     phone: 'Cell Phone',
     email: 'Email Address',
     atCF: 'How long have you attended Christ Fellowship?',
+    reason: 'What is your main reason for signing up for Journey?',
+    reasonPlaceholder: 'Select a reason',
     hopeToGet: 'What do you hope to gain from this Journey Experience?',
     submit: 'Submit',
     loading: 'Loading...',
@@ -61,7 +81,9 @@ const FORM_COPY = {
     requiredPhone: 'Please enter a valid number',
     requiredEmail: 'Please enter a valid email',
     requiredAtCF: 'Please select an option',
+    requiredReason: 'Please select a reason',
     atCFOptions: AT_CF_OPTIONS,
+    reasonOptions: REASON_OPTIONS,
   },
   Spanish: {
     cardHeading: 'Información personal',
@@ -70,6 +92,8 @@ const FORM_COPY = {
     phone: 'Teléfono celular',
     email: 'Correo electrónico',
     atCF: '¿Cuánto tiempo has asistido a Christ Fellowship?',
+    reason: '¿Cuál es tu razón principal para inscribirte en Journey?',
+    reasonPlaceholder: 'Selecciona una razón',
     hopeToGet: '¿Qué esperas recibir de esta experiencia de Journey?',
     submit: 'Enviar',
     loading: 'Cargando...',
@@ -80,7 +104,9 @@ const FORM_COPY = {
     requiredPhone: 'Por favor ingresa un número válido',
     requiredEmail: 'Por favor ingresa un correo electrónico válido',
     requiredAtCF: 'Por favor selecciona una opción',
+    requiredReason: 'Por favor selecciona una razón',
     atCFOptions: SPANISH_AT_CF_OPTIONS,
+    reasonOptions: SPANISH_REASON_OPTIONS,
   },
 };
 
@@ -210,6 +236,40 @@ const JourneyFinderSignUpForm: React.FC<JourneyFinderSignUpFormProps> = ({
           </div>
           <RadixFormErrorMessage match='valueMissing'>
             {copy.requiredAtCF}
+          </RadixFormErrorMessage>
+        </Form.Field>
+
+        <Form.Field
+          name='reason'
+          className={cn(
+            'col-span-1 mt-2 md:col-span-2',
+            radixFormFieldStackClassName,
+          )}
+        >
+          <Form.Label className={radixFormLabelClassName}>
+            {copy.reason}
+          </Form.Label>
+          <RadixFormSelectShell>
+            <Form.Control asChild>
+              <select
+                name='reason'
+                required
+                defaultValue=''
+                className={radixSelectClassName}
+              >
+                <option value='' disabled>
+                  {copy.reasonPlaceholder}
+                </option>
+                {copy.reasonOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </Form.Control>
+          </RadixFormSelectShell>
+          <RadixFormErrorMessage match='valueMissing'>
+            {copy.requiredReason}
           </RadixFormErrorMessage>
         </Form.Field>
 

--- a/app/components/modals/journey-finder-sign-up/tests/journey-finder-sign-up-form.test.tsx
+++ b/app/components/modals/journey-finder-sign-up/tests/journey-finder-sign-up-form.test.tsx
@@ -85,6 +85,33 @@ describe('JourneyFinderSignUpForm', () => {
     ).toBeInTheDocument();
   });
 
+  it('renders the required Reason select options', () => {
+    renderForm();
+    expect(
+      screen.getByText('What is your main reason for signing up for Journey?'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Learn more about Christ Fellowship Church'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Find community and build relationships'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Grow in my faith')).toBeInTheDocument();
+    expect(
+      screen.getByText('Join the Dream Team and start serving'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Get more involved at Christ Fellowship'),
+    ).toBeInTheDocument();
+
+    const select = document.querySelector(
+      "select[name='reason']",
+    ) as HTMLSelectElement;
+    expect(select).toBeInTheDocument();
+    expect(select.required).toBe(true);
+    expect(select.options.length).toBe(6);
+  });
+
   it('includes a hidden Group input populated from the URL search param', () => {
     renderForm();
     const hidden = document.querySelector(
@@ -151,6 +178,24 @@ describe('JourneyFinderSignUpForm', () => {
     expect(screen.getByText('Teléfono celular')).toBeInTheDocument();
     expect(screen.getByText('Correo electrónico')).toBeInTheDocument();
     expect(screen.getByText('Menos de 1 mes')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        '¿Cuál es tu razón principal para inscribirte en Journey?',
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Conocer más acerca de la Iglesia Christ Fellowship'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Encontrar comunidad y construir relaciones'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Crecer en mi fe')).toBeInTheDocument();
+    expect(
+      screen.getByText('Unirme al Dream Team y comenzar a servir'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Involucrarme más en Christ Fellowship'),
+    ).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /enviar/i })).toBeInTheDocument();
   });
 

--- a/app/routes/journey-finder-sign-up/action.test.ts
+++ b/app/routes/journey-finder-sign-up/action.test.ts
@@ -14,6 +14,7 @@ const createRequest = (language?: 'English' | 'Spanish') => {
   formData.set('phone', '5555555555');
   formData.set('email', 'test@example.com');
   formData.set('atCF', '1');
+  formData.set('reason', '3');
 
   const searchParams = new URLSearchParams({ Group: 'group-guid-123' });
   if (language) {
@@ -46,6 +47,7 @@ describe('journey finder sign up action', () => {
       body: expect.objectContaining({
         Group: 'group-guid-123',
         LaunchSource: 'app',
+        Reason: '3',
       }),
       instanceName: 'Test Person',
     });
@@ -62,6 +64,7 @@ describe('journey finder sign up action', () => {
       body: expect.objectContaining({
         Group: 'group-guid-123',
         LaunchSource: 'app',
+        Reason: '3',
       }),
       instanceName: 'Test Person',
     });

--- a/app/routes/journey-finder-sign-up/action.ts
+++ b/app/routes/journey-finder-sign-up/action.ts
@@ -11,6 +11,7 @@ export const action: ActionFunction = async ({ request }) => {
     const phone = formData.phone?.toString() ?? '';
     const email = formData.email?.toString() ?? '';
     const atCF = formData.atCF?.toString() ?? '';
+    const reason = formData.reason?.toString() ?? '';
     const hopeToGet = formData.hopeToGet?.toString() ?? '';
 
     const url = new URL(request.url);
@@ -19,7 +20,15 @@ export const action: ActionFunction = async ({ request }) => {
       url.searchParams.get('Language') === 'Spanish' ? 'Spanish' : 'English';
     const workflowTypeId = language === 'Spanish' ? '1835' : '1833';
 
-    if (!firstName || !lastName || !phone || !email || !atCF || !group) {
+    if (
+      !firstName ||
+      !lastName ||
+      !phone ||
+      !email ||
+      !atCF ||
+      !reason ||
+      !group
+    ) {
       return data({ error: 'Missing required fields' }, { status: 400 });
     }
 
@@ -29,6 +38,7 @@ export const action: ActionFunction = async ({ request }) => {
       PrimaryPhoneNumber: phone,
       EmailAddress: email,
       AtCF: atCF,
+      Reason: reason,
       LaunchSource: 'app',
       Group: group,
     };

--- a/app/routes/journey-finder-sign-up/types.ts
+++ b/app/routes/journey-finder-sign-up/types.ts
@@ -4,6 +4,7 @@ export type JourneyFinderSignUpFormType = {
   PrimaryPhoneNumber: string;
   EmailAddress: string;
   AtCF: string; // "1" | "2" | "3" | "4" | "5"
+  Reason: string; // "1" | "2" | "3" | "4" | "5"
   hopetoget?: string;
   LaunchSource: 'app';
   Group: string;


### PR DESCRIPTION
## Summary
- Add a required Reason select field to the Journey Finder Sign Up form
- Localize the Reason labels for English and Spanish while submitting Rock values 1-5
- Include the submitted value in the Rock workflow payload as `Reason`

## Validation
- `pnpm test app/components/modals/journey-finder-sign-up/tests/journey-finder-sign-up-form.test.tsx app/routes/journey-finder-sign-up/action.test.ts`

Note: Vitest also matched existing `.claude/worktrees` copies of these test paths during the targeted run; all matched suites passed.