### PR TITLE
Three Days Journey

### DIFF
--- a/app/routes/events/event-single/components/clickable-card.component.tsx
+++ b/app/routes/events/event-single/components/clickable-card.component.tsx
@@ -77,7 +77,7 @@ export const ClickableCard = ({
               e.stopPropagation();
               onClick();
             }}
-            className='mt-auto w-full bg-ocean text-white px-4 py-2 rounded-lg font-semibold text-sm hover:bg-ocean-dark transition-colors'
+            className='mt-auto w-full cursor-pointer bg-ocean text-white px-4 py-2 rounded-lg font-semibold text-sm hover:bg-ocean-dark transition-colors'
           >
             {buttonText}
           </button>

--- a/app/routes/events/event-single/components/clickthrough-registration.component.tsx
+++ b/app/routes/events/event-single/components/clickthrough-registration.component.tsx
@@ -24,6 +24,7 @@ import {
   eventFinderDatesMatch,
   formatEventFinderDateLabel,
   formatEventFinderDatesDisplay,
+  joinEventFinderDateLabels,
   normalizeEventFinderDates,
   parseSerializedEventFinderDates,
   serializeEventFinderDates,
@@ -736,9 +737,9 @@ const DateStep = ({
     <div className='flex flex-wrap justify-center gap-4'>
       {uniqueDates.map((dateInfo) => {
         const dateKey = serializeEventFinderDates(dateInfo.dates);
-        const title = dateInfo.dates
-          .map(formatEventFinderDateLabel)
-          .join(' & ');
+        const title = joinEventFinderDateLabels(
+          dateInfo.dates.map(formatEventFinderDateLabel),
+        );
 
         return (
           <ClickableCard

--- a/app/routes/events/event-single/event-finder-dates.ts
+++ b/app/routes/events/event-single/event-finder-dates.ts
@@ -55,6 +55,14 @@ export const formatEventFinderDateLabel = (dateString: string): string => {
   return `${monthName} ${dayNum}${suffix}`;
 };
 
+export const joinEventFinderDateLabels = (labels: string[]): string => {
+  if (labels.length === 0) return '';
+  if (labels.length === 1) return labels[0];
+
+  const allButLast = labels.slice(0, -1).join(', ');
+  return `${allButLast} & ${labels[labels.length - 1]}`;
+};
+
 export const formatEventFinderDatesDisplay = (
   dates: string[],
   day?: string,
@@ -62,8 +70,8 @@ export const formatEventFinderDatesDisplay = (
   const normalizedDates = normalizeEventFinderDates(dates);
   if (normalizedDates.length === 0) return '';
 
-  const dateLabels = normalizedDates
-    .map(formatEventFinderDateLabel)
-    .join(' & ');
+  const dateLabels = joinEventFinderDateLabels(
+    normalizedDates.map(formatEventFinderDateLabel),
+  );
   return day ? `${day} ${dateLabels}` : dateLabels;
 };

--- a/app/routes/events/event-single/registration.data.ts
+++ b/app/routes/events/event-single/registration.data.ts
@@ -24,7 +24,7 @@ export const subGroupTypeDescriptions: Record<string, SubGroupTypeDescription> =
     },
     'Three Days': {
       description:
-        'Join us for a three-part conversation, where you will Know God, Grow in your Relationships, Discover your Purpose & partner together as we Impact the World.',
+        'The Journey is the starting point to learn the heartbeat of Christ Fellowship. Join us for a three-part experience in which you will Know God, Grow in your Relationships, Discover your Purpose, & partner with us as we Impact the World together.',
     },
   };
 

--- a/app/routes/events/event-single/registration.data.ts
+++ b/app/routes/events/event-single/registration.data.ts
@@ -22,6 +22,10 @@ export const subGroupTypeDescriptions: Record<string, SubGroupTypeDescription> =
       description:
         'Join us for a two-session conversation, where you will Know God, Grow in your Relationships, Discover your Purpose & partner together as we Impact the World. Bonus! Session 2 of Journey will include Dream Team Kickoff. Childcare is available through our regularly scheduled CFKids programming',
     },
+    'Three Days': {
+      description:
+        'Join us for a three-part conversation, where you will Know God, Grow in your Relationships, Discover your Purpose & partner together as we Impact the World.',
+    },
   };
 
 // Spanish descriptions per CFDP-4104. 'Two Days' uses the translation
@@ -38,6 +42,10 @@ export const spanishSubGroupTypeDescriptions: Record<
   'Two Days with Dream Team Kickoff': {
     description:
       '¡Journey es el primer paso para conectarte a Christ Fellowship! Es una clase de dos sesiones donde aprenderás sobre la historia y el corazón de nuestra iglesia. Durante esta experiencia, nuestra oración es que conozcas a Dios, crezcas en tu relación personal con Él y con otros para que puedas descubrir tu propósito e impactar al mundo. ¡Bono! La sesión 2 de Journey incluirá Dream Team Kickoff. Hay cuidado de niños disponible a través de nuestra programación regular de CFKids.',
+  },
+  'Three Days': {
+    description:
+      '¡Journey es el primer paso para conectarte a Christ Fellowship! Es una clase de tres sesiones donde aprenderás sobre la historia y el corazón de nuestra iglesia. Durante esta experiencia, nuestra oración es que conozcas a Dios, crezcas en tu relación personal con Él y con otros para que puedas descubrir tu propósito e impactar al mundo.',
   },
 };
 

--- a/app/routes/events/event-single/tests/registration.data.test.ts
+++ b/app/routes/events/event-single/tests/registration.data.test.ts
@@ -13,4 +13,16 @@ describe('getSubGroupTypeDescription', () => {
       '¡Journey es el primer paso para conectarte a Christ Fellowship! Es una clase de dos sesiones donde aprenderás sobre la historia y el corazón de nuestra iglesia. Durante esta experiencia, nuestra oración es que conozcas a Dios, crezcas en tu relación personal con Él y con otros para que puedas descubrir tu propósito e impactar al mundo.',
     );
   });
+
+  it('returns the English Three Days description by default', () => {
+    expect(getSubGroupTypeDescription('Three Days')).toBe(
+      'Join us for a three-part conversation, where you will Know God, Grow in your Relationships, Discover your Purpose & partner together as we Impact the World.',
+    );
+  });
+
+  it('returns the Spanish Three Days translation when isSpanish is true', () => {
+    expect(getSubGroupTypeDescription('Three Days', true)).toBe(
+      '¡Journey es el primer paso para conectarte a Christ Fellowship! Es una clase de tres sesiones donde aprenderás sobre la historia y el corazón de nuestra iglesia. Durante esta experiencia, nuestra oración es que conozcas a Dios, crezcas en tu relación personal con Él y con otros para que puedas descubrir tu propósito e impactar al mundo.',
+    );
+  });
 });

--- a/app/routes/events/event-single/tests/registration.data.test.ts
+++ b/app/routes/events/event-single/tests/registration.data.test.ts
@@ -16,7 +16,7 @@ describe('getSubGroupTypeDescription', () => {
 
   it('returns the English Three Days description by default', () => {
     expect(getSubGroupTypeDescription('Three Days')).toBe(
-      'Join us for a three-part conversation, where you will Know God, Grow in your Relationships, Discover your Purpose & partner together as we Impact the World.',
+      'The Journey is the starting point to learn the heartbeat of Christ Fellowship. Join us for a three-part experience in which you will Know God, Grow in your Relationships, Discover your Purpose, & partner with us as we Impact the World together.',
     );
   });
 

--- a/app/routes/podcasts/all-podcasts/components/podcast-card.tsx
+++ b/app/routes/podcasts/all-podcasts/components/podcast-card.tsx
@@ -89,7 +89,7 @@ export function PodcastHubCard({ podcast, className = '' }: PodcastCardProps) {
 
   const platformLinks: PlatformLink[] = [
     {
-      label: 'Apple Music',
+      label: 'Apple Podcasts',
       icon: 'appleLogo',
       href: apple,
     },

--- a/app/routes/podcasts/podcast-show/partials/subscribe-section.partial.tsx
+++ b/app/routes/podcasts/podcast-show/partials/subscribe-section.partial.tsx
@@ -16,7 +16,7 @@ export const SubscribeSection = ({
 }) => {
   const links = [
     {
-      label: 'Apple Music',
+      label: 'Apple Podcasts',
       icon: 'appleLogo',
       href: apple,
     },


### PR DESCRIPTION
## Summary

Adds support for **three-day Journey sessions** in the Event Finder / registration flow (CFDP-4106), and fixes a mislabeled podcast platform link (CFDP-4116).

- Introduces a new `Three Days` sub-group type with English + Spanish card descriptions.
- Extracts date-label joining into a shared `joinEventFinderDateLabels` helper so 3+ dates render with an Oxford-style separator (e.g. `Jan 1, Jan 2 & Jan 3`) instead of only handling two dates.
- Fixes the podcast subscribe link labeled "Apple Music" → "Apple Podcasts" (the link/icon already pointed at the correct Apple Podcasts data).

## Screenshots

N/A

## Testing

- [x] Run `pnpm check` (lint/type/prettier) and `pnpm test` — added unit tests for the `Three Days` descriptions (English default + Spanish).
- [x] In the Event Finder, select a Journey event configured as a three-day session and confirm the date card renders all three dates joined as `<date>, <date> & <date>`.
- [x] Confirm the `Three Days` card shows the correct description in both English and Spanish.
- [x] On the podcast show page and the all-podcasts cards, confirm the Apple link now reads **"Apple Podcasts"** and still opens the correct Apple Podcasts URL.

## Tickets

- https://christfellowshipchurch.atlassian.net/browse/CFDP-4106
- https://christfellowshipchurch.atlassian.net/browse/CFDP-4116

## Changes Made

### New Utilities

- `joinEventFinderDateLabels(labels: string[])` in `app/routes/events/event-single/event-finder-dates.ts` — joins date labels with commas and a final `&`, handling 0, 1, 2, and 3+ label cases. Now used by both `formatEventFinderDatesDisplay` and the `DateStep` card title.

### Route Implementation

- `app/routes/events/event-single/registration.data.ts` — added `Three Days` entries to `subGroupTypeDescriptions` (English) and `spanishSubGroupTypeDescriptions` (Spanish).
- `app/routes/events/event-single/components/clickthrough-registration.component.tsx` — date-step card title now uses `joinEventFinderDateLabels`.
- `app/routes/events/event-single/components/clickable-card.component.tsx` — added `cursor-pointer` to the card button.
- `app/routes/podcasts/podcast-show/partials/subscribe-section.partial.tsx` and `app/routes/podcasts/all-podcasts/components/podcast-card.tsx` — label `Apple Music` → `Apple Podcasts` (CFDP-4116).

### Tests

- `app/routes/events/event-single/tests/registration.data.test.ts` — added cases for the English default and Spanish `Three Days` descriptions.

### Other

- `vercel.json` — removed the `/ministry-breakout-presentations-and-resources` → `/link-tree/...` redirect. *(Not part of CFDP-4106/4116 — flagging for reviewer awareness.)*

### Dependencies

- None.