### PR TITLE
Sermon Series + Classes Finder Fixes

### DIFF
--- a/app/routes/class-finder/class-single/partials/upcoming-sections.partial.tsx
+++ b/app/routes/class-finder/class-single/partials/upcoming-sections.partial.tsx
@@ -404,8 +404,9 @@ function ClassSingleUpcomingResults({
       </h3>
       {ordered.length === 0 ? (
         <p className='text-text-secondary pb-4'>
-          No upcoming sessions match your filters. Try adjusting location or
-          format.
+          {filtersActive
+            ? 'No upcoming sessions match your filters. Try adjusting location or format.'
+            : 'There are no upcoming sessions for this class right now. Check back soon!'}
         </p>
       ) : (
         <div className='flex w-full justify-center md:justify-start'>

--- a/app/routes/class-finder/finder/class-finder.tsx
+++ b/app/routes/class-finder/finder/class-finder.tsx
@@ -17,7 +17,7 @@ export function ClassFinderPage() {
 From topics like building your faith, growing your marriage, managing your finances, finding Freedom, and more–there’s a class for you!'
         />
       </div>
-      <div className='flex flex-col flex-1 w-full'>
+      <div className='flex flex-col flex-1 w-full bg-gray'>
         <ClassSearch />
       </div>
     </div>

--- a/app/routes/class-finder/finder/partials/class-search.partial.tsx
+++ b/app/routes/class-finder/finder/partials/class-search.partial.tsx
@@ -32,6 +32,7 @@ import {
 import { useAlgoliaUrlSync } from '~/hooks/use-algolia-url-sync';
 import { useScrollToSearchResultsOnLoad } from '~/hooks/use-scroll-to-search-results-on-load';
 import { HubsTagsRefinementList } from '~/components/hubs-tags-refinement';
+import { Button } from '~/primitives/button/button.primitive';
 import {
   classFinderEmptyState,
   ClassFinderUrlState,
@@ -273,6 +274,7 @@ export const ClassSearch = () => {
                   interestOnlyHits={interestOnlyHits}
                   filtersActive={finderFiltersActive}
                   fromClassFinderUrl={fromClassFinderUrl}
+                  onClearFilters={clearAllFiltersFromUrl}
                 />
               </div>
             </div>
@@ -300,6 +302,7 @@ export const ClassSearch = () => {
                   interestOnlyHits={interestOnlyHits}
                   filtersActive={finderFiltersActive}
                   fromClassFinderUrl={fromClassFinderUrl}
+                  onClearFilters={clearAllFiltersFromUrl}
                 />
               </div>
             </div>
@@ -317,11 +320,13 @@ function ClassTypeGroupedInstantSearchResults({
   interestOnlyHits,
   filtersActive,
   fromClassFinderUrl,
+  onClearFilters,
 }: {
   initialHits: ClassHitType[];
   interestOnlyHits: ClassHitType[];
   filtersActive: boolean;
   fromClassFinderUrl?: string;
+  onClearFilters: () => void;
 }) {
   const { items } = useHits<ClassHitType>();
   const { status } = useInstantSearch();
@@ -339,6 +344,7 @@ function ClassTypeGroupedInstantSearchResults({
       interestOnlyHits={interestOnlyHits}
       filtersActive={filtersActive}
       fromClassFinderUrl={fromClassFinderUrl}
+      onClearFilters={onClearFilters}
     />
   );
 }
@@ -349,12 +355,14 @@ function ClassTypeGroupedResults({
   interestOnlyHits,
   filtersActive,
   fromClassFinderUrl,
+  onClearFilters,
 }: {
   hits: ClassHitType[];
   isLoading: boolean;
   interestOnlyHits: ClassHitType[];
   filtersActive: boolean;
   fromClassFinderUrl?: string;
+  onClearFilters: () => void;
 }) {
   const [currentPage, setCurrentPage] = useState(1);
   const [searchParams] = useSearchParams();
@@ -417,6 +425,8 @@ function ClassTypeGroupedResults({
     setCurrentPage(1);
   }, [mappedHits.length]);
 
+  const noResults = filtersActive && !isLoading && mappedHits.length === 0;
+
   return (
     <>
       <div
@@ -426,25 +436,39 @@ function ClassTypeGroupedResults({
       >
         <FinderResultsStats hitCount={mappedHits.length} />
 
-        <div className='flex w-full items-center justify-center md:items-start md:justify-start'>
-          <div className='grid w-full max-w-[900px] items-stretch lg:max-w-[1296px] gap-y-6 sm:gap-x-8 md:gap-y-8 lg:gap-x-4 lg:gap-y-16 xl:gap-x-8! grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4'>
-            {pageHits.map((hit) => (
-              <ClassHitComponent
-                key={hit.objectID}
-                hit={hit}
-                fromClassFinderUrl={fromClassFinderUrl}
-              />
-            ))}
+        {noResults ? (
+          <div className='flex flex-col items-center gap-4 py-8 text-center'>
+            <p className='text-text-secondary'>
+              No classes match your search. Try adjusting your filters, or
+              browse all classes.
+            </p>
+            <Button intent='secondary' size='md' onClick={onClearFilters}>
+              Clear All Filters
+            </Button>
           </div>
-        </div>
+        ) : (
+          <div className='flex w-full items-center justify-center md:items-start md:justify-start'>
+            <div className='grid w-full max-w-[900px] items-stretch lg:max-w-[1296px] gap-y-6 sm:gap-x-8 md:gap-y-8 lg:gap-x-4 lg:gap-y-16 xl:gap-x-8! grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4'>
+              {pageHits.map((hit) => (
+                <ClassHitComponent
+                  key={hit.objectID}
+                  hit={hit}
+                  fromClassFinderUrl={fromClassFinderUrl}
+                />
+              ))}
+            </div>
+          </div>
+        )}
       </div>
 
-      <ClassSearchPagination
-        totalItems={mappedHits.length}
-        itemsPerPage={ITEMS_PER_PAGE}
-        currentPage={currentPage}
-        onPageChange={setCurrentPage}
-      />
+      {!noResults && (
+        <ClassSearchPagination
+          totalItems={mappedHits.length}
+          itemsPerPage={ITEMS_PER_PAGE}
+          currentPage={currentPage}
+          onPageChange={setCurrentPage}
+        />
+      )}
     </>
   );
 }

--- a/app/routes/series-resources/series-resources-page.tsx
+++ b/app/routes/series-resources/series-resources-page.tsx
@@ -64,12 +64,14 @@ export function SeriesResourcesPage() {
         )}
 
         {/* Series Messages */}
-        <SeriesResourceCarousel
-          type='messages'
-          title='Series Messages'
-          items={messages}
-          bg='gray'
-        />
+        {messages && messages.length > 0 && (
+          <SeriesResourceCarousel
+            type='messages'
+            title='Series Messages'
+            items={messages}
+            bg='gray'
+          />
+        )}
 
         {/* Resources Section */}
         {resources && resources.length > 0 && (

--- a/app/routes/yes/components/yes-devotional-hero.component.tsx
+++ b/app/routes/yes/components/yes-devotional-hero.component.tsx
@@ -58,8 +58,8 @@ const heroCardData: { link: string; copy: string }[] = [
 
 const spanishHeroCardData: { link: string; copy: string }[] = [
   {
-    link: googleLink,
-    copy: 'Un curso de dos semanas para comenzar tu relación con Jesús.',
+    link: '#devo',
+    copy: 'Un curso de tres semanas para comenzar tu relación con Jesús.',
   },
   {
     link: googleLink,


### PR DESCRIPTION
## Summary
This PR updates Classes Finder and Sermon Series pages to fix minor bugs, read below for more.

## Screenshots


## Testing
- [x] Classes Finder - no white bar under search & when no results it gives a messages and there is a clear all filters button. [Example](https://remix-web-app-git-sermon-series-39e331-christ-fellowship-church.vercel.app/class-finder?q=freedom)
- [x] Classes Single - when no sessions are set for that class the copy on the no results should reflect that instead of hinting that the filters are filtering out classes. [Example](https://remix-web-app-git-sermon-series-39e331-christ-fellowship-church.vercel.app/class-finder-freedom)
- [x] Sermon Series Messages - when a series has no messages yet it does not show the messages section. [Example](https://remix-web-app-git-sermon-series-39e331-christ-fellowship-church.vercel.app/series-resources/moses)
- [x] /dijiste-si/devocional says "tres" instead of "dos" and anchors down.

## Tickets

[CFDP-4092](https://christfellowshipchurch.atlassian.net/browse/CFDP-4092)
[CFDP-4101](https://christfellowshipchurch.atlassian.net/browse/CFDP-4101)

## Changes Made

### Route Implementation

- **`app/routes/series-resources/series-resources-page.tsx`** — Wrapped the "Series Messages" carousel in a `messages && messages.length > 0` guard so the section is hidden entirely when a series has no messages yet, matching the existing empty-state pattern already used for the Events and Related Resources sections on the same page.

- **`app/routes/class-finder/finder/class-finder.tsx`** — Added `bg-gray` to the flex-1 wrapper around `ClassSearch` so the results area's background fills the full viewport height instead of leaving a white gap below short result sets.

- **`app/routes/class-finder/finder/partials/class-search.partial.tsx`** — Added a no-results empty state to the class search results grid:
  - Threaded an `onClearFilters` callback down through `ClassTypeGroupedInstantSearchResults` → `ClassTypeGroupedResults`, reusing the existing `clearAllFiltersFromUrl` handler.
  - When a preloaded/active filter (e.g. `?q=freedom`) returns zero results, the results grid and pagination are replaced with a message ("No classes match your search...") and a **Clear All Filters** button that resets the URL back to the unfiltered Class Finder.

### Key Features

- Sermon Series pages no longer show an empty "Series Messages" section when a series has no messages.
- Class Finder now gives clear, actionable feedback (message + reset button) when a preloaded filter/search returns no results, instead of showing a blank grid.
- Fixed a layout bug where the Class Finder results area showed a white background gap below short result sets instead of the expected gray background.

[CFDP-4092]: https://christfellowshipchurch.atlassian.net/browse/CFDP-4092?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CFDP-4101]: https://christfellowshipchurch.atlassian.net/browse/CFDP-4101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ