### PR TITLE
Home Location Search Update

### DIFF
--- a/app/routes/home/components/location-search/__tests__/location-search-results.test.ts
+++ b/app/routes/home/components/location-search/__tests__/location-search-results.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, it } from 'vitest';
 
-import { sortCampusHitsForDistanceSearch } from '../location-search-results';
+import {
+  filterCampusHitsByQuery,
+  sortCampusHitsForDistanceSearch,
+} from '../location-search-results';
 import type { CampusSearchHit } from '../location-search-results';
 
 function createCampusHit(
   campusUrl: string,
   geoDistance?: number,
+  overrides: Partial<CampusSearchHit> = {},
 ): CampusSearchHit {
   return {
     campusUrl,
@@ -28,6 +32,7 @@ function createCampusHit(
         : {
             geoDistance,
           },
+    ...overrides,
   };
 }
 
@@ -81,5 +86,43 @@ describe('sortCampusHitsForDistanceSearch', () => {
       'physical',
       'cf-everywhere',
     ]);
+  });
+});
+
+describe('filterCampusHitsByQuery', () => {
+  const hits = [
+    createCampusHit('jupiter', undefined, {
+      campusName: 'Jupiter',
+      campusLocation: {
+        street1: '1200 W Indiantown Rd',
+        street2: '',
+        city: 'Jupiter',
+        state: 'FL',
+        zip: '33458',
+      },
+    }),
+    createCampusHit('boca-raton', undefined, {
+      campusName: 'Boca Raton',
+      campusLocation: {
+        street1: '9087 Glades Rd',
+        street2: '',
+        city: 'Boca Raton',
+        state: 'FL',
+        zip: '33434',
+      },
+    }),
+  ];
+
+  it('returns all hits when the query is empty so distance/browse UIs stay intact', () => {
+    expect(filterCampusHitsByQuery(hits, '')).toEqual(hits);
+  });
+
+  it('matches campus name, url, and city because Algolia keyword search cannot', () => {
+    expect(
+      filterCampusHitsByQuery(hits, 'jupiter').map((hit) => hit.campusUrl),
+    ).toEqual(['jupiter']);
+    expect(
+      filterCampusHitsByQuery(hits, 'boca').map((hit) => hit.campusUrl),
+    ).toEqual(['boca-raton']);
   });
 });

--- a/app/routes/home/components/location-search/location-search-inner.component.tsx
+++ b/app/routes/home/components/location-search/location-search-inner.component.tsx
@@ -53,6 +53,7 @@ export function LocationSearchInner({
   } | null>(null);
   const [isDistanceSearch, setIsDistanceSearch] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
+  const [inputClearRequestId, setInputClearRequestId] = useState(0);
 
   useEffect(() => {
     if (ALGOLIA_APP_ID && ALGOLIA_SEARCH_API_KEY && !globalSearchClient) {
@@ -129,6 +130,11 @@ export function LocationSearchInner({
     submittedZipRef.current = null;
     submittedGeocodeRequestIdRef.current = null;
     hasPendingGeocodeResponseRef.current = false;
+    // Clear typed city/ZIP so distance results aren't mixed with leftover text,
+    // and keep the popup open for the ranked list.
+    setSearchQuery('');
+    setInputClearRequestId((id) => id + 1);
+    setIsSearching(true);
     getCurrentPositionFromUserGesture(
       (position) => {
         setCoordinates({
@@ -141,7 +147,7 @@ export function LocationSearchInner({
         console.error('Geolocation error:', error);
       },
     );
-  }, []);
+  }, [setIsSearching]);
 
   useEffect(() => {
     if (geocodeFetcher.state !== 'idle') {
@@ -238,6 +244,7 @@ export function LocationSearchInner({
               onSearchStateChange={setIsSearching}
               onQueryChange={setSearchQuery}
               onSearchSubmit={handleSearch}
+              clearRequestId={inputClearRequestId}
               data-gtm='hero-cta'
             />
           </div>

--- a/app/routes/home/components/location-search/location-search-inner.component.tsx
+++ b/app/routes/home/components/location-search/location-search-inner.component.tsx
@@ -52,6 +52,7 @@ export function LocationSearchInner({
     lng: number;
   } | null>(null);
   const [isDistanceSearch, setIsDistanceSearch] = useState(false);
+  const [searchQuery, setSearchQuery] = useState('');
 
   useEffect(() => {
     if (ALGOLIA_APP_ID && ALGOLIA_SEARCH_API_KEY && !globalSearchClient) {
@@ -104,6 +105,10 @@ export function LocationSearchInner({
       submittedZipRef.current = null;
       submittedGeocodeRequestIdRef.current = null;
       hasPendingGeocodeResponseRef.current = false;
+      // Drop geo bias when the query is no longer a ZIP so keyword search
+      // is not mixed with stale aroundLatLng from a previous ZIP/GPS search.
+      setCoordinates(null);
+      setIsDistanceSearch(false);
       return;
     }
     const requestId = `home-location-${geocodeRequestIdRef.current + 1}`;
@@ -217,6 +222,7 @@ export function LocationSearchInner({
             >
               <div className='h-14 shrink-0' aria-hidden='true' />
               <SearchPopup
+                query={searchQuery}
                 isDistanceSearch={isDistanceSearch}
                 onRequestPreciseLocation={handlePreciseLocationRequest}
               />
@@ -230,6 +236,7 @@ export function LocationSearchInner({
           >
             <SearchBar
               onSearchStateChange={setIsSearching}
+              onQueryChange={setSearchQuery}
               onSearchSubmit={handleSearch}
               data-gtm='hero-cta'
             />

--- a/app/routes/home/components/location-search/location-search-results.ts
+++ b/app/routes/home/components/location-search/location-search-results.ts
@@ -50,3 +50,32 @@ export function sortCampusHitsForDistanceSearch(hits: CampusSearchHit[]) {
 
   return [...physicalHits, ...onlineHits];
 }
+
+/**
+ * The locations Algolia index only returns hits for an empty query — campus
+ * names/addresses are not keyword-searchable server-side. Match locally like
+ * the navbar global search does.
+ */
+export function filterCampusHitsByQuery(
+  hits: CampusSearchHit[],
+  query: string,
+): CampusSearchHit[] {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) return hits;
+
+  return hits.filter((hit) => {
+    const searchableValues = [
+      hit.campusName,
+      hit.campusUrl,
+      hit.campusLocation?.city,
+      hit.campusLocation?.state,
+      hit.campusLocation?.street1,
+      hit.campusLocation?.street2,
+      hit.campusLocation?.zip,
+    ];
+
+    return searchableValues.some((value) =>
+      value?.toLowerCase().includes(normalizedQuery),
+    );
+  });
+}

--- a/app/routes/home/components/location-search/search-bar.tsx
+++ b/app/routes/home/components/location-search/search-bar.tsx
@@ -12,10 +12,12 @@ import Icon from '~/primitives/icon';
 
 export const SearchBar = ({
   onSearchStateChange,
+  onQueryChange,
   onSearchSubmit,
   'data-gtm': dataGtm,
 }: {
   onSearchStateChange: (isSearching: boolean) => void;
+  onQueryChange: (query: string) => void;
   onSearchSubmit: (query: string | null) => void;
   'data-gtm'?: string;
 }) => {
@@ -24,20 +26,24 @@ export const SearchBar = ({
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
+    // Locations index is not keyword-searchable in Algolia — keep the index
+    // query empty and filter hits client-side from `onQueryChange`.
     refine('');
   }, [refine]);
 
   const syncFromInput = (raw: string) => {
     setInputValue(raw);
-    refine('');
 
     const trimmed = raw.trim();
+    refine('');
+    onQueryChange(trimmed);
+    onSearchStateChange(!!trimmed);
+
+    // Additionally geocode when the input is a valid 5-digit ZIP.
     if (trimmed.length === 5 && isValidZip(trimmed)) {
-      onSearchStateChange(true);
       onSearchSubmit(trimmed);
     } else {
       onSearchSubmit(null);
-      onSearchStateChange(!!raw.trim());
     }
   };
 
@@ -47,15 +53,7 @@ export const SearchBar = ({
 
   const handleSubmit = (e: FormEvent) => {
     e.preventDefault();
-    const trimmed = inputValue.trim();
-    refine('');
-    if (trimmed.length === 5 && isValidZip(trimmed)) {
-      onSearchStateChange(true);
-      onSearchSubmit(trimmed);
-    } else {
-      onSearchSubmit(null);
-      onSearchStateChange(!!trimmed);
-    }
+    syncFromInput(inputValue);
     inputRef.current?.blur();
   };
 
@@ -83,13 +81,12 @@ export const SearchBar = ({
       <input
         ref={inputRef}
         type='text'
-        inputMode='numeric'
-        autoComplete='postal-code'
+        autoComplete='off'
         value={inputValue}
         onChange={handleChange}
         placeholder='Find a service near you'
         className='w-full grow justify-center text-black px-3 outline-none appearance-none bg-transparent'
-        aria-label='Zip code'
+        aria-label='Find a service near you'
       />
     </form>
   );

--- a/app/routes/home/components/location-search/search-bar.tsx
+++ b/app/routes/home/components/location-search/search-bar.tsx
@@ -14,11 +14,14 @@ export const SearchBar = ({
   onSearchStateChange,
   onQueryChange,
   onSearchSubmit,
+  clearRequestId = 0,
   'data-gtm': dataGtm,
 }: {
   onSearchStateChange: (isSearching: boolean) => void;
   onQueryChange: (query: string) => void;
   onSearchSubmit: (query: string | null) => void;
+  /** Increment to clear the input while keeping the results popup open. */
+  clearRequestId?: number;
   'data-gtm'?: string;
 }) => {
   const { refine } = useSearchBox();
@@ -36,13 +39,28 @@ export const SearchBar = ({
     refine('');
   }, [refine]);
 
+  useEffect(() => {
+    if (clearRequestId === 0) return;
+    setInputValue('');
+    refine('');
+    onQueryChange('');
+    onSearchSubmit(null);
+    onSearchStateChange(true);
+  }, [
+    clearRequestId,
+    refine,
+    onQueryChange,
+    onSearchSubmit,
+    onSearchStateChange,
+  ]);
+
   const syncFromInput = (raw: string) => {
     setInputValue(raw);
 
     const trimmed = raw.trim();
     refine('');
     onQueryChange(trimmed);
-    onSearchStateChange(!!trimmed);
+    onSearchStateChange(true);
 
     // Additionally geocode when the input is a valid 5-digit ZIP.
     if (trimmed.length === 5 && isValidZip(trimmed)) {
@@ -89,7 +107,11 @@ export const SearchBar = ({
         autoComplete='off'
         value={inputValue}
         onChange={handleChange}
-        onFocus={() => setIsFocused(true)}
+        onFocus={() => {
+          setIsFocused(true);
+          // Open results (and precise-location) on focus — not only after typing.
+          onSearchStateChange(true);
+        }}
         onBlur={() => setIsFocused(false)}
         placeholder={placeholder}
         className='w-full grow justify-center text-black px-3 outline-none appearance-none bg-transparent'

--- a/app/routes/home/components/location-search/search-bar.tsx
+++ b/app/routes/home/components/location-search/search-bar.tsx
@@ -23,7 +23,12 @@ export const SearchBar = ({
 }) => {
   const { refine } = useSearchBox();
   const [inputValue, setInputValue] = useState('');
+  const [isFocused, setIsFocused] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
+  const placeholder =
+    isFocused && !inputValue
+      ? 'Search by city or ZIP code'
+      : 'Find a service near you';
 
   useEffect(() => {
     // Locations index is not keyword-searchable in Algolia — keep the index
@@ -84,7 +89,9 @@ export const SearchBar = ({
         autoComplete='off'
         value={inputValue}
         onChange={handleChange}
-        placeholder='Find a service near you'
+        onFocus={() => setIsFocused(true)}
+        onBlur={() => setIsFocused(false)}
+        placeholder={placeholder}
         className='w-full grow justify-center text-black px-3 outline-none appearance-none bg-transparent'
         aria-label='Find a service near you'
       />

--- a/app/routes/home/components/location-search/search-popup.tsx
+++ b/app/routes/home/components/location-search/search-popup.tsx
@@ -2,23 +2,35 @@ import { Link } from 'react-router-dom';
 import { useHits } from 'react-instantsearch';
 
 import { Icon } from '~/primitives/icon/icon';
+import { isValidZip } from '~/lib/utils';
 import { CampusHit } from './location-hit';
-import { sortCampusHitsForDistanceSearch } from './location-search-results';
+import {
+  filterCampusHitsByQuery,
+  sortCampusHitsForDistanceSearch,
+} from './location-search-results';
 import type { CampusHitType } from './location-hit';
 import type { CampusSearchHit } from './location-search-results';
 
 export const SearchPopup = ({
+  query,
   isDistanceSearch,
   onRequestPreciseLocation,
 }: {
+  query: string;
   isDistanceSearch: boolean;
   /** Must run geolocation only from this click — not from useEffect (iOS Safari). */
   onRequestPreciseLocation: () => void;
 }) => {
   const { items } = useHits<CampusSearchHit>();
+  const isZipQuery = query.length === 5 && isValidZip(query);
+  // ZIP / GPS: keep Algolia's geo-ranked list (don't filter ZIP digits as keywords —
+  // the index isn't keyword-searchable and ZIPs aren't in hit text).
+  // Keyword: filter locally because non-empty Algolia queries return 0 hits.
   const hits = isDistanceSearch
     ? sortCampusHitsForDistanceSearch(items)
-    : items;
+    : isZipQuery
+      ? items
+      : filterCampusHitsByQuery(items, query);
 
   return (
     <div className='w-full overflow-hidden min-h-[332px]'>

--- a/app/routes/home/components/location-search/search-popup.tsx
+++ b/app/routes/home/components/location-search/search-popup.tsx
@@ -64,15 +64,21 @@ export const SearchPopup = ({
 
       {/* Buttons */}
       <div className='flex justify-between gap-2 pt-4'>
-        <div
-          className='flex gap-1 cursor-pointer text-ocean hover:text-navy transition-colors duration-300'
+        <button
+          type='button'
+          className='flex gap-1 cursor-pointer text-ocean hover:text-navy transition-colors duration-300 bg-transparent border-0 p-0'
+          // preventDefault on pointerdown so mobile doesn't spend the tap dismissing
+          // the keyboard (which would skip click / break the geolocation user-gesture).
+          onPointerDown={(event) => {
+            event.preventDefault();
+          }}
           onClick={() => {
             onRequestPreciseLocation();
           }}
         >
           <Icon name='currentLocation' size={21} />
           <p className='text-sm font-semibold'>Use my precise location</p>
-        </div>
+        </button>
 
         <Link to='/locations' prefetch='intent'>
           <p className='text-sm font-medium hover:underline transition-all duration-300'>


### PR DESCRIPTION
## Summary

The home hero location search previously only ran once a user entered a valid 5-digit ZIP (geocode → Algolia `_geoloc` / `aroundLatLng`). City/campus name searches did nothing useful because the locations Algolia index returns **0 hits for any non-empty query**—only an empty query returns campuses (same constraint the navbar global search already works around).

This updates the home search so it:
1. **Always** filters locations by keyword as the user types (client-side match on campus name, URL, city, address, etc.)
2. **Also** keeps the existing ZIP → Google Geocode → distance-ranked (`aroundLatLng`) path when a valid 5-digit ZIP is entered
3. Clears stale geo bias when the query is no longer a ZIP, and allows typing city names (no longer `inputMode="numeric"`)

## Screenshots

[Paste your screenshots here]

## Testing

- [x] On the home page hero, click the location search and type a campus/city keyword (e.g. `Jupiter`, `Boca`, `Palm`) — matching campuses appear in the popup
- [x] Clear the input and type a valid 5-digit ZIP (e.g. `33418`) — results update to nearby campuses ranked by distance after geocode
- [x] After a ZIP search, change the query to a city name — geo bias clears and keyword filtering applies again
- [x] Use **Use my precise location** and confirm distance-ranked results still work
- [x] Confirm **View All Locations** still links to `/locations`
- [x] Spot-check mobile + desktop hero layouts
- [x] Ran `pnpm check` and `pnpm test` (or at least `pnpm vitest run app/routes/home/components/location-search/__tests__/location-search-results.test.ts`) with no new failures from these changes

## Tickets

[CFDP-4136](https://christfellowshipchurch.atlassian.net/browse/CFDP-4136)

## Changes Made

### New Components Added

- None

### New Utilities

- `filterCampusHitsByQuery` in `app/routes/home/components/location-search/location-search-results.ts` — client-side keyword filter for campus hits (needed because the locations Algolia index is not keyword-searchable)
- Unit coverage for the new helper in `app/routes/home/components/location-search/__tests__/location-search-results.test.ts`

### New Assets

- None

### Dependencies

- None

### Route Implementation

- No new routes. Updates to the existing home hero location search:
  - `app/routes/home/components/location-search/search-bar.tsx` — always emit the query for client filtering; still trigger ZIP geocode on valid 5-digit ZIP; allow text input (not ZIP-only keyboard)
  - `app/routes/home/components/location-search/location-search-inner.component.tsx` — track `searchQuery`; clear coordinates / distance mode when leaving ZIP search so keyword results aren’t stuck with stale geo
  - `app/routes/home/components/location-search/search-popup.tsx` — apply local keyword filter for non-ZIP queries; keep geo sorting for ZIP/GPS distance search

### Key Features

- Home location search supports **city/campus keyword search** and **ZIP distance search** together
- Keyword filtering matches the navbar approach (browse with empty Algolia query, filter locally)
- ZIP path unchanged in intent: geocode → `aroundLatLng` + ranking info → distance-aware ordering (including online campus handling)
- Accessibility: input `aria-label` updated from “Zip code” to “Find a service near you” to reflect city + ZIP usage

[CFDP-4136]: https://christfellowshipchurch.atlassian.net/browse/CFDP-4136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ