### PR TITLE
Gate Microsoft Clarity behind cookie consent

### DIFF
--- a/app/components/cookie-consent/__tests__/index.test.tsx
+++ b/app/components/cookie-consent/__tests__/index.test.tsx
@@ -7,14 +7,18 @@ describe('CookieConsent', () => {
   const mockOnDecline = vi.fn();
 
   beforeEach(() => {
-    // Clear localStorage and mock functions before each test
-    localStorage.clear();
     mockOnAccept.mockClear();
     mockOnDecline.mockClear();
   });
 
-  it('renders when no consent is stored', () => {
-    render(<CookieConsent onAccept={mockOnAccept} onDecline={mockOnDecline} />);
+  it('renders when visible', () => {
+    render(
+      <CookieConsent
+        isVisible
+        onAccept={mockOnAccept}
+        onDecline={mockOnDecline}
+      />,
+    );
 
     expect(screen.getByRole('dialog')).toBeInTheDocument();
     expect(screen.getByText('Cookie Settings')).toBeInTheDocument();
@@ -23,44 +27,58 @@ describe('CookieConsent', () => {
     expect(screen.getByRole('button', { name: 'Decline' })).toBeInTheDocument();
   });
 
-  it("doesn't render when consent is already accepted", () => {
-    localStorage.setItem('cookieConsent', 'accepted');
-    render(<CookieConsent onAccept={mockOnAccept} onDecline={mockOnDecline} />);
+  it('does not render when not visible', () => {
+    render(
+      <CookieConsent
+        isVisible={false}
+        onAccept={mockOnAccept}
+        onDecline={mockOnDecline}
+      />,
+    );
 
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
 
-  it("doesn't render when consent is already declined", () => {
-    localStorage.setItem('cookieConsent', 'declined');
-    render(<CookieConsent onAccept={mockOnAccept} onDecline={mockOnDecline} />);
+  it('handles accept action correctly without writing localStorage', () => {
+    localStorage.clear();
+    render(
+      <CookieConsent
+        isVisible
+        onAccept={mockOnAccept}
+        onDecline={mockOnDecline}
+      />,
+    );
 
-    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
-  });
+    fireEvent.click(screen.getByRole('button', { name: 'Accept' }));
 
-  it('handles accept action correctly', () => {
-    render(<CookieConsent onAccept={mockOnAccept} onDecline={mockOnDecline} />);
-
-    const acceptButton = screen.getByRole('button', { name: 'Accept' });
-    fireEvent.click(acceptButton);
-
-    expect(localStorage.getItem('cookieConsent')).toBe('accepted');
+    expect(localStorage.getItem('cookieConsent')).toBeNull();
     expect(mockOnAccept).toHaveBeenCalledTimes(1);
-    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
 
-  it('handles decline action correctly', () => {
-    render(<CookieConsent onAccept={mockOnAccept} onDecline={mockOnDecline} />);
+  it('handles decline action correctly without writing localStorage', () => {
+    localStorage.clear();
+    render(
+      <CookieConsent
+        isVisible
+        onAccept={mockOnAccept}
+        onDecline={mockOnDecline}
+      />,
+    );
 
-    const declineButton = screen.getByRole('button', { name: 'Decline' });
-    fireEvent.click(declineButton);
+    fireEvent.click(screen.getByRole('button', { name: 'Decline' }));
 
-    expect(localStorage.getItem('cookieConsent')).toBe('declined');
+    expect(localStorage.getItem('cookieConsent')).toBeNull();
     expect(mockOnDecline).toHaveBeenCalledTimes(1);
-    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
 
   it('has correct accessibility attributes', () => {
-    render(<CookieConsent onAccept={mockOnAccept} onDecline={mockOnDecline} />);
+    render(
+      <CookieConsent
+        isVisible
+        onAccept={mockOnAccept}
+        onDecline={mockOnDecline}
+      />,
+    );
 
     const dialog = screen.getByRole('dialog');
     expect(dialog).toHaveAttribute('aria-labelledby', 'cookie-consent-title');

--- a/app/components/cookie-consent/index.tsx
+++ b/app/components/cookie-consent/index.tsx
@@ -1,34 +1,16 @@
-import { useState, useEffect } from 'react';
 import { Button } from '~/primitives/button/button.primitive';
 
 interface CookieConsentProps {
+  isVisible: boolean;
   onAccept: () => void;
   onDecline: () => void;
 }
 
-export function CookieConsent({ onAccept, onDecline }: CookieConsentProps) {
-  const [isVisible, setIsVisible] = useState(false);
-
-  useEffect(() => {
-    // Check if user has already made a choice
-    const hasConsent = localStorage.getItem('cookieConsent');
-    if (!hasConsent) {
-      setIsVisible(true);
-    }
-  }, []);
-
-  const handleAccept = () => {
-    localStorage.setItem('cookieConsent', 'accepted');
-    setIsVisible(false);
-    onAccept();
-  };
-
-  const handleDecline = () => {
-    localStorage.setItem('cookieConsent', 'declined');
-    setIsVisible(false);
-    onDecline();
-  };
-
+export function CookieConsent({
+  isVisible,
+  onAccept,
+  onDecline,
+}: CookieConsentProps) {
   if (!isVisible) return null;
 
   return (
@@ -52,10 +34,10 @@ export function CookieConsent({ onAccept, onDecline }: CookieConsentProps) {
             </p>
           </div>
           <div className='flex gap-3'>
-            <Button onClick={handleDecline} intent='secondary' size='sm'>
+            <Button onClick={onDecline} intent='secondary' size='sm'>
               Decline
             </Button>
-            <Button onClick={handleAccept} intent='primary' size='sm'>
+            <Button onClick={onAccept} intent='primary' size='sm'>
               Accept
             </Button>
           </div>

--- a/app/components/footer/footer-column.component.test.tsx
+++ b/app/components/footer/footer-column.component.test.tsx
@@ -43,14 +43,14 @@ describe('FooterColumnComponent', () => {
 
   it('renders Cookie Settings as a button that opens consent', () => {
     localStorage.setItem('cookieConsent', 'true');
-    const moreColumn = footerColumns.find(
-      (column) => column.title === 'More',
+    const aboutColumn = footerColumns.find(
+      (column) => column.title === 'About',
     );
 
-    expect(moreColumn).toBeDefined();
+    expect(aboutColumn).toBeDefined();
     render(
       <CookieConsentProvider>
-        <FooterColumnComponent column={moreColumn!} />
+        <FooterColumnComponent column={aboutColumn!} />
       </CookieConsentProvider>,
     );
 

--- a/app/components/footer/footer-column.component.test.tsx
+++ b/app/components/footer/footer-column.component.test.tsx
@@ -1,7 +1,8 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { FooterColumnComponent } from './footer-column.component';
 import { footerColumns } from './footer-data';
+import { CookieConsentProvider } from '~/providers/cookie-consent-provider';
 
 vi.mock('~/components', () => ({
   ConnectCardModal: ({ buttonTitle }: { buttonTitle?: string }) => (
@@ -15,6 +16,10 @@ vi.mock('~/components', () => ({
   ),
 }));
 
+vi.mock('~/lib/load-clarity', () => ({
+  loadClarity: vi.fn(),
+}));
+
 describe('FooterColumnComponent', () => {
   it('renders Subscribe to Updates as the newsletter subscription modal trigger', () => {
     const connectColumn = footerColumns.find(
@@ -22,7 +27,11 @@ describe('FooterColumnComponent', () => {
     );
 
     expect(connectColumn).toBeDefined();
-    render(<FooterColumnComponent column={connectColumn!} />);
+    render(
+      <CookieConsentProvider>
+        <FooterColumnComponent column={connectColumn!} />
+      </CookieConsentProvider>,
+    );
 
     expect(
       screen.getByTestId('newsletter-subscription-modal'),
@@ -30,5 +39,32 @@ describe('FooterColumnComponent', () => {
     expect(
       screen.queryByRole('link', { name: /subscribe to updates/i }),
     ).not.toBeInTheDocument();
+  });
+
+  it('renders Cookie Settings as a button that opens consent', () => {
+    localStorage.setItem('cookieConsent', 'true');
+    const moreColumn = footerColumns.find(
+      (column) => column.title === 'More',
+    );
+
+    expect(moreColumn).toBeDefined();
+    render(
+      <CookieConsentProvider>
+        <FooterColumnComponent column={moreColumn!} />
+      </CookieConsentProvider>,
+    );
+
+    const cookieSettings = screen.getByRole('button', {
+      name: 'Cookie Settings',
+    });
+    expect(cookieSettings).toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: /cookie settings/i }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(cookieSettings);
+    expect(
+      screen.getByRole('dialog', { name: /cookie settings/i }),
+    ).toBeInTheDocument();
   });
 });

--- a/app/components/footer/footer-column.component.tsx
+++ b/app/components/footer/footer-column.component.tsx
@@ -4,12 +4,18 @@ import {
   NewsletterSubscriptionModal,
   PrayerRequestModal,
 } from '~/components';
+import { useCookieConsent } from '~/providers/cookie-consent-provider';
 
 interface FooterColumnProps {
   column: FooterColumn;
 }
 
+const footerActionButtonClassName =
+  'text-lg font-light text-coconut m-0 p-0 border-0 rounded-none bg-transparent items-start justify-start min-h-0 min-w-0 hover:enabled:bg-transparent hover:cursor-pointer hover:text-white/50';
+
 export const FooterColumnComponent = ({ column }: FooterColumnProps) => {
+  const { openConsent } = useCookieConsent();
+
   return (
     <div className='flex flex-col gap-3 md:col-span-4 lg:col-span-1'>
       <div
@@ -23,21 +29,31 @@ export const FooterColumnComponent = ({ column }: FooterColumnProps) => {
         link.url === '#connect-card' ? (
           <ConnectCardModal
             key={link.title}
-            triggerStyles='text-lg font-light text-coconut m-0 p-0 border-0 rounded-none bg-transparent items-start justify-start min-h-0 min-w-0 hover:enabled:bg-transparent hover:cursor-pointer hover:text-white/50'
+            triggerStyles={footerActionButtonClassName}
             buttonTitle={link.title}
           />
         ) : link.url === '#prayer-request' ? (
           <PrayerRequestModal
             key={link.title}
-            triggerStyles='text-lg font-light text-coconut m-0 p-0 border-0 rounded-none bg-transparent items-start justify-start min-h-0 min-w-0 hover:enabled:bg-transparent hover:cursor-pointer hover:text-white/50'
+            triggerStyles={footerActionButtonClassName}
             buttonTitle={link.title}
           />
         ) : link.url === '#newsletter-subscription' ? (
           <NewsletterSubscriptionModal
             key={link.title}
-            triggerStyles='text-lg font-light text-coconut m-0 p-0 border-0 rounded-none bg-transparent items-start justify-start min-h-0 min-w-0 hover:enabled:bg-transparent hover:cursor-pointer hover:text-white/50'
+            triggerStyles={footerActionButtonClassName}
             buttonTitle={link.title}
           />
+        ) : link.url === '#cookie-settings' ? (
+          <button
+            key={link.title}
+            type='button'
+            className='text-lg text-left hover:text-white/50 transition-colors'
+            onClick={openConsent}
+            aria-label={`${link.title}`}
+          >
+            {link.title}
+          </button>
         ) : (
           <a
             key={link.title}

--- a/app/components/footer/footer-data.ts
+++ b/app/components/footer/footer-data.ts
@@ -36,6 +36,7 @@ export const footerColumns: FooterColumn[] = [
       { title: 'Career Opportunities', url: '/career-opportunities' },
       { title: 'Privacy Policy', url: '/privacy-policy' },
       { title: 'Terms of Use', url: '/terms-of-use' },
+      { title: 'Cookie Settings', url: '#cookie-settings' },
     ],
   },
   {
@@ -47,7 +48,6 @@ export const footerColumns: FooterColumn[] = [
       },
       { title: 'Get Your Degree', url: 'https://www.cfseu.com/' },
       { title: 'Shop Online', url: 'https://cf-church.square.site/home' },
-      { title: 'Cookie Settings', url: '#cookie-settings' },
     ],
   },
 ];

--- a/app/components/footer/footer-data.ts
+++ b/app/components/footer/footer-data.ts
@@ -47,6 +47,7 @@ export const footerColumns: FooterColumn[] = [
       },
       { title: 'Get Your Degree', url: 'https://www.cfseu.com/' },
       { title: 'Shop Online', url: 'https://cf-church.square.site/home' },
+      { title: 'Cookie Settings', url: '#cookie-settings' },
     ],
   },
 ];

--- a/app/lib/__tests__/load-clarity.test.ts
+++ b/app/lib/__tests__/load-clarity.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { loadClarity } from '../load-clarity';
+
+describe('loadClarity', () => {
+  beforeEach(() => {
+    document
+      .querySelectorAll('script[src*="clarity.ms/tag/"]')
+      .forEach((el) => el.remove());
+    delete window.clarity;
+  });
+
+  afterEach(() => {
+    document
+      .querySelectorAll('script[src*="clarity.ms/tag/"]')
+      .forEach((el) => el.remove());
+    delete window.clarity;
+    vi.restoreAllMocks();
+  });
+
+  it('injects the Clarity tag script with the default project id', () => {
+    loadClarity();
+
+    const script = document.querySelector(
+      'script[src="https://www.clarity.ms/tag/ojo9prqys0"]',
+    );
+    expect(script).toBeInTheDocument();
+    expect(typeof window.clarity).toBe('function');
+  });
+
+  it('is idempotent when Clarity is already present', () => {
+    const stub = Object.assign(function clarityStub() {}, {
+      q: [] as IArguments[],
+    });
+    window.clarity = stub;
+    loadClarity();
+
+    expect(
+      document.querySelector('script[src*="clarity.ms/tag/"]'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('is idempotent when a Clarity script tag already exists', () => {
+    const existing = document.createElement('script');
+    existing.src = 'https://www.clarity.ms/tag/ojo9prqys0';
+    document.head.appendChild(existing);
+
+    loadClarity();
+
+    expect(
+      document.querySelectorAll('script[src*="clarity.ms/tag/"]').length,
+    ).toBe(1);
+  });
+});

--- a/app/lib/load-clarity.ts
+++ b/app/lib/load-clarity.ts
@@ -1,0 +1,40 @@
+const DEFAULT_CLARITY_ID = 'ojo9prqys0';
+
+declare global {
+  interface Window {
+    clarity?: ((...args: unknown[]) => void) & { q?: IArguments[] };
+  }
+}
+
+/**
+ * Idempotent Microsoft Clarity bootstrap. No-ops if Clarity is already present
+ * or if a tag script is already in the document.
+ */
+export function loadClarity(projectId = DEFAULT_CLARITY_ID): void {
+  if (typeof window === 'undefined' || typeof document === 'undefined') {
+    return;
+  }
+
+  if (
+    typeof window.clarity === 'function' ||
+    document.querySelector('script[src*="clarity.ms/tag/"]')
+  ) {
+    return;
+  }
+
+  // Match Clarity's official stub so queued calls stay compatible.
+  window.clarity = function () {
+    (window.clarity!.q = window.clarity!.q || []).push(arguments);
+  };
+
+  const script = document.createElement('script');
+  script.async = true;
+  script.src = `https://www.clarity.ms/tag/${projectId}`;
+
+  const firstScript = document.getElementsByTagName('script')[0];
+  if (firstScript?.parentNode) {
+    firstScript.parentNode.insertBefore(script, firstScript);
+  } else {
+    (document.head || document.documentElement).appendChild(script);
+  }
+}

--- a/app/providers/__tests__/cookie-consent-provider.test.tsx
+++ b/app/providers/__tests__/cookie-consent-provider.test.tsx
@@ -5,28 +5,39 @@ import {
   useCookieConsent,
 } from '../cookie-consent-provider';
 
+const loadClarityMock = vi.fn();
+
+vi.mock('~/lib/load-clarity', () => ({
+  loadClarity: (...args: unknown[]) => loadClarityMock(...args),
+}));
+
 vi.mock('../../components/cookie-consent', () => ({
   CookieConsent: ({
+    isVisible,
     onAccept,
     onDecline,
   }: {
+    isVisible: boolean;
     onAccept: () => void;
     onDecline: () => void;
-  }) => (
-    <div>
-      <button onClick={onAccept}>Accept cookies</button>
-      <button onClick={onDecline}>Decline cookies</button>
-    </div>
-  ),
+  }) =>
+    isVisible ? (
+      <div>
+        <button onClick={onAccept}>Accept cookies</button>
+        <button onClick={onDecline}>Decline cookies</button>
+      </div>
+    ) : null,
 }));
 
 function TestConsumer() {
-  const { hasConsent, acceptCookies, declineCookies } = useCookieConsent();
+  const { hasConsent, acceptCookies, declineCookies, openConsent } =
+    useCookieConsent();
   return (
     <div>
       <span data-testid='consent'>{String(hasConsent)}</span>
       <button onClick={acceptCookies}>accept</button>
       <button onClick={declineCookies}>decline</button>
+      <button onClick={openConsent}>open settings</button>
     </div>
   );
 }
@@ -36,6 +47,7 @@ describe('CookieConsentProvider', () => {
     localStorage.clear();
     sessionStorage.clear();
     window.dataLayer = [];
+    loadClarityMock.mockClear();
   });
 
   afterEach(() => {
@@ -51,14 +63,28 @@ describe('CookieConsentProvider', () => {
     expect(screen.getByText('child')).toBeInTheDocument();
   });
 
-  it('renders the CookieConsent component', () => {
-    render(
-      <CookieConsentProvider>
-        <div />
-      </CookieConsentProvider>,
-    );
+  it('shows the CookieConsent banner when no consent is stored', async () => {
+    await act(async () => {
+      render(
+        <CookieConsentProvider>
+          <div />
+        </CookieConsentProvider>,
+      );
+    });
     expect(screen.getByText('Accept cookies')).toBeInTheDocument();
     expect(screen.getByText('Decline cookies')).toBeInTheDocument();
+  });
+
+  it('does not show the banner when consent is already stored', async () => {
+    localStorage.setItem('cookieConsent', 'true');
+    await act(async () => {
+      render(
+        <CookieConsentProvider>
+          <div />
+        </CookieConsentProvider>,
+      );
+    });
+    expect(screen.queryByText('Accept cookies')).not.toBeInTheDocument();
   });
 
   it('throws when useCookieConsent used outside provider', () => {
@@ -70,7 +96,7 @@ describe('CookieConsentProvider', () => {
     console.error = originalError;
   });
 
-  it('acceptCookies sets localStorage and pushes dataLayer event', () => {
+  it('acceptCookies sets localStorage to true and loads Clarity', () => {
     render(
       <CookieConsentProvider>
         <TestConsumer />
@@ -78,6 +104,7 @@ describe('CookieConsentProvider', () => {
     );
     fireEvent.click(screen.getByText('accept'));
     expect(localStorage.getItem('cookieConsent')).toBe('true');
+    expect(loadClarityMock).toHaveBeenCalledTimes(1);
     const events = window.dataLayer.filter(
       (e) => typeof e === 'object' && e !== null && 'event' in e,
     );
@@ -89,7 +116,7 @@ describe('CookieConsentProvider', () => {
     ).toBe(true);
   });
 
-  it('declineCookies sets localStorage and pushes dataLayer event', () => {
+  it('declineCookies sets localStorage to false and does not load Clarity', () => {
     render(
       <CookieConsentProvider>
         <TestConsumer />
@@ -97,6 +124,7 @@ describe('CookieConsentProvider', () => {
     );
     fireEvent.click(screen.getByText('decline'));
     expect(localStorage.getItem('cookieConsent')).toBe('false');
+    expect(loadClarityMock).not.toHaveBeenCalled();
     const events = window.dataLayer.filter(
       (e) => typeof e === 'object' && e !== null && 'event' in e,
     );
@@ -108,7 +136,18 @@ describe('CookieConsentProvider', () => {
     ).toBe(true);
   });
 
-  it('on mount with saved consent=true, pushes cookie_consent_accepted if not already fired', async () => {
+  it('does not load Clarity when no consent is stored', async () => {
+    await act(async () => {
+      render(
+        <CookieConsentProvider>
+          <div />
+        </CookieConsentProvider>,
+      );
+    });
+    expect(loadClarityMock).not.toHaveBeenCalled();
+  });
+
+  it('on mount with saved consent=true, loads Clarity and pushes cookie_consent_accepted if not already fired', async () => {
     localStorage.setItem('cookieConsent', 'true');
     await act(async () => {
       render(
@@ -117,6 +156,7 @@ describe('CookieConsentProvider', () => {
         </CookieConsentProvider>,
       );
     });
+    expect(loadClarityMock).toHaveBeenCalledTimes(1);
     const events = window.dataLayer.filter(
       (e) => typeof e === 'object' && e !== null && 'event' in e,
     );
@@ -128,7 +168,7 @@ describe('CookieConsentProvider', () => {
     ).toBe(true);
   });
 
-  it('on mount with saved consent=true and session already fired, does not push event again', async () => {
+  it('on mount with saved consent=true and session already fired, does not push event again but still loads Clarity', async () => {
     localStorage.setItem('cookieConsent', 'true');
     sessionStorage.setItem('gtm_consent_fired', 'true');
     await act(async () => {
@@ -138,6 +178,7 @@ describe('CookieConsentProvider', () => {
         </CookieConsentProvider>,
       );
     });
+    expect(loadClarityMock).toHaveBeenCalledTimes(1);
     const events = window.dataLayer.filter(
       (e) => typeof e === 'object' && e !== null && 'event' in e,
     );
@@ -147,5 +188,32 @@ describe('CookieConsentProvider', () => {
           (e as Record<string, unknown>).event === 'cookie_consent_accepted',
       ),
     ).toBe(false);
+  });
+
+  it('on mount with saved consent=false, does not load Clarity', async () => {
+    localStorage.setItem('cookieConsent', 'false');
+    await act(async () => {
+      render(
+        <CookieConsentProvider>
+          <div />
+        </CookieConsentProvider>,
+      );
+    });
+    expect(loadClarityMock).not.toHaveBeenCalled();
+  });
+
+  it('openConsent re-opens the banner', async () => {
+    localStorage.setItem('cookieConsent', 'false');
+    await act(async () => {
+      render(
+        <CookieConsentProvider>
+          <TestConsumer />
+        </CookieConsentProvider>,
+      );
+    });
+    expect(screen.queryByText('Accept cookies')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('open settings'));
+    expect(screen.getByText('Accept cookies')).toBeInTheDocument();
   });
 });

--- a/app/providers/cookie-consent-provider.tsx
+++ b/app/providers/cookie-consent-provider.tsx
@@ -1,5 +1,12 @@
-import { createContext, useContext, useEffect, ReactNode } from 'react';
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from 'react';
 import { CookieConsent } from '../components/cookie-consent';
+import { loadClarity } from '~/lib/load-clarity';
 
 declare global {
   interface Window {
@@ -11,6 +18,7 @@ interface CookieConsentContextType {
   hasConsent: boolean | null;
   acceptCookies: () => void;
   declineCookies: () => void;
+  openConsent: () => void;
 }
 
 const CookieConsentContext = createContext<
@@ -18,6 +26,8 @@ const CookieConsentContext = createContext<
 >(undefined);
 
 export function CookieConsentProvider({ children }: { children: ReactNode }) {
+  const [isBannerVisible, setIsBannerVisible] = useState(false);
+
   // GTM specifically looks for the 'arguments' object to be pushed
   // Use function declaration (not arrow function) to access arguments object
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -32,8 +42,14 @@ export function CookieConsentProvider({ children }: { children: ReactNode }) {
 
   // Re-apply consent from localStorage on mount so GTM "remembers" for returning users.
   // Only push cookie_consent_accepted once per session so Page View fires once; History Change handles subsequent navigations.
+  // Load Clarity only when analytics consent was previously granted.
   useEffect(() => {
     const savedConsent = localStorage.getItem('cookieConsent');
+
+    if (!savedConsent) {
+      setIsBannerVisible(true);
+      return;
+    }
 
     if (savedConsent === 'true') {
       gtag('consent', 'update', {
@@ -47,6 +63,8 @@ export function CookieConsentProvider({ children }: { children: ReactNode }) {
         window.dataLayer.push({ event: 'cookie_consent_accepted' });
         sessionStorage.setItem('gtm_consent_fired', 'true');
       }
+
+      loadClarity();
     } else if (savedConsent === 'false') {
       gtag('consent', 'update', {
         ad_storage: 'denied',
@@ -70,7 +88,9 @@ export function CookieConsentProvider({ children }: { children: ReactNode }) {
       window.dataLayer.push({ event: 'cookie_consent_accepted' });
       sessionStorage.setItem('gtm_consent_fired', 'true');
       localStorage.setItem('cookieConsent', 'true');
+      loadClarity();
     }
+    setIsBannerVisible(false);
   };
 
   const handleDeclineCookies = () => {
@@ -85,6 +105,11 @@ export function CookieConsentProvider({ children }: { children: ReactNode }) {
       window.dataLayer.push({ event: 'cookie_consent_declined' });
       localStorage.setItem('cookieConsent', 'false');
     }
+    setIsBannerVisible(false);
+  };
+
+  const openConsent = () => {
+    setIsBannerVisible(true);
   };
 
   return (
@@ -96,10 +121,12 @@ export function CookieConsentProvider({ children }: { children: ReactNode }) {
             : null,
         acceptCookies: handleAcceptCookies,
         declineCookies: handleDeclineCookies,
+        openConsent,
       }}
     >
       {children}
       <CookieConsent
+        isVisible={isBannerVisible}
         onAccept={handleAcceptCookies}
         onDecline={handleDeclineCookies}
       />

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -79,19 +79,6 @@ export function Layout({ children }: { children: ReactNode }) {
         />
         <meta charSet='utf-8' />
         <meta name='viewport' content='width=device-width, initial-scale=1' />
-        {/* Microsoft Clarity */}
-        <script
-          nonce={nonce}
-          dangerouslySetInnerHTML={{
-            __html: `
-              (function(c,l,a,r,i,t,y){
-                  c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
-                  t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
-                  y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
-              })(window, document, "clarity", "script", "ojo9prqys0");
-            `,
-          }}
-        />
         <Meta />
         <Links />
       </head>

--- a/app/routes/missions-private-events/meta.test.ts
+++ b/app/routes/missions-private-events/meta.test.ts
@@ -4,7 +4,7 @@ import { meta } from './meta';
 
 describe('missions-private-events metadata', () => {
   it('prevents search engines from indexing the privately shared finder', () => {
-    const robots = meta({} as Parameters<typeof meta>[0]).find(
+    const robots = (meta({} as never) ?? []).find(
       (entry) => 'name' in entry && entry.name === 'robots',
     );
 


### PR DESCRIPTION
## Summary

Gates Microsoft Clarity behind cookie consent so it no longer loads before the user accepts, fixes the mismatched localStorage consent values, and adds a footer **Cookie Settings** withdrawal path under About so users can reopen the banner and change their choice.

These changes close the main gap from the cookie consent audit: Clarity was firing unconditionally outside Consent Mode, while Google tags were deny-by-default until Accept.

## Screenshots

N/A — consent banner UI unchanged; Clarity load timing and footer link behavior are the functional changes.

## Testing

- [x] Clean browser / no `cookieConsent` in localStorage: banner shows; no `clarity.ms/tag/...` network request before Accept
- [x] Accept: Consent Mode grants analytics; Clarity script loads; `localStorage.cookieConsent === 'true'`
- [x] Decline: Consent Mode stays denied; Clarity does not load; `localStorage.cookieConsent === 'false'`
- [x] Returning user with `cookieConsent=true`: Clarity loads on mount without showing banner
- [x] Footer → About → **Cookie Settings**: reopens banner; Accept/Decline update consent again
- [x] `pnpm check` (lint / typecheck / prettier) passes
- [x] Related unit tests pass (`cookie-consent`, provider, `load-clarity`, footer column)

## Tickets

N/A

## Changes Made

### New Components Added

- None

### New Utilities

- `app/lib/load-clarity.ts` — idempotent Microsoft Clarity bootstrap (project id `ojo9prqys0`), loaded only after analytics consent is granted
- `app/lib/__tests__/load-clarity.test.ts` — covers inject + idempotency

### New Assets

- None

### Dependencies

- None

### Route Implementation

- `app/root.tsx` — removed unconditional Clarity `<script>` from `<head>`
- No new routes

### Key Features

- Clarity only loads on Accept or when returning users already have `cookieConsent=true`
- Cookie consent banner visibility lifted into `CookieConsentProvider` with `openConsent()` for withdrawal
- Provider is the single owner of `localStorage.cookieConsent` (`'true'` / `'false'`); banner no longer writes conflicting `'accepted'` / `'declined'` values
- Footer About column includes **Cookie Settings** button that reopens the consent banner
- Minor typecheck fix in `missions-private-events/meta.test.ts` so `pnpm check` passes


Made with [Cursor](https://cursor.com)