### PR TITLE
Redirect Missions church opportunity to community volunteer page

### DIFF
--- a/app/routes/volunteer/church-serving-area/__tests__/church-serving-area-page.test.tsx
+++ b/app/routes/volunteer/church-serving-area/__tests__/church-serving-area-page.test.tsx
@@ -97,9 +97,7 @@ describe('ChurchServingAreaPage', () => {
 
     await selectRoleAndContinue('Missions');
 
-    expect(mockNavigate).toHaveBeenCalledWith(
-      'https://www.christfellowship.church/volunteer#community',
-    );
+    expect(mockNavigate).toHaveBeenCalledWith('/volunteer#community');
   });
 
   it('keeps non-Missions opportunities on the Rock church opportunity form flow', async () => {

--- a/app/routes/volunteer/church-serving-area/__tests__/church-serving-area-page.test.tsx
+++ b/app/routes/volunteer/church-serving-area/__tests__/church-serving-area-page.test.tsx
@@ -1,0 +1,114 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+
+import type { LoaderReturnType } from '../loader';
+import { ChurchServingAreaPage } from '../church-serving-area-page';
+
+const { mockNavigate, mockUseLoaderData } = vi.hoisted(() => ({
+  mockNavigate: vi.fn(),
+  mockUseLoaderData: vi.fn(),
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual =
+    await vi.importActual<typeof import('react-router-dom')>(
+      'react-router-dom',
+    );
+
+  return {
+    ...actual,
+    useLoaderData: mockUseLoaderData,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+vi.mock('~/hooks/use-copy-page-path', () => ({
+  useCopyPagePath: () => ({
+    copied: false,
+    copyPath: vi.fn(),
+  }),
+}));
+
+vi.mock(
+  '../../components/volunteer-detail/volunteer-detail-nav.component',
+  () => ({
+    VolunteerDetailNav: () => <nav aria-label='Volunteer detail' />,
+  }),
+);
+
+vi.mock(
+  '../../components/volunteer-detail/volunteer-detail-hero.component',
+  () => ({
+    VolunteerDetailHero: ({ title }: { title: string }) => <h1>{title}</h1>,
+  }),
+);
+
+const baseLoaderData: LoaderReturnType = {
+  bucketGuid: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+  bucket: {
+    name: 'Outreach & Missions',
+    description: 'Serve locally and globally.',
+    tag: 'Make a Difference',
+    image: 'https://example.com/outreach.jpg',
+    pathname: '/volunteer/church/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+  },
+  roles: [
+    {
+      id: 'missions-role-guid',
+      title: 'Missions',
+      description: '<p>Serve with missions.</p>',
+    },
+    {
+      id: 'care-role-guid',
+      title: 'Care Team',
+      description: '<p>Serve with care.</p>',
+    },
+  ],
+};
+
+function renderPage(loaderData: LoaderReturnType = baseLoaderData) {
+  mockUseLoaderData.mockReturnValue(loaderData);
+
+  return render(
+    <MemoryRouter>
+      <ChurchServingAreaPage />
+    </MemoryRouter>,
+  );
+}
+
+async function selectRoleAndContinue(roleName: string) {
+  const user = userEvent.setup();
+
+  await user.click(
+    screen.getAllByRole('radio', { name: new RegExp(`^${roleName}\\b`) })[0],
+  );
+  await user.click(screen.getAllByRole('button', { name: 'Continue' })[0]);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('ChurchServingAreaPage', () => {
+  it('navigates Missions opportunities to the volunteer community URL', async () => {
+    renderPage();
+
+    await selectRoleAndContinue('Missions');
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      'https://www.christfellowship.church/volunteer#community',
+    );
+  });
+
+  it('keeps non-Missions opportunities on the Rock church opportunity form flow', async () => {
+    renderPage();
+
+    await selectRoleAndContinue('Care Team');
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      '/rock-page?embed=church-opportunity&opportunityId=care-role-guid',
+    );
+  });
+});

--- a/app/routes/volunteer/church-serving-area/church-serving-area-page.tsx
+++ b/app/routes/volunteer/church-serving-area/church-serving-area-page.tsx
@@ -15,7 +15,7 @@ import {
 import type { LoaderReturnType } from './loader';
 
 const MISSIONS_OPPORTUNITY_URL =
-  'https://www.christfellowship.church/volunteer#community';
+  '/volunteer#community';
 
 export function ChurchServingAreaPage() {
   const { bucket, roles } = useLoaderData<LoaderReturnType>();

--- a/app/routes/volunteer/church-serving-area/church-serving-area-page.tsx
+++ b/app/routes/volunteer/church-serving-area/church-serving-area-page.tsx
@@ -14,6 +14,9 @@ import {
 } from './partials/church-serving-area-partials.partial';
 import type { LoaderReturnType } from './loader';
 
+const MISSIONS_OPPORTUNITY_URL =
+  'https://www.christfellowship.church/volunteer#community';
+
 export function ChurchServingAreaPage() {
   const { bucket, roles } = useLoaderData<LoaderReturnType>();
   const navigate = useNavigate();
@@ -30,12 +33,19 @@ export function ChurchServingAreaPage() {
   const onContinue = useCallback(() => {
     const opportunityId = selectedRoleGuid?.trim();
     if (!opportunityId) return;
+
+    const selectedRole = roles.find((role) => role.id === opportunityId);
+    if (selectedRole?.title.trim().toLowerCase() === 'missions') {
+      navigate(MISSIONS_OPPORTUNITY_URL);
+      return;
+    }
+
     const searchParams = new URLSearchParams({
       embed: 'church-opportunity',
       opportunityId,
     });
     navigate(`/rock-page?${searchParams.toString()}`);
-  }, [navigate, selectedRoleGuid]);
+  }, [navigate, roles, selectedRoleGuid]);
 
   useEffect(() => {
     const timer = setTimeout(() => setIsVisible(true), 50);


### PR DESCRIPTION
## Summary

Redirect the Missions church opportunity on the Outreach & Missions volunteer page to the community volunteer section instead of the Rock application form.

This keeps the existing Rock flow for all other church-serving opportunities and adds focused test coverage for both navigation paths.

## Screenshots

[Paste your screenshots here]

## Testing

- [ ] What steps can someone follow to verify functionality? (Write out checklist of steps to test)
- Visit `/volunteer/church/<Outreach & Missions bucketGuid>`.
- Select the `Missions` card and click `Continue`.
- Confirm the browser navigates to `https://www.christfellowship.church/volunteer#community`.
- Select a different role such as `Care Team` and click `Continue`.
- Confirm the browser navigates to `/rock-page?embed=church-opportunity&opportunityId=<role-guid>`.
- [ ] Was any new linter/type/test errors/warnings(run `pnpm check` for linter/type/prettier check and `pnpm test` for running tests)?
- Ran `pnpm vitest run app/routes/volunteer/church-serving-area/__tests__/church-serving-area-page.test.tsx`.

## Tickets

N/A

## Changes Made

### New Components Added

- None.

### New Utilities

- None.

### New Assets

- None.

### Dependencies

- None.

### Route Implementation

- Updated `app/routes/volunteer/church-serving-area/church-serving-area-page.tsx` to route the selected `Missions` church opportunity to the community volunteer URL instead of the Rock form.

### Key Features

- The `Missions` church opportunity now redirects to the community volunteer section.
- All other church opportunity cards keep the existing Rock application flow.
- Added focused component coverage in `app/routes/volunteer/church-serving-area/__tests__/church-serving-area-page.test.tsx` for both navigation outcomes.
