### PR TITLE
Español Page Breadcrumbs Hardcoding

### DIFF
--- a/app/components/breadcrumbs/__tests__/index.test.tsx
+++ b/app/components/breadcrumbs/__tests__/index.test.tsx
@@ -114,4 +114,27 @@ describe('Breadcrumbs', () => {
     expect(screen.getByText('Test Path')).toBeInTheDocument();
     expect(screen.getByText('Another Segment')).toBeInTheDocument();
   });
+
+  it('maps known ASCII slugs to accented breadcrumb labels', () => {
+    render(
+      <MemoryRouter initialEntries={['/ministries/espanol']}>
+        <Breadcrumbs />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('Ministries')).toBeInTheDocument();
+    expect(screen.getByText('Español')).toBeInTheDocument();
+    expect(screen.queryByText('Espanol')).not.toBeInTheDocument();
+    expect(screen.getByText('Español')).toHaveAttribute('aria-current', 'page');
+  });
+
+  it('leaves unmapped ministry slugs capitalized from the URL', () => {
+    render(
+      <MemoryRouter initialEntries={['/ministries/young-adults']}>
+        <Breadcrumbs />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('Young Adults')).toBeInTheDocument();
+  });
 });

--- a/app/components/breadcrumbs/index.tsx
+++ b/app/components/breadcrumbs/index.tsx
@@ -5,6 +5,25 @@ interface BreadcrumbsProps {
   mode?: 'light' | 'dark';
 }
 
+/**
+ * ASCII slug → display label for breadcrumbs when capitalization alone
+ * cannot recover accents (e.g. `espanol` → `Español`). URLs stay unchanged.
+ */
+const BREADCRUMB_SLUG_LABELS: Record<string, string> = {
+  espanol: 'Español',
+};
+
+function breadcrumbLabelFromSegment(segment: string): string {
+  const decoded = decodeURIComponent(segment);
+  const mapped = BREADCRUMB_SLUG_LABELS[decoded.toLowerCase()];
+  if (mapped) return mapped;
+
+  return decoded
+    .split('-')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
 export function Breadcrumbs({ mode = 'dark' }: BreadcrumbsProps) {
   const location = useLocation();
   const pathSegments = location.pathname.split('/').filter(Boolean);
@@ -14,11 +33,7 @@ export function Breadcrumbs({ mode = 'dark' }: BreadcrumbsProps) {
   const breadcrumbs = pathSegments.map((segment, index) => {
     const path = `/${pathSegments.slice(0, index + 1).join('/')}`;
     const isCurrentPage = index === pathSegments.length - 1;
-    const pageName = segment
-      .split('-')
-      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-      .join(' ');
-    const label = decodeURIComponent(pageName);
+    const label = breadcrumbLabelFromSegment(segment);
 
     return (
       <div

--- a/app/components/breadcrumbs/index.tsx
+++ b/app/components/breadcrumbs/index.tsx
@@ -6,13 +6,20 @@ interface BreadcrumbsProps {
 }
 
 /**
- * ASCII slug → display label for breadcrumbs when capitalization alone
- * cannot recover accents (e.g. `espanol` → `Español`). URLs stay unchanged.
+ * Explicit ASCII slug → breadcrumb display label.
+ *
+ * Breadcrumb text is URL-derived (capitalize the path segment). That cannot
+ * invent accents: `/ministries/espanol` would otherwise show "Espanol". Putting
+ * `ñ` in the Rock Pathname also breaks the ministry loader (exact Pathname
+ * match), so keep the ASCII URL and override display here only.
+ *
+ * Add entries sparingly when a slug needs characters capitalization cannot restore.
  */
 const BREADCRUMB_SLUG_LABELS: Record<string, string> = {
   espanol: 'Español',
 };
 
+/** Prefer a slug map label; otherwise decode + title-case hyphenated segments. */
 function breadcrumbLabelFromSegment(segment: string): string {
   const decoded = decodeURIComponent(segment);
   const mapped = BREADCRUMB_SLUG_LABELS[decoded.toLowerCase()];

--- a/app/routes/ministries/loader.ts
+++ b/app/routes/ministries/loader.ts
@@ -10,7 +10,14 @@ export type Ministry = {
   url: string;
 };
 
-/** Spanish ministry pages are listed separately; keep them off the main ministries index. */
+/**
+ * Hide Spanish / Español ministry cards from the `/ministries` index grid.
+ *
+ * The Español ministry page still lives at `/ministries/espanol` (ministry
+ * builder + Rock Pathname `espanol`). It should not appear as a card on the
+ * main ministries listing, which is English-facing. Match both "Español" and
+ * ASCII "espanol" / "Espanol" because Rock titles may use either form.
+ */
 const isEspanolMinistryTitle = (title: string): boolean => {
   const lower = title.toLowerCase();
   return title.includes('Español') || lower.includes('espanol');
@@ -76,6 +83,7 @@ export const loader: LoaderFunction = async (): Promise<{
       ministriesArray = ministriesData;
     }
 
+    // Drop Español from the index after mapping (+ hard-coded cards); page stays reachable by URL.
     const ministries = [
       ...(await mapMinistryChannelItems(ministriesArray)),
       ...hardCodedMinistries,


### PR DESCRIPTION
## Summary

Breadcrumb labels are derived from the URL path (ASCII slug capitalized), so `/ministries/espanol` previously showed **Espanol** instead of **Español**. Changing the Rock pathname to include `ñ` breaks the page lookup, and inventing accents from ASCII generally is not safe.

This change keeps the public URL as `/ministries/espanol` and adds a small, explicit slug → display map in `Breadcrumbs` so the visible label can show **Español**. Unmapped ministry slugs continue to use the existing capitalize-from-slug behavior.

## Screenshots
|Before|After|
|-|-|
|<img width="324" height="98" alt="Screenshot 2026-07-08 at 9 51 15 AM" src="https://github.com/user-attachments/assets/300d7367-a2ff-457e-8459-27a2e50904a8" />|<img width="394" height="108" alt="Screenshot 2026-07-08 at 9 50 55 AM" src="https://github.com/user-attachments/assets/fc4488b5-1a8b-4ade-b7cf-b4597bb053e4" />|

## Testing

- [ ] Run `pnpm check` — no linter/type/prettier errors
- [ ] Visit `/ministries/espanol` and confirm the page still loads
- [ ] Confirm breadcrumbs show **Español** (not **Espanol**)
- [ ] Confirm the URL remains `/ministries/espanol`
- [ ] Visit another ministry (e.g. `/ministries/young-adults`) and confirm breadcrumb labeling is unchanged

## Tickets
[CFDP-4127](https://christfellowshipchurch.atlassian.net/browse/CFDP-4127)

## Changes Made

### New Components Added

- None

### New Utilities

- `breadcrumbLabelFromSegment()` in `app/components/breadcrumbs/index.tsx` — resolves a path segment to a breadcrumb label via an optional map, then falls back to capitalize-from-slug
- `BREADCRUMB_SLUG_LABELS` in `app/components/breadcrumbs/index.tsx` — explicit ASCII slug → display label map (`espanol` → `Español`)

### New Assets

- None

### Dependencies

- None

### Route Implementation

- None — breadcrumbs only; ministry route/loader and Rock Pathname lookup are unchanged

### Key Features

- Breadcrumb on `/ministries/espanol` displays **Español** while the URL stays ASCII
- Other breadcrumb segments and ministries keep existing slug-based labeling
- Coverage for mapped vs unmapped ministry slug behavior in `app/components/breadcrumbs/__tests__/index.test.tsx`

[CFDP-4127]: https://christfellowshipchurch.atlassian.net/browse/CFDP-4127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ