### PR TITLE
Replace KEYS with SCAN in deleteByPrefix for non-blocking cache invalidation

### DIFF
--- a/app/lib/.server/__tests__/cache-utils.test.ts
+++ b/app/lib/.server/__tests__/cache-utils.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from 'vitest';
-import { buildCacheKey, TTL } from '../cache-utils';
+import { describe, it, expect, vi } from 'vitest';
+import type Redis from 'ioredis';
+import { buildCacheKey, deleteByPrefix, TTL } from '../cache-utils';
 
 describe('TTL constants', () => {
   it('has expected values', () => {
@@ -59,5 +60,72 @@ describe('buildCacheKey', () => {
     const key2 = buildCacheKey('People', {});
     expect(key1).toBe(key2);
     expect(key1).toMatch(/^rock:People:[a-f0-9]{12}$/);
+  });
+});
+
+describe('deleteByPrefix', () => {
+  it('returns 0 without touching redis when redis is null', async () => {
+    const result = await deleteByPrefix(null, 'People');
+    expect(result).toBe(0);
+  });
+
+  it('never calls KEYS — uses SCAN to find matching keys', async () => {
+    const keysSpy = vi.fn();
+    const scan = vi
+      .fn()
+      .mockResolvedValue(['0', ['rock:People:aaa', 'rock:People:bbb']]);
+    const del = vi.fn().mockResolvedValue(2);
+    const fakeRedis = { keys: keysSpy, scan, del } as unknown as Redis;
+
+    const result = await deleteByPrefix(fakeRedis, 'People');
+
+    expect(keysSpy).not.toHaveBeenCalled();
+    expect(scan).toHaveBeenCalledWith('0', 'MATCH', 'rock:People:*', 'COUNT', 100);
+    expect(del).toHaveBeenCalledWith('rock:People:aaa', 'rock:People:bbb');
+    expect(result).toBe(2);
+  });
+
+  it('follows a multi-page scan cursor and deletes all pages in one batch', async () => {
+    const scan = vi
+      .fn()
+      .mockResolvedValueOnce(['42', ['rock:Groups:aaa']])
+      .mockResolvedValueOnce(['0', ['rock:Groups:bbb']]);
+    const del = vi.fn().mockResolvedValue(2);
+    const fakeRedis = { scan, del } as unknown as Redis;
+
+    const result = await deleteByPrefix(fakeRedis, 'Groups');
+
+    expect(scan).toHaveBeenCalledTimes(2);
+    expect(scan).toHaveBeenNthCalledWith(
+      2,
+      '42',
+      'MATCH',
+      'rock:Groups:*',
+      'COUNT',
+      100,
+    );
+    expect(del).toHaveBeenCalledTimes(1);
+    expect(del).toHaveBeenCalledWith('rock:Groups:aaa', 'rock:Groups:bbb');
+    expect(result).toBe(2);
+  });
+
+  it('returns 0 and does not call del when no keys match', async () => {
+    const scan = vi.fn().mockResolvedValue(['0', []]);
+    const del = vi.fn();
+    const fakeRedis = { scan, del } as unknown as Redis;
+
+    const result = await deleteByPrefix(fakeRedis, 'Nonexistent');
+
+    expect(del).not.toHaveBeenCalled();
+    expect(result).toBe(0);
+  });
+
+  it('normalizes leading and trailing slashes when building the MATCH pattern', async () => {
+    const scan = vi.fn().mockResolvedValue(['0', []]);
+    const fakeRedis = { scan, del: vi.fn() } as unknown as Redis;
+
+    await deleteByPrefix(fakeRedis, '/People/');
+
+    expect(scan).toHaveBeenCalledWith('0', 'MATCH', 'rock:People:*', 'COUNT', 100);
   });
 });

--- a/app/lib/.server/cache-utils.ts
+++ b/app/lib/.server/cache-utils.ts
@@ -46,6 +46,10 @@ export function buildCacheKey(
  * Deletes all cache keys matching a given endpoint prefix.
  * Useful for invalidating all cached data for a specific Rock endpoint.
  *
+ * Uses SCAN instead of KEYS to walk the keyspace in small increments —
+ * KEYS blocks the single-threaded Redis server for the full scan duration,
+ * which is risky once the keyspace grows.
+ *
  * @returns Number of keys deleted
  */
 export async function deleteByPrefix(
@@ -56,7 +60,21 @@ export async function deleteByPrefix(
 
   const normalizedPrefix = endpointPrefix.replace(/^\/+|\/+$/g, '');
   const pattern = `rock:${normalizedPrefix}:*`;
-  const keys = await redis.keys(pattern);
+
+  const keys: string[] = [];
+  let cursor = '0';
+
+  do {
+    const [nextCursor, batch] = await redis.scan(
+      cursor,
+      'MATCH',
+      pattern,
+      'COUNT',
+      100,
+    );
+    keys.push(...batch);
+    cursor = nextCursor;
+  } while (cursor !== '0');
 
   if (keys.length === 0) return 0;
   return redis.del(...keys);


### PR DESCRIPTION
## Summary

Replace the blocking `KEYS` command with `SCAN` in the `deleteByPrefix` cache utility function. The `KEYS` command blocks the single-threaded Redis server for the entire scan duration, which becomes problematic as the keyspace grows. `SCAN` iterates in small increments and is safe for production use.

## Changes Made

### Key Features

- **Non-blocking cache invalidation**: Replaced `redis.keys()` with `redis.scan()` to avoid blocking the Redis server during keyspace traversal
- **Cursor-based iteration**: Implements proper SCAN cursor handling to walk through all matching keys across multiple batches
- **Batch deletion**: Collects all keys from all SCAN pages before deleting them in a single `DEL` call for efficiency
- **Pattern normalization**: Maintains existing behavior of stripping leading/trailing slashes from the endpoint prefix

### Implementation Details

- Uses `SCAN` with `MATCH` pattern and `COUNT 100` for efficient iteration
- Loops until cursor returns to `'0'` (indicating completion)
- Handles null Redis gracefully (returns 0 without attempting operations)
- Added comprehensive test coverage for all code paths

## Testing

- Added 5 new unit tests covering:
  - Null Redis handling
  - SCAN usage (never calls KEYS)
  - Multi-page cursor following
  - Empty result handling
  - Pattern normalization with leading/trailing slashes
- All tests pass and verify both the mechanism (correct Redis calls) and the outcome (correct number of deletions)

https://claude.ai/code/session_017WXLks86VkWYzzyYSYxWGU