### PR TITLE
CFDP-4095 Add Rock-driven ordering to Serving Area opportunities

### DIFF
--- a/app/routes/volunteer/church-serving-area/__tests__/church-roles.server.test.ts
+++ b/app/routes/volunteer/church-serving-area/__tests__/church-roles.server.test.ts
@@ -26,6 +26,7 @@ describe('fetchChurchRolesByPreferenceAreaGuid', () => {
       expect.objectContaining({
         endpoint: 'ConnectionOpportunities/GetByAttributeValue',
         queryParams: expect.objectContaining({
+          $orderby: 'Order',
           attributeKey: 'preferenceArea',
           value: BUCKET_GUID,
         }),

--- a/app/routes/volunteer/church-serving-area/church-roles.server.ts
+++ b/app/routes/volunteer/church-serving-area/church-roles.server.ts
@@ -29,6 +29,7 @@ export async function fetchChurchRolesByPreferenceAreaGuid(
     const raw = await fetchRockData({
       endpoint: 'ConnectionOpportunities/GetByAttributeValue',
       queryParams: {
+        $orderby: 'Order',
         attributeKey: 'preferenceArea',
         value: bucketGuid,
       },


### PR DESCRIPTION
## Summary

Updates church Serving Area Connection Opportunities to request Rock ordering so the site reflects the Connection Type Detail sort order without code changes.

## Screenshots

N/A - server-side ordering change only.

## Testing

- [x] Run `pnpm test app/routes/volunteer/church-serving-area/__tests__/church-roles.server.test.ts`
- [x] Run `pnpm typecheck`
- [x] Open a church Serving Area page with multiple Connection Opportunities, such as `/volunteer/church/{bucketGuid}`.
- [x] Compare the displayed opportunity order against the Rock Connection Type Detail configuration for type `55`.
- [x] Change the sort order in Rock, reload the Serving Area page after cache expiry or cache clear, and confirm the site reflects the updated order without any code changes.
- [x] Select the `Missions` role and confirm Continue still routes to `/volunteer#community` after reordering.
- [x] Select a non-`Missions` role and confirm Continue still routes to `/rock-page?embed=church-opportunity&opportunityId={roleGuid}`.

## Tickets

CFDP-4095

## Changes Made

### New Components Added

- None.

### New Utilities

- None.

### New Assets

- None.

### Dependencies

- None.

### Route Implementation

- Updated `app/routes/volunteer/church-serving-area/church-roles.server.ts` to request `$orderby: "Order"` from the Rock `ConnectionOpportunities/GetByAttributeValue` endpoint.
- Updated `app/routes/volunteer/church-serving-area/__tests__/church-roles.server.test.ts` to assert the ordered Rock query.

### Key Features

- Serving Area Connection Opportunities now follow the sort order configured in Rock.
- Ordering remains data-driven and does not introduce client-side sorting or hardcoded role order.