### PR TITLE
Add worship church opportunity override

### DIFF
--- a/app/routes/volunteer/church-serving-area/__tests__/church-serving-area-page.test.tsx
+++ b/app/routes/volunteer/church-serving-area/__tests__/church-serving-area-page.test.tsx
@@ -65,6 +65,11 @@ const baseLoaderData: LoaderReturnType = {
       title: 'Care Team',
       description: '<p>Serve with care.</p>',
     },
+    {
+      id: 'worship-role-guid',
+      title: 'Worship',
+      description: '<p>Serve with worship.</p>',
+    },
   ],
 };
 
@@ -107,6 +112,16 @@ describe('ChurchServingAreaPage', () => {
 
     expect(mockNavigate).toHaveBeenCalledWith(
       '/rock-page?embed=church-opportunity&opportunityId=care-role-guid',
+    );
+  });
+
+  it('navigates Worship opportunities to the worship links page', async () => {
+    renderPage();
+
+    await selectRoleAndContinue('Worship');
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      'https://lnk.bio/CFWorshipLinks',
     );
   });
 });

--- a/app/routes/volunteer/church-serving-area/__tests__/church-serving-area-page.test.tsx
+++ b/app/routes/volunteer/church-serving-area/__tests__/church-serving-area-page.test.tsx
@@ -11,6 +11,9 @@ const { mockNavigate, mockUseLoaderData } = vi.hoisted(() => ({
   mockUseLoaderData: vi.fn(),
 }));
 
+const mockLocationAssign = vi.fn();
+const originalLocation = window.location;
+
 vi.mock('react-router-dom', async () => {
   const actual =
     await vi.importActual<typeof import('react-router-dom')>(
@@ -94,6 +97,10 @@ async function selectRoleAndContinue(roleName: string) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.stubGlobal('location', {
+    ...originalLocation,
+    assign: mockLocationAssign,
+  });
 });
 
 describe('ChurchServingAreaPage', () => {
@@ -120,7 +127,10 @@ describe('ChurchServingAreaPage', () => {
 
     await selectRoleAndContinue('Worship');
 
-    expect(mockNavigate).toHaveBeenCalledWith(
+    expect(mockLocationAssign).toHaveBeenCalledWith(
+      'https://lnk.bio/CFWorshipLinks',
+    );
+    expect(mockNavigate).not.toHaveBeenCalledWith(
       'https://lnk.bio/CFWorshipLinks',
     );
   });

--- a/app/routes/volunteer/church-serving-area/__tests__/church-serving-area-page.test.tsx
+++ b/app/routes/volunteer/church-serving-area/__tests__/church-serving-area-page.test.tsx
@@ -11,8 +11,7 @@ const { mockNavigate, mockUseLoaderData } = vi.hoisted(() => ({
   mockUseLoaderData: vi.fn(),
 }));
 
-const mockLocationAssign = vi.fn();
-const originalLocation = window.location;
+const mockWindowOpen = vi.fn();
 
 vi.mock('react-router-dom', async () => {
   const actual =
@@ -97,10 +96,7 @@ async function selectRoleAndContinue(roleName: string) {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  vi.stubGlobal('location', {
-    ...originalLocation,
-    assign: mockLocationAssign,
-  });
+  vi.stubGlobal('open', mockWindowOpen);
 });
 
 describe('ChurchServingAreaPage', () => {
@@ -127,8 +123,10 @@ describe('ChurchServingAreaPage', () => {
 
     await selectRoleAndContinue('Worship');
 
-    expect(mockLocationAssign).toHaveBeenCalledWith(
+    expect(mockWindowOpen).toHaveBeenCalledWith(
       'https://lnk.bio/CFWorshipLinks',
+      '_blank',
+      'noopener,noreferrer',
     );
     expect(mockNavigate).not.toHaveBeenCalledWith(
       'https://lnk.bio/CFWorshipLinks',

--- a/app/routes/volunteer/church-serving-area/church-serving-area-page.tsx
+++ b/app/routes/volunteer/church-serving-area/church-serving-area-page.tsx
@@ -42,7 +42,7 @@ export function ChurchServingAreaPage() {
       : null;
     if (overrideUrl) {
       if (/^https?:\/\//.test(overrideUrl)) {
-        window.location.assign(overrideUrl);
+        window.open(overrideUrl, '_blank', 'noopener,noreferrer');
         return;
       }
 

--- a/app/routes/volunteer/church-serving-area/church-serving-area-page.tsx
+++ b/app/routes/volunteer/church-serving-area/church-serving-area-page.tsx
@@ -41,6 +41,11 @@ export function ChurchServingAreaPage() {
       ? CHURCH_OPPORTUNITY_OVERRIDES[selectedRole.title.trim().toLowerCase()]
       : null;
     if (overrideUrl) {
+      if (/^https?:\/\//.test(overrideUrl)) {
+        window.location.assign(overrideUrl);
+        return;
+      }
+
       navigate(overrideUrl);
       return;
     }

--- a/app/routes/volunteer/church-serving-area/church-serving-area-page.tsx
+++ b/app/routes/volunteer/church-serving-area/church-serving-area-page.tsx
@@ -14,8 +14,10 @@ import {
 } from './partials/church-serving-area-partials.partial';
 import type { LoaderReturnType } from './loader';
 
-const MISSIONS_OPPORTUNITY_URL =
-  '/volunteer#community';
+const CHURCH_OPPORTUNITY_OVERRIDES: Record<string, string> = {
+  missions: '/volunteer#community',
+  worship: 'https://lnk.bio/CFWorshipLinks',
+};
 
 export function ChurchServingAreaPage() {
   const { bucket, roles } = useLoaderData<LoaderReturnType>();
@@ -35,8 +37,11 @@ export function ChurchServingAreaPage() {
     if (!opportunityId) return;
 
     const selectedRole = roles.find((role) => role.id === opportunityId);
-    if (selectedRole?.title.trim().toLowerCase() === 'missions') {
-      navigate(MISSIONS_OPPORTUNITY_URL);
+    const overrideUrl = selectedRole
+      ? CHURCH_OPPORTUNITY_OVERRIDES[selectedRole.title.trim().toLowerCase()]
+      : null;
+    if (overrideUrl) {
+      navigate(overrideUrl);
       return;
     }
 


### PR DESCRIPTION
## Summary

Add a second church opportunity override so the `Worship` role on the volunteer church-serving page routes to the Christ Fellowship Worship links page instead of the Rock application form.

This builds on the existing Missions override pattern and keeps the default Rock flow for all other church opportunities.

## Screenshots

[Paste your screenshots here]

## Testing

- [ ] What steps can someone follow to verify functionality? (Write out checklist of steps to test)
- Open the volunteer church-serving page for a bucket that includes the `Worship` role.
- Select `Worship` and click `Continue`.
- Confirm navigation goes to `https://lnk.bio/CFWorshipLinks`.
- Select `Missions` and click `Continue`.
- Confirm navigation still goes to `/volunteer#community`.
- Select a non-overridden role such as `Care Team` and click `Continue`.
- Confirm navigation still goes to `/rock-page?embed=church-opportunity&opportunityId=<role-guid>`.
- [ ] Was any new linter/type/test errors/warnings(run `pnpm check` for linter/type/prettier check and `pnpm test` for running tests)?
- Ran `pnpm vitest run app/routes/volunteer/church-serving-area/__tests__/church-serving-area-page.test.tsx`.

## Tickets

CFDP-4097

## Changes Made

### New Components Added

- None.

### New Utilities

- None.

### New Assets

- None.

### Dependencies

- None.

### Route Implementation

- Updated `app/routes/volunteer/church-serving-area/church-serving-area-page.tsx` to use a title-based override map for church opportunities, adding `Worship` while preserving the existing `Missions` override and default Rock form behavior.

### Key Features

- `Worship` now redirects to the Christ Fellowship Worship links page.
- `Missions` continues to redirect to the community volunteer section.
- Added focused coverage in `app/routes/volunteer/church-serving-area/__tests__/church-serving-area-page.test.tsx` for Missions, Worship, and the default Rock flow.
