### PR TITLE
Online campus sorting update in locations finder

### DIFF
--- a/app/routes/locations/location-search/partials/__tests__/location-card-list.partial.test.ts
+++ b/app/routes/locations/location-search/partials/__tests__/location-card-list.partial.test.ts
@@ -37,18 +37,18 @@ function createCampusHit(
 }
 
 describe('getLocationCardDisplayItems', () => {
-  it('keeps the online campus first on the /location page', () => {
+  it('shows the online campus last when no distance info is available', () => {
     const onlineCampus = createCampusHit('cf-everywhere');
     const nearbyCampus = createCampusHit('nearby');
 
     const displayItems = getLocationCardDisplayItems([
-      nearbyCampus,
       onlineCampus,
+      nearbyCampus,
     ]);
 
     expect(displayItems.map((hit) => hit.campusUrl)).toEqual([
-      'cf-everywhere',
       'nearby',
+      'cf-everywhere',
     ]);
   });
 
@@ -66,14 +66,14 @@ describe('getLocationCardDisplayItems', () => {
     ]);
 
     expect(displayItems.map((hit) => hit.campusUrl)).toEqual([
-      'cf-everywhere',
       'first',
       'second',
       'third',
+      'cf-everywhere',
     ]);
   });
 
-  it('keeps online first after a zip or GPS search (physical hits stay in input order)', () => {
+  it('shows online last when the closest campus is within 80 miles', () => {
     const onlineCampus = createCampusHit('cf-everywhere', { geoDistance: 100 });
     const nearbyCampus = createCampusHit('nearby', {
       geoDistance: 5 * 1609.344,
@@ -90,9 +90,30 @@ describe('getLocationCardDisplayItems', () => {
     );
 
     expect(displayItems.map((hit) => hit.campusUrl)).toEqual([
-      'cf-everywhere',
       'nearby',
       'farther',
+      'cf-everywhere',
+    ]);
+  });
+
+  it('shows online first when the closest campus is over 80 miles away', () => {
+    const onlineCampus = createCampusHit('cf-everywhere', { geoDistance: 100 });
+    const fartherCampus = createCampusHit('farther', {
+      geoDistance: 100 * 1609.344,
+    });
+    const farthestCampus = createCampusHit('farthest', {
+      geoDistance: 200 * 1609.344,
+    });
+
+    const displayItems = getLocationCardDisplayItems(
+      [fartherCampus, farthestCampus, onlineCampus],
+      { sortByGeo: true },
+    );
+
+    expect(displayItems.map((hit) => hit.campusUrl)).toEqual([
+      'cf-everywhere',
+      'farther',
+      'farthest',
     ]);
   });
 });

--- a/app/routes/locations/location-search/partials/location-card-list.partial.tsx
+++ b/app/routes/locations/location-search/partials/location-card-list.partial.tsx
@@ -103,11 +103,30 @@ function sortPhysicalCampusesByOrder(items: CampusHit[]) {
   );
 }
 
+const METERS_PER_MILE = 1609.344;
+const ONLINE_FIRST_DISTANCE_THRESHOLD_MILES = 80;
+const onlineFirstDistanceThresholdMeters =
+  ONLINE_FIRST_DISTANCE_THRESHOLD_MILES * METERS_PER_MILE;
+
+function getClosestPhysicalDistanceMeters(items: CampusHit[]) {
+  return items.reduce<number | null>((closestDistance, item) => {
+    const distance = item._rankingInfo?.geoDistance;
+    if (typeof distance !== 'number' || !Number.isFinite(distance)) {
+      return closestDistance;
+    }
+
+    return closestDistance === null
+      ? distance
+      : Math.min(closestDistance, distance);
+  }, null);
+}
+
 /**
- * /location (Location Search page) always lists the Online campus first, then
- * physical campuses by Algolia `order` (default) or by distance when coordinates
- * are set. Home/nav location popups use different rules via
- * `sortCampusHitsForDistanceSearch`.
+ * /location (Location Search page) lists physical campuses by Algolia `order`
+ * (default) or by distance when coordinates are set, with the Online campus
+ * last — unless the closest physical campus is over
+ * ONLINE_FIRST_DISTANCE_THRESHOLD_MILES away, in which case Online is first.
+ * Mirrors the home hero's `sortCampusHitsForDistanceSearch`.
  */
 export function getLocationCardDisplayItems(
   items: CampusHit[],
@@ -119,7 +138,17 @@ export function getLocationCardDisplayItems(
     ? physicalItems
     : sortPhysicalCampusesByOrder(physicalItems);
 
-  return [...onlineItems, ...sortedPhysicalItems];
+  const closestPhysicalDistanceMeters =
+    getClosestPhysicalDistanceMeters(physicalItems);
+
+  if (
+    closestPhysicalDistanceMeters != null &&
+    closestPhysicalDistanceMeters > onlineFirstDistanceThresholdMeters
+  ) {
+    return [...onlineItems, ...sortedPhysicalItems];
+  }
+
+  return [...sortedPhysicalItems, ...onlineItems];
 }
 
 export function LocationCardGrid({

--- a/app/routes/locations/location-search/partials/locations-search-hero.partial.tsx
+++ b/app/routes/locations/location-search/partials/locations-search-hero.partial.tsx
@@ -82,7 +82,7 @@ export const Search = ({
   };
 
   return (
-    <div className='flex h-[80vh] w-full items-center justify-center md:h-[78vh]'>
+    <div className='flex h-[90vh] w-full items-center justify-center md:h-[78vh]'>
       <div className='relative flex size-full overflow-hidden text-pretty'>
         <div
           ref={heroVideoMountRef}


### PR DESCRIPTION
## Summary

On the `/locations` finder, the Online (CF Everywhere) campus was always pinned to the top of the list. Per CFDP-4128, Online should only show first when the visitor is genuinely far from every physical campus — otherwise it should show last.

This ports the same rule the home page hero finder already uses (`sortCampusHitsForDistanceSearch`): Online now renders **last** by default, and moves to **first** only when the closest physical campus is more than **80 miles** away (based on Algolia `geoDistance` after a zip or GPS search). With no distance info (default browse, no search), Online shows last. The threshold lives in `ONLINE_FIRST_DISTANCE_THRESHOLD_MILES` and is a one-line change. UI is unchanged — only card ordering.

## Screenshots

[Paste your screenshots here]

## Testing

- [x] Visit `/locations` with no search — Online (CF Everywhere) appears last, physical campuses sorted by their Algolia `order`
- [x] Search zip `33418` (Palm Beach Gardens, closest campus ~4 mi) — campuses sorted by distance, Online last
- [x] Search zip `32801` (Orlando, closest campus ~87 mi) — Online first, then campuses by distance
- [x] No new linter warnings or errors when running `pnpm check`

## Tickets

[CFDP-4128](https://christfellowshipchurch.atlassian.net/browse/CFDP-4128)

## Changes Made

### New Components Added

- None

### New Utilities

- `getClosestPhysicalDistanceMeters()` in `app/routes/locations/location-search/partials/location-card-list.partial.tsx` — finds the nearest physical campus from Algolia `_rankingInfo.geoDistance`, mirroring the home hero's implementation

### New Assets

- None

### Dependencies

- None

### Route Implementation

- `app/routes/locations/location-search/partials/location-card-list.partial.tsx` — `getLocationCardDisplayItems()` now appends Online last, flipping it to first only when the closest physical campus exceeds the 80-mile threshold (`ONLINE_FIRST_DISTANCE_THRESHOLD_MILES`)
- `app/routes/locations/location-search/partials/__tests__/location-card-list.partial.test.ts` — tests updated for the new rule, plus a new case covering the over-80-miles flip

### Key Features

- Online campus no longer crowds out nearby physical campuses at the top of the finder
- Visitors far from any campus (80+ mi) still see Online surfaced first
- Behavior now consistent with the home page hero location finder

[CFDP-4128]: https://christfellowshipchurch.atlassian.net/browse/CFDP-4128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ