### PR TITLE
Update Spanish devotional hero card to scroll to section

### DIFF
--- a/app/routes/yes/components/__tests__/yes-devotional-hero.component.test.tsx
+++ b/app/routes/yes/components/__tests__/yes-devotional-hero.component.test.tsx
@@ -61,4 +61,17 @@ describe('YesHero', () => {
       getCardLink('Descarga la app de la Biblia YouVersion gratis'),
     ).toHaveAttribute('href', 'https://www.bible.com/app');
   });
+
+  it('scrolls to the devotional section for the Spanish card instead of opening a new tab', () => {
+    render(<YesHero isSpanish />);
+
+    const devotionalLink = getCardLink(
+      'Un curso de tres semanas para comenzar tu relación con Jesús.',
+    );
+    expect(devotionalLink).toHaveAttribute('href', '#devo');
+    expect(devotionalLink).not.toHaveAttribute('target', '_blank');
+
+    fireEvent.click(devotionalLink);
+    expect(scrollToAnchor).toHaveBeenCalledWith('devo');
+  });
 });

--- a/app/routes/yes/components/yes-devotional-hero.component.tsx
+++ b/app/routes/yes/components/yes-devotional-hero.component.tsx
@@ -58,8 +58,8 @@ const heroCardData: { link: string; copy: string }[] = [
 
 const spanishHeroCardData: { link: string; copy: string }[] = [
   {
-    link: googleLink,
-    copy: 'Un curso de dos semanas para comenzar tu relación con Jesús.',
+    link: '#devo',
+    copy: 'Un curso de tres semanas para comenzar tu relación con Jesús.',
   },
   {
     link: googleLink,


### PR DESCRIPTION
## Summary

Updated the Spanish language devotional hero card to scroll to the devotional section (`#devo`) instead of opening Google Play in a new tab. Also corrected the course duration from "dos semanas" (two weeks) to "tres semanas" (three weeks) to match the actual content.

## Changes Made

### Component Updates
- **app/routes/yes/components/yes-devotional-hero.component.tsx**
  - Changed Spanish hero card link from `googleLink` to `'#devo'` for anchor-based navigation
  - Updated Spanish card copy from "Un curso de dos semanas..." to "Un curso de tres semanas..."

### Test Updates
- **app/routes/yes/components/__tests__/yes-devotional-hero.component.test.tsx**
  - Added test case verifying Spanish card scrolls to devotional section
  - Confirms link has `href="#devo"` and no `target="_blank"` attribute
  - Verifies `scrollToAnchor('devo')` is called on click

## Testing

- [x] Added unit test covering the new behavior
- [x] Test verifies both the link target and the scroll function invocation
- [x] Existing tests continue to pass

The new test encodes the intent: Spanish users should be scrolled to the devotional content rather than redirected to an app store, improving the in-page user experience.

https://claude.ai/code/session_01Mbk1Ey3vvNJsT7NREPPTJq