### PR TITLE
Yes / Devotional Minor Copy Fix

### DIFF
--- a/app/routes/yes/components/yes-devotional-hero.component.tsx
+++ b/app/routes/yes/components/yes-devotional-hero.component.tsx
@@ -44,7 +44,7 @@ export const YesHero = ({ isSpanish }: { isSpanish?: boolean }) => {
 const heroCardData: { link: string; copy: string }[] = [
   {
     link: '#devo',
-    copy: 'A three-week course to start your relationship with Jesus.',
+    copy: 'A three-week devotional to start your relationship with Jesus.',
   },
   {
     link: isAppleDevice() ? appleLink : googleLink,
@@ -59,7 +59,7 @@ const heroCardData: { link: string; copy: string }[] = [
 const spanishHeroCardData: { link: string; copy: string }[] = [
   {
     link: '#devo',
-    copy: 'Un curso de tres semanas para comenzar tu relación con Jesús.',
+    copy: 'Un devocional de tres semanas para comenzar tu relación con Jesús.',
   },
   {
     link: googleLink,


### PR DESCRIPTION
## Summary

Updates the first hero card copy on the English and Spanish Yes/devotional pages so "course" / "curso" say "devotional" / "devocional" instead.

## Screenshots

|Before|After|
|-|-|
|<img width="896" height="504" alt="Screenshot 2026-07-14 at 2 27 38 PM" src="https://github.com/user-attachments/assets/8fdbfed2-13cc-412f-97da-6ed76d9a0bfe" />|<img width="787" height="489" alt="Screenshot 2026-07-14 at 2 29 26 PM" src="https://github.com/user-attachments/assets/2e6c301f-ed07-4e55-af88-bc9d4fb555b0" />|

## Testing

- [x] Confirm the first box on `/yes/devotional` says **devotional** (not "course")
- [x] Confirm the first box on `/dijiste-si/devocional` says **devocional** (not "curso")

## Tickets

[CFDP-4139](https://christfellowshipchurch.atlassian.net/browse/CFDP-4139)

## Changes Made

### New Components Added

- None

### New Utilities

- None

### New Assets

- None

### Dependencies

- None

### Route Implementation

- No route changes. Copy updated in `app/routes/yes/components/yes-devotional-hero.component.tsx`:
  - EN: `course` → `devotional`
  - ES: `curso` → `devocional`

### Key Features

- Aligns the first hero card wording with the page being a three-week **devotional** / **devocional**, not a course.

[CFDP-4139]: https://christfellowshipchurch.atlassian.net/browse/CFDP-4139?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ