### PR TITLE
Impact Offering redirect

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -12,6 +12,11 @@
       "statusCode": 301
     },
     {
+      "source": "/events/impact-offering",
+      "destination": "https://www.impactoffering.church/",
+      "statusCode": 301
+    },
+    {
       "source": "/articles/give-to-the-crisis-fund",
       "destination": "/give-to-the-crisis-fund",
       "statusCode": 301


### PR DESCRIPTION
## Summary

Adds a permanent redirect so `/events/impact-offering` sends traffic to the Impact Offering campaign site at [https://www.impactoffering.church/](https://www.impactoffering.church/). Visitors and shared links to the old event URL should land on the current giving experience instead of a stale event page.

## Screenshots

N/A

## Testing

- [ ] Confirm `vercel.json` includes the `/events/impact-offering` → `https://www.impactoffering.church/` redirect with status `301`
- [ ] After deploy to a Vercel preview/production environment, open `/events/impact-offering` and confirm a `301` to `https://www.impactoffering.church/`
- [ ] Confirm the destination Impact Offering site loads as expected
- [ ] `pnpm check`  — no errors or warnings

## Tickets

[insert Jira ticket reference here]

## Changes Made

### New Components Added

- None

### New Utilities

- None

### New Assets

- None

### Dependencies

- None

### Route Implementation

- `vercel.json` — added redirect:
  - Source: `/events/impact-offering`
  - Destination: `https://www.impactoffering.church/`
  - Status: `301`

### Key Features

- Permanent redirect from the legacy Impact Offering event URL to the campaign site
- Matches existing event redirect pattern (e.g. `/events/terremoto-venezuela`)