### PR TITLE
Add legacy URL redirects

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -9,6 +9,27 @@ NPM_FLAGS = "--no-optional"
 [dev]
 command = "pnpm dev"
 
+# Legacy URL redirects (old platform -> new site). 301 permanent.
+# User-defined rules are processed before the framework's SSR catch-all,
+# so these match first. force = true ensures the redirect always wins.
+[[redirects]]
+  from = "/ministry-breakout-presentations-and-resources"
+  to = "/link-tree/ministry-breakout-presentations-and-resources"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/events/terremoto-venezuela"
+  to = "/terremoto-venezuela"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/articles/give-to-the-crisis-fund"
+  to = "/give-to-the-crisis-fund"
+  status = 301
+  force = true
+
 # Security headers applied to all routes
 [[headers]]
   for = "/*"

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "redirects": [
+    {
+      "source": "/ministry-breakout-presentations-and-resources",
+      "destination": "/link-tree/ministry-breakout-presentations-and-resources",
+      "statusCode": 301
+    },
+    {
+      "source": "/events/terremoto-venezuela",
+      "destination": "/terremoto-venezuela",
+      "statusCode": 301
+    },
+    {
+      "source": "/articles/give-to-the-crisis-fund",
+      "destination": "/give-to-the-crisis-fund",
+      "statusCode": 301
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds three permanent (301) redirects mapping legacy URLs from the old platform to their new locations on the Remix site, now that we've gone live. Redirects are defined in host config (not per-route files) so the list is easy to extend as more legacy URLs surface.

Configured for **both** hosts the repo supports (`netlify.toml` and a new `vercel.json`), so the redirects fire regardless of which host serves a given request.

| Old URL | New URL |
|---|---|
| `/ministry-breakout-presentations-and-resources` | `/link-tree/ministry-breakout-presentations-and-resources` |
| `/events/terremoto-venezuela` | `/terremoto-venezuela` |
| `/articles/give-to-the-crisis-fund` | `/give-to-the-crisis-fund` |

## Screenshots

N/A — config-only change.

## Testing

- [ ] After deploy, verify each redirect returns `301` to the new path, e.g.:
  - `curl -sI https://www.christfellowship.church/events/terremoto-venezuela` → `301` → `/terremoto-venezuela`
  - `curl -sI https://www.christfellowship.church/articles/give-to-the-crisis-fund` → `301` → `/give-to-the-crisis-fund`
  - `curl -sI https://www.christfellowship.church/ministry-breakout-presentations-and-resources` → `301` → `/link-tree/ministry-breakout-presentations-and-resources`
- [ ] Confirm each destination renders (these resolve via CMS-backed routes — the page-builder catch-all and link-tree loader — so the content must exist in Rock at those slugs).
- [ ] No new linter/type/test errors (`pnpm check`, `pnpm test`). 

## Changes Made

### Route Implementation

- `netlify.toml` — added three `[[redirects]]` blocks (`status = 301`, `force = true`). User-defined rules are processed before the framework's SSR catch-all, so they match first.
- `vercel.json` (new) — added a `redirects` array using `statusCode: 301`. Note: Vercel's `permanent: true` emits a 308, so `statusCode: 301` is set explicitly to keep both hosts consistent.

### New Components Added

- None

### New Utilities

- None

### New Assets

- None

### Dependencies

- None

### Key Features

- Legacy URLs from the old platform now 301-redirect to their new locations, preserving SEO and existing inbound links.
- Redirects live in host config, making future additions a one-line change per host.