### PR TITLE
Cookies Consent Refinement

### DIFF
--- a/app/components/cookie-consent/__tests__/index.test.tsx
+++ b/app/components/cookie-consent/__tests__/index.test.tsx
@@ -1,6 +1,19 @@
 import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import { CookieConsent } from '../index';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+function renderBanner(props: {
+  isVisible: boolean;
+  onAccept: () => void;
+  onDecline: () => void;
+}) {
+  return render(
+    <MemoryRouter>
+      <CookieConsent {...props} />
+    </MemoryRouter>,
+  );
+}
 
 describe('CookieConsent', () => {
   const mockOnAccept = vi.fn();
@@ -11,45 +24,46 @@ describe('CookieConsent', () => {
     mockOnDecline.mockClear();
   });
 
-  it('renders when visible', () => {
-    render(
-      <CookieConsent
-        isVisible
-        onAccept={mockOnAccept}
-        onDecline={mockOnDecline}
-      />,
-    );
+  it('renders when visible with analytics-scoped copy and actions', () => {
+    renderBanner({
+      isVisible: true,
+      onAccept: mockOnAccept,
+      onDecline: mockOnDecline,
+    });
 
     expect(screen.getByRole('dialog')).toBeInTheDocument();
     expect(screen.getByText('Cookie Settings')).toBeInTheDocument();
-    expect(screen.getByText(/We use cookies/)).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Accept' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Decline' })).toBeInTheDocument();
+    expect(screen.getByText(/optional analytics cookies/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Allow analytics' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Reject analytics' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: /learn more in our privacy policy/i }),
+    ).toHaveAttribute('href', '/privacy-policy');
   });
 
   it('does not render when not visible', () => {
-    render(
-      <CookieConsent
-        isVisible={false}
-        onAccept={mockOnAccept}
-        onDecline={mockOnDecline}
-      />,
-    );
+    renderBanner({
+      isVisible: false,
+      onAccept: mockOnAccept,
+      onDecline: mockOnDecline,
+    });
 
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
 
   it('handles accept action correctly without writing localStorage', () => {
     localStorage.clear();
-    render(
-      <CookieConsent
-        isVisible
-        onAccept={mockOnAccept}
-        onDecline={mockOnDecline}
-      />,
-    );
+    renderBanner({
+      isVisible: true,
+      onAccept: mockOnAccept,
+      onDecline: mockOnDecline,
+    });
 
-    fireEvent.click(screen.getByRole('button', { name: 'Accept' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Allow analytics' }));
 
     expect(localStorage.getItem('cookieConsent')).toBeNull();
     expect(mockOnAccept).toHaveBeenCalledTimes(1);
@@ -57,33 +71,42 @@ describe('CookieConsent', () => {
 
   it('handles decline action correctly without writing localStorage', () => {
     localStorage.clear();
-    render(
-      <CookieConsent
-        isVisible
-        onAccept={mockOnAccept}
-        onDecline={mockOnDecline}
-      />,
-    );
+    renderBanner({
+      isVisible: true,
+      onAccept: mockOnAccept,
+      onDecline: mockOnDecline,
+    });
 
-    fireEvent.click(screen.getByRole('button', { name: 'Decline' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Reject analytics' }));
 
     expect(localStorage.getItem('cookieConsent')).toBeNull();
     expect(mockOnDecline).toHaveBeenCalledTimes(1);
   });
 
   it('has correct accessibility attributes', () => {
-    render(
-      <CookieConsent
-        isVisible
-        onAccept={mockOnAccept}
-        onDecline={mockOnDecline}
-      />,
-    );
+    renderBanner({
+      isVisible: true,
+      onAccept: mockOnAccept,
+      onDecline: mockOnDecline,
+    });
 
     const dialog = screen.getByRole('dialog');
     expect(dialog).toHaveAttribute('aria-labelledby', 'cookie-consent-title');
 
     const title = screen.getByText('Cookie Settings');
     expect(title).toHaveAttribute('id', 'cookie-consent-title');
+  });
+
+  it('gives accept and reject comparable visual prominence', () => {
+    renderBanner({
+      isVisible: true,
+      onAccept: mockOnAccept,
+      onDecline: mockOnDecline,
+    });
+
+    const allow = screen.getByRole('button', { name: 'Allow analytics' });
+    const reject = screen.getByRole('button', { name: 'Reject analytics' });
+
+    expect(allow.className).toBe(reject.className);
   });
 });

--- a/app/components/cookie-consent/index.tsx
+++ b/app/components/cookie-consent/index.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom';
 import { Button } from '~/primitives/button/button.primitive';
 
 interface CookieConsentProps {
@@ -29,16 +30,24 @@ export function CookieConsent({
               Cookie Settings
             </h2>
             <p className='mt-1 text-sm text-gray-600'>
-              We use cookies to enhance your browsing experience and analyze our
-              traffic. You can choose to accept or decline these cookies.
+              We use optional analytics cookies to understand how our website is
+              used and improve your experience. You can allow or reject
+              analytics cookies. Necessary site features will continue to work
+              either way.{' '}
+              <Link
+                to='/privacy-policy'
+                className='underline text-ocean hover:text-navy focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ocean'
+              >
+                Learn more in our Privacy Policy.
+              </Link>
             </p>
           </div>
           <div className='flex gap-3'>
             <Button onClick={onDecline} intent='secondary' size='sm'>
-              Decline
+              Reject analytics
             </Button>
-            <Button onClick={onAccept} intent='primary' size='sm'>
-              Accept
+            <Button onClick={onAccept} intent='secondary' size='sm'>
+              Allow analytics
             </Button>
           </div>
         </div>

--- a/app/components/deferred-gtm.test.tsx
+++ b/app/components/deferred-gtm.test.tsx
@@ -1,0 +1,61 @@
+import { render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DeferredGtm } from './deferred-gtm';
+
+describe('DeferredGtm', () => {
+  const gtmId = 'GTM-TEST123';
+
+  beforeEach(() => {
+    document
+      .querySelectorAll('script[src*="googletagmanager.com/gtm.js"]')
+      .forEach((el) => el.remove());
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    document
+      .querySelectorAll('script[src*="googletagmanager.com/gtm.js"]')
+      .forEach((el) => el.remove());
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('injects the GTM script for the given container id', () => {
+    render(<DeferredGtm gtmId={gtmId} />);
+    vi.runAllTimers();
+
+    const scripts = document.querySelectorAll(
+      `script[src="https://www.googletagmanager.com/gtm.js?id=${gtmId}"]`,
+    );
+    expect(scripts).toHaveLength(1);
+  });
+
+  it('does not inject a duplicate script when mounted repeatedly for the same id', () => {
+    const { unmount } = render(<DeferredGtm gtmId={gtmId} />);
+    vi.runAllTimers();
+    unmount();
+
+    render(<DeferredGtm gtmId={gtmId} />);
+    vi.runAllTimers();
+
+    const scripts = document.querySelectorAll(
+      `script[src="https://www.googletagmanager.com/gtm.js?id=${gtmId}"]`,
+    );
+    expect(scripts).toHaveLength(1);
+  });
+
+  it('does not inject a second script when one already exists in the document', () => {
+    const existing = document.createElement('script');
+    existing.src = `https://www.googletagmanager.com/gtm.js?id=${gtmId}`;
+    document.head.appendChild(existing);
+
+    render(<DeferredGtm gtmId={gtmId} />);
+    vi.runAllTimers();
+
+    expect(
+      document.querySelectorAll(
+        `script[src="https://www.googletagmanager.com/gtm.js?id=${gtmId}"]`,
+      ),
+    ).toHaveLength(1);
+  });
+});

--- a/app/components/deferred-gtm.tsx
+++ b/app/components/deferred-gtm.tsx
@@ -3,10 +3,18 @@ import { useEffect } from 'react';
 /**
  * Loads GTM after idle so first paint is not blocked by googletagmanager.com.
  * Consent defaults remain in root Layout (inline, before any GTM network).
+ * Idempotent: does not inject a second script for the same container ID.
  */
 export function DeferredGtm({ gtmId }: { gtmId: string }) {
   useEffect(() => {
     const load = () => {
+      const existingScript = document.querySelector(
+        `script[src*="googletagmanager.com/gtm.js"][src*="id=${gtmId}"]`,
+      );
+      if (existingScript) {
+        return;
+      }
+
       const script = document.createElement('script');
       script.async = true;
       script.src = `https://www.googletagmanager.com/gtm.js?id=${gtmId}`;

--- a/app/components/footer/footer-column.component.test.tsx
+++ b/app/components/footer/footer-column.component.test.tsx
@@ -1,8 +1,13 @@
 import { render, screen, fireEvent } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { MemoryRouter } from 'react-router-dom';
 import { describe, it, expect, vi } from 'vitest';
 import { FooterColumnComponent } from './footer-column.component';
 import { footerColumns } from './footer-data';
-import { CookieConsentProvider } from '~/providers/cookie-consent-provider';
+import {
+  CONSENT_POLICY_VERSION,
+  CookieConsentProvider,
+} from '~/providers/cookie-consent-provider';
 
 vi.mock('~/components', () => ({
   ConnectCardModal: ({ buttonTitle }: { buttonTitle?: string }) => (
@@ -20,6 +25,14 @@ vi.mock('~/lib/load-clarity', () => ({
   loadClarity: vi.fn(),
 }));
 
+function renderWithProviders(ui: ReactNode) {
+  return render(
+    <MemoryRouter>
+      <CookieConsentProvider>{ui}</CookieConsentProvider>
+    </MemoryRouter>,
+  );
+}
+
 describe('FooterColumnComponent', () => {
   it('renders Subscribe to Updates as the newsletter subscription modal trigger', () => {
     const connectColumn = footerColumns.find(
@@ -27,11 +40,7 @@ describe('FooterColumnComponent', () => {
     );
 
     expect(connectColumn).toBeDefined();
-    render(
-      <CookieConsentProvider>
-        <FooterColumnComponent column={connectColumn!} />
-      </CookieConsentProvider>,
-    );
+    renderWithProviders(<FooterColumnComponent column={connectColumn!} />);
 
     expect(
       screen.getByTestId('newsletter-subscription-modal'),
@@ -43,16 +52,13 @@ describe('FooterColumnComponent', () => {
 
   it('renders Cookie Settings as a button that opens consent', () => {
     localStorage.setItem('cookieConsent', 'true');
+    localStorage.setItem('cookieConsentVersion', CONSENT_POLICY_VERSION);
     const aboutColumn = footerColumns.find(
       (column) => column.title === 'About',
     );
 
     expect(aboutColumn).toBeDefined();
-    render(
-      <CookieConsentProvider>
-        <FooterColumnComponent column={aboutColumn!} />
-      </CookieConsentProvider>,
-    );
+    renderWithProviders(<FooterColumnComponent column={aboutColumn!} />);
 
     const cookieSettings = screen.getByRole('button', {
       name: 'Cookie Settings',

--- a/app/components/footer/footer-column.component.tsx
+++ b/app/components/footer/footer-column.component.tsx
@@ -48,7 +48,7 @@ export const FooterColumnComponent = ({ column }: FooterColumnProps) => {
           <button
             key={link.title}
             type='button'
-            className='text-lg text-left hover:text-white/50 transition-colors'
+            className='text-lg text-left hover:text-white/50 transition-colors cursor-pointer'
             onClick={openConsent}
             aria-label={`${link.title}`}
           >

--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -1,0 +1,42 @@
+import type { EntryContext } from 'react-router';
+import {
+  handleRequest as vercelHandleRequest,
+  streamTimeout,
+} from '@vercel/react-router/entry.server';
+
+export { streamTimeout };
+
+interface RootLoaderData {
+  nonce?: string;
+}
+
+function getRootNonce(routerContext: EntryContext): string | undefined {
+  const rootData = routerContext.staticHandlerContext.loaderData?.root as
+    | RootLoaderData
+    | undefined;
+  return rootData?.nonce;
+}
+
+/**
+ * Pass the root-loader nonce into ServerRouter + renderToPipeableStream.
+ * Without this, React Router's streamController.enqueue/close scripts render
+ * without a nonce and are blocked by our script-src CSP — breaking hydration.
+ *
+ * @see https://reactrouter.com/how-to/security
+ */
+export default function handleRequest(
+  ...args: Parameters<typeof vercelHandleRequest>
+) {
+  const [request, responseStatusCode, responseHeaders, routerContext, loadContext] =
+    args;
+  const nonce = getRootNonce(routerContext);
+
+  return vercelHandleRequest(
+    request,
+    responseStatusCode,
+    responseHeaders,
+    routerContext,
+    loadContext,
+    nonce ? { nonce } : undefined,
+  );
+}

--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -63,11 +63,7 @@ export default function handleRequest(
     );
 
     const { pipe, abort } = renderToPipeableStream(
-      <ServerRouter
-        context={routerContext}
-        url={request.url}
-        nonce={nonce}
-      />,
+      <ServerRouter context={routerContext} url={request.url} nonce={nonce} />,
       {
         nonce,
         [readyOption]() {

--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -1,10 +1,13 @@
-import type { EntryContext } from 'react-router';
-import {
-  handleRequest as vercelHandleRequest,
-  streamTimeout,
-} from '@vercel/react-router/entry.server';
+import { PassThrough } from 'node:stream';
 
-export { streamTimeout };
+import type { AppLoadContext, EntryContext } from 'react-router';
+import { createReadableStreamFromReadable } from '@react-router/node';
+import { ServerRouter } from 'react-router';
+import { isbot } from 'isbot';
+import type { RenderToPipeableStreamOptions } from 'react-dom/server';
+import { renderToPipeableStream } from 'react-dom/server';
+
+export const streamTimeout = 5_000;
 
 interface RootLoaderData {
   nonce?: string;
@@ -18,25 +21,97 @@ function getRootNonce(routerContext: EntryContext): string | undefined {
 }
 
 /**
- * Pass the root-loader nonce into ServerRouter + renderToPipeableStream.
- * Without this, React Router's streamController.enqueue/close scripts render
- * without a nonce and are blocked by our script-src CSP — breaking hydration.
+ * Custom entry.server so we can pass the root-loader CSP nonce into
+ * ServerRouter + renderToPipeableStream. Without that, React Router's
+ * streamController.enqueue/close scripts omit the nonce and are blocked.
+ *
+ * Implemented here (not via `@vercel/react-router/entry.server`) so
+ * ServerRouter shares the app's React/react-router instances. Importing the
+ * Vercel package leaves it externalized and splits context, which crashes
+ * Layout with "useRouteLoaderData must be used within a data router".
  *
  * @see https://reactrouter.com/how-to/security
  */
 export default function handleRequest(
-  ...args: Parameters<typeof vercelHandleRequest>
+  request: Request,
+  responseStatusCode: number,
+  responseHeaders: Headers,
+  routerContext: EntryContext,
+  _loadContext: AppLoadContext,
 ) {
-  const [request, responseStatusCode, responseHeaders, routerContext, loadContext] =
-    args;
+  if (request.method.toUpperCase() === 'HEAD') {
+    return new Response(null, {
+      status: responseStatusCode,
+      headers: responseHeaders,
+    });
+  }
+
   const nonce = getRootNonce(routerContext);
 
-  return vercelHandleRequest(
-    request,
-    responseStatusCode,
-    responseHeaders,
-    routerContext,
-    loadContext,
-    nonce ? { nonce } : undefined,
-  );
+  return new Promise((resolve, reject) => {
+    let shellRendered = false;
+    const userAgent = request.headers.get('user-agent');
+
+    const readyOption: keyof RenderToPipeableStreamOptions =
+      (userAgent && isbot(userAgent)) || routerContext.isSpaMode
+        ? 'onAllReady'
+        : 'onShellReady';
+
+    let timeoutId: ReturnType<typeof setTimeout> | undefined = setTimeout(
+      () => abort(),
+      streamTimeout + 1000,
+    );
+
+    const { pipe, abort } = renderToPipeableStream(
+      <ServerRouter
+        context={routerContext}
+        url={request.url}
+        nonce={nonce}
+      />,
+      {
+        nonce,
+        [readyOption]() {
+          shellRendered = true;
+          const body = new PassThrough({
+            final(callback) {
+              clearTimeout(timeoutId);
+              timeoutId = undefined;
+              callback();
+            },
+          });
+          const stream = createReadableStreamFromReadable(body);
+
+          responseHeaders.set('Content-Type', 'text/html');
+
+          if (
+            process.env.VERCEL_SKEW_PROTECTION_ENABLED === '1' &&
+            process.env.VERCEL_DEPLOYMENT_ID
+          ) {
+            responseHeaders.append(
+              'Set-Cookie',
+              `__vdpl=${process.env.VERCEL_DEPLOYMENT_ID}; HttpOnly`,
+            );
+          }
+
+          pipe(body);
+
+          resolve(
+            new Response(stream, {
+              headers: responseHeaders,
+              status: responseStatusCode,
+            }),
+          );
+        },
+        onShellError(error: unknown) {
+          reject(error);
+        },
+        onError(error: unknown) {
+          responseStatusCode = 500;
+          if (shellRendered) {
+            console.error(error);
+          }
+        },
+      },
+    );
+  });
 }

--- a/app/lib/__tests__/analytics-host.test.ts
+++ b/app/lib/__tests__/analytics-host.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { isProductionHost, PRODUCTION_HOSTS } from '../analytics-host';
+
+describe('PRODUCTION_HOSTS', () => {
+  it('lists only the canonical production hostnames', () => {
+    expect(PRODUCTION_HOSTS).toEqual([
+      'www.christfellowship.church',
+      'christfellowship.church',
+    ]);
+  });
+});
+
+describe('isProductionHost', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns true for www production hostname', () => {
+    vi.stubGlobal('location', { hostname: 'www.christfellowship.church' });
+    expect(isProductionHost()).toBe(true);
+  });
+
+  it('returns true for apex production hostname', () => {
+    vi.stubGlobal('location', { hostname: 'christfellowship.church' });
+    expect(isProductionHost()).toBe(true);
+  });
+
+  it('returns false for preview vercel.app hostnames', () => {
+    vi.stubGlobal('location', {
+      hostname: 'remix-web-app-git-feature.vercel.app',
+    });
+    expect(isProductionHost()).toBe(false);
+  });
+
+  it('returns false for localhost', () => {
+    vi.stubGlobal('location', { hostname: 'localhost' });
+    expect(isProductionHost()).toBe(false);
+  });
+
+  it('returns false when window is undefined', () => {
+    const originalWindow = globalThis.window;
+    // @ts-expect-error intentional SSR simulation
+    delete globalThis.window;
+    expect(isProductionHost()).toBe(false);
+    globalThis.window = originalWindow;
+  });
+});

--- a/app/lib/__tests__/load-clarity.test.ts
+++ b/app/lib/__tests__/load-clarity.test.ts
@@ -1,12 +1,17 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { loadClarity } from '../load-clarity';
 
+function stubHostname(hostname: string) {
+  vi.stubGlobal('location', { hostname });
+}
+
 describe('loadClarity', () => {
   beforeEach(() => {
     document
       .querySelectorAll('script[src*="clarity.ms/tag/"]')
       .forEach((el) => el.remove());
     delete window.clarity;
+    stubHostname('www.christfellowship.church');
   });
 
   afterEach(() => {
@@ -14,10 +19,11 @@ describe('loadClarity', () => {
       .querySelectorAll('script[src*="clarity.ms/tag/"]')
       .forEach((el) => el.remove());
     delete window.clarity;
+    vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
 
-  it('injects the Clarity tag script with the default project id', () => {
+  it('injects the Clarity tag script on a production hostname', () => {
     loadClarity();
 
     const script = document.querySelector(
@@ -25,6 +31,16 @@ describe('loadClarity', () => {
     );
     expect(script).toBeInTheDocument();
     expect(typeof window.clarity).toBe('function');
+  });
+
+  it('does not inject Clarity on preview or non-production hostnames', () => {
+    stubHostname('remix-web-app-git-feature.vercel.app');
+    loadClarity();
+
+    expect(
+      document.querySelector('script[src*="clarity.ms/tag/"]'),
+    ).not.toBeInTheDocument();
+    expect(window.clarity).toBeUndefined();
   });
 
   it('is idempotent when Clarity is already present', () => {

--- a/app/lib/analytics-host.ts
+++ b/app/lib/analytics-host.ts
@@ -1,0 +1,22 @@
+/**
+ * Canonical production hostnames for analytics destination routing.
+ * Preview/staging (e.g. *.vercel.app) and local must not be treated as production.
+ */
+export const PRODUCTION_HOSTS = [
+  'www.christfellowship.church',
+  'christfellowship.church',
+] as const;
+
+/**
+ * True only when running in the browser on a production hostname.
+ * Returns false during SSR or whenever `window` is unavailable.
+ */
+export function isProductionHost(): boolean {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  return (PRODUCTION_HOSTS as readonly string[]).includes(
+    window.location.hostname,
+  );
+}

--- a/app/lib/load-clarity.ts
+++ b/app/lib/load-clarity.ts
@@ -1,3 +1,5 @@
+import { isProductionHost } from '~/lib/analytics-host';
+
 const DEFAULT_CLARITY_ID = 'ojo9prqys0';
 
 declare global {
@@ -9,9 +11,19 @@ declare global {
 /**
  * Idempotent Microsoft Clarity bootstrap. No-ops if Clarity is already present
  * or if a tag script is already in the document.
+ *
+ * Production-only: the current Clarity project is tied to production traffic.
+ * Preview/staging/local must not send sessions into that project.
+ *
+ * TODO: If a separate dev Clarity project ID is added later, select the project
+ * ID by hostname instead of skipping non-production hosts.
  */
 export function loadClarity(projectId = DEFAULT_CLARITY_ID): void {
   if (typeof window === 'undefined' || typeof document === 'undefined') {
+    return;
+  }
+
+  if (!isProductionHost()) {
     return;
   }
 

--- a/app/providers/__tests__/cookie-consent-provider.test.tsx
+++ b/app/providers/__tests__/cookie-consent-provider.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
+  CONSENT_POLICY_VERSION,
   CookieConsentProvider,
   useCookieConsent,
 } from '../cookie-consent-provider';
@@ -9,6 +10,12 @@ const loadClarityMock = vi.fn();
 
 vi.mock('~/lib/load-clarity', () => ({
   loadClarity: (...args: unknown[]) => loadClarityMock(...args),
+}));
+
+vi.mock('~/components/deferred-gtm', () => ({
+  DeferredGtm: ({ gtmId }: { gtmId: string }) => (
+    <div data-testid='deferred-gtm' data-gtm-id={gtmId} />
+  ),
 }));
 
 vi.mock('../../components/cookie-consent', () => ({
@@ -23,34 +30,64 @@ vi.mock('../../components/cookie-consent', () => ({
   }) =>
     isVisible ? (
       <div>
-        <button onClick={onAccept}>Accept cookies</button>
-        <button onClick={onDecline}>Decline cookies</button>
+        <button onClick={onAccept}>Allow analytics</button>
+        <button onClick={onDecline}>Reject analytics</button>
       </div>
     ) : null,
 }));
 
 function TestConsumer() {
-  const { hasConsent, acceptCookies, declineCookies, openConsent } =
-    useCookieConsent();
+  const {
+    hasStoredDecision,
+    isAnalyticsAllowed,
+    acceptAnalytics,
+    rejectAnalytics,
+    openConsent,
+  } = useCookieConsent();
   return (
     <div>
-      <span data-testid='consent'>{String(hasConsent)}</span>
-      <button onClick={acceptCookies}>accept</button>
-      <button onClick={declineCookies}>decline</button>
+      <span data-testid='has-decision'>{String(hasStoredDecision)}</span>
+      <span data-testid='analytics-allowed'>{String(isAnalyticsAllowed)}</span>
+      <button onClick={acceptAnalytics}>accept</button>
+      <button onClick={rejectAnalytics}>reject</button>
       <button onClick={openConsent}>open settings</button>
     </div>
   );
 }
 
+function getConsentUpdates(): Array<Record<string, string>> {
+  return window.dataLayer
+    .filter((entry): entry is IArguments => {
+      if (!entry || typeof entry !== 'object') {
+        return false;
+      }
+      const maybeArgs = entry as IArguments;
+      return maybeArgs[0] === 'consent' && maybeArgs[1] === 'update';
+    })
+    .map((entry) => entry[2] as Record<string, string>);
+}
+
+function storePreference(
+  isAnalyticsAllowed: boolean,
+  version = CONSENT_POLICY_VERSION,
+) {
+  localStorage.setItem('cookieConsent', String(isAnalyticsAllowed));
+  localStorage.setItem('cookieConsentVersion', version);
+}
+
 describe('CookieConsentProvider', () => {
+  const originalGtmId = import.meta.env.VITE_GTM_ID;
+
   beforeEach(() => {
     localStorage.clear();
     sessionStorage.clear();
     window.dataLayer = [];
     loadClarityMock.mockClear();
+    import.meta.env.VITE_GTM_ID = 'GTM-TEST123';
   });
 
   afterEach(() => {
+    import.meta.env.VITE_GTM_ID = originalGtmId;
     vi.restoreAllMocks();
   });
 
@@ -63,20 +100,24 @@ describe('CookieConsentProvider', () => {
     expect(screen.getByText('child')).toBeInTheDocument();
   });
 
-  it('shows the CookieConsent banner when no consent is stored', async () => {
+  it('shows the banner and loads neither GTM nor Clarity when no preference is stored', async () => {
     await act(async () => {
       render(
         <CookieConsentProvider>
-          <div />
+          <TestConsumer />
         </CookieConsentProvider>,
       );
     });
-    expect(screen.getByText('Accept cookies')).toBeInTheDocument();
-    expect(screen.getByText('Decline cookies')).toBeInTheDocument();
+
+    expect(screen.getByText('Allow analytics')).toBeInTheDocument();
+    expect(screen.getByText('Reject analytics')).toBeInTheDocument();
+    expect(screen.queryByTestId('deferred-gtm')).not.toBeInTheDocument();
+    expect(loadClarityMock).not.toHaveBeenCalled();
+    expect(screen.getByTestId('analytics-allowed')).toHaveTextContent('false');
   });
 
-  it('does not show the banner when consent is already stored', async () => {
-    localStorage.setItem('cookieConsent', 'true');
+  it('does not show the banner when a current accepted preference is stored', async () => {
+    storePreference(true);
     await act(async () => {
       render(
         <CookieConsentProvider>
@@ -84,7 +125,7 @@ describe('CookieConsentProvider', () => {
         </CookieConsentProvider>,
       );
     });
-    expect(screen.queryByText('Accept cookies')).not.toBeInTheDocument();
+    expect(screen.queryByText('Allow analytics')).not.toBeInTheDocument();
   });
 
   it('throws when useCookieConsent used outside provider', () => {
@@ -96,15 +137,30 @@ describe('CookieConsentProvider', () => {
     console.error = originalError;
   });
 
-  it('acceptCookies sets localStorage to true and loads Clarity', () => {
+  it('accept grants analytics only, keeps advertising denied, and loads GTM and Clarity', () => {
     render(
       <CookieConsentProvider>
         <TestConsumer />
       </CookieConsentProvider>,
     );
     fireEvent.click(screen.getByText('accept'));
+
     expect(localStorage.getItem('cookieConsent')).toBe('true');
+    expect(localStorage.getItem('cookieConsentVersion')).toBe(
+      CONSENT_POLICY_VERSION,
+    );
     expect(loadClarityMock).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('deferred-gtm')).toBeInTheDocument();
+    expect(screen.getByTestId('analytics-allowed')).toHaveTextContent('true');
+
+    const updates = getConsentUpdates();
+    expect(updates.at(-1)).toEqual({
+      analytics_storage: 'granted',
+      ad_storage: 'denied',
+      ad_user_data: 'denied',
+      ad_personalization: 'denied',
+    });
+
     const events = window.dataLayer.filter(
       (e) => typeof e === 'object' && e !== null && 'event' in e,
     );
@@ -116,15 +172,30 @@ describe('CookieConsentProvider', () => {
     ).toBe(true);
   });
 
-  it('declineCookies sets localStorage to false and does not load Clarity', () => {
+  it('reject denies all consent signals and loads neither GTM nor Clarity', () => {
     render(
       <CookieConsentProvider>
         <TestConsumer />
       </CookieConsentProvider>,
     );
-    fireEvent.click(screen.getByText('decline'));
+    fireEvent.click(screen.getByText('reject'));
+
     expect(localStorage.getItem('cookieConsent')).toBe('false');
+    expect(localStorage.getItem('cookieConsentVersion')).toBe(
+      CONSENT_POLICY_VERSION,
+    );
     expect(loadClarityMock).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('deferred-gtm')).not.toBeInTheDocument();
+    expect(screen.getByTestId('analytics-allowed')).toHaveTextContent('false');
+
+    const updates = getConsentUpdates();
+    expect(updates.at(-1)).toEqual({
+      analytics_storage: 'denied',
+      ad_storage: 'denied',
+      ad_user_data: 'denied',
+      ad_personalization: 'denied',
+    });
+
     const events = window.dataLayer.filter(
       (e) => typeof e === 'object' && e !== null && 'event' in e,
     );
@@ -136,40 +207,29 @@ describe('CookieConsentProvider', () => {
     ).toBe(true);
   });
 
-  it('does not load Clarity when no consent is stored', async () => {
+  it('returning accepted user loads Clarity and GTM once and keeps the banner hidden', async () => {
+    storePreference(true);
     await act(async () => {
       render(
         <CookieConsentProvider>
-          <div />
+          <TestConsumer />
         </CookieConsentProvider>,
       );
     });
-    expect(loadClarityMock).not.toHaveBeenCalled();
-  });
 
-  it('on mount with saved consent=true, loads Clarity and pushes cookie_consent_accepted if not already fired', async () => {
-    localStorage.setItem('cookieConsent', 'true');
-    await act(async () => {
-      render(
-        <CookieConsentProvider>
-          <div />
-        </CookieConsentProvider>,
-      );
-    });
+    expect(screen.queryByText('Allow analytics')).not.toBeInTheDocument();
     expect(loadClarityMock).toHaveBeenCalledTimes(1);
-    const events = window.dataLayer.filter(
-      (e) => typeof e === 'object' && e !== null && 'event' in e,
-    );
-    expect(
-      events.some(
-        (e) =>
-          (e as Record<string, unknown>).event === 'cookie_consent_accepted',
-      ),
-    ).toBe(true);
+    expect(screen.getByTestId('deferred-gtm')).toBeInTheDocument();
+    expect(getConsentUpdates().at(-1)).toEqual({
+      analytics_storage: 'granted',
+      ad_storage: 'denied',
+      ad_user_data: 'denied',
+      ad_personalization: 'denied',
+    });
   });
 
-  it('on mount with saved consent=true and session already fired, does not push event again but still loads Clarity', async () => {
-    localStorage.setItem('cookieConsent', 'true');
+  it('returning accepted user with session already fired does not push event again but still loads analytics', async () => {
+    storePreference(true);
     sessionStorage.setItem('gtm_consent_fired', 'true');
     await act(async () => {
       render(
@@ -179,6 +239,7 @@ describe('CookieConsentProvider', () => {
       );
     });
     expect(loadClarityMock).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('deferred-gtm')).toBeInTheDocument();
     const events = window.dataLayer.filter(
       (e) => typeof e === 'object' && e !== null && 'event' in e,
     );
@@ -190,20 +251,8 @@ describe('CookieConsentProvider', () => {
     ).toBe(false);
   });
 
-  it('on mount with saved consent=false, does not load Clarity', async () => {
-    localStorage.setItem('cookieConsent', 'false');
-    await act(async () => {
-      render(
-        <CookieConsentProvider>
-          <div />
-        </CookieConsentProvider>,
-      );
-    });
-    expect(loadClarityMock).not.toHaveBeenCalled();
-  });
-
-  it('openConsent re-opens the banner', async () => {
-    localStorage.setItem('cookieConsent', 'false');
+  it('returning rejected user keeps scripts absent and banner hidden', async () => {
+    storePreference(false);
     await act(async () => {
       render(
         <CookieConsentProvider>
@@ -211,9 +260,115 @@ describe('CookieConsentProvider', () => {
         </CookieConsentProvider>,
       );
     });
-    expect(screen.queryByText('Accept cookies')).not.toBeInTheDocument();
+
+    expect(screen.queryByText('Allow analytics')).not.toBeInTheDocument();
+    expect(loadClarityMock).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('deferred-gtm')).not.toBeInTheDocument();
+    expect(getConsentUpdates().at(-1)).toEqual({
+      analytics_storage: 'denied',
+      ad_storage: 'denied',
+      ad_user_data: 'denied',
+      ad_personalization: 'denied',
+    });
+  });
+
+  it('re-prompts when legacy preference lacks the current consent version', async () => {
+    localStorage.setItem('cookieConsent', 'true');
+    await act(async () => {
+      render(
+        <CookieConsentProvider>
+          <TestConsumer />
+        </CookieConsentProvider>,
+      );
+    });
+
+    expect(screen.getByText('Allow analytics')).toBeInTheDocument();
+    expect(loadClarityMock).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('deferred-gtm')).not.toBeInTheDocument();
+  });
+
+  it('re-prompts when consent version is outdated', async () => {
+    storePreference(true, '2025-01');
+    await act(async () => {
+      render(
+        <CookieConsentProvider>
+          <div />
+        </CookieConsentProvider>,
+      );
+    });
+
+    expect(screen.getByText('Allow analytics')).toBeInTheDocument();
+    expect(loadClarityMock).not.toHaveBeenCalled();
+  });
+
+  it('fails safely and shows the banner for malformed localStorage values', async () => {
+    localStorage.setItem('cookieConsent', 'yes-please');
+    localStorage.setItem('cookieConsentVersion', CONSENT_POLICY_VERSION);
+    await act(async () => {
+      render(
+        <CookieConsentProvider>
+          <div />
+        </CookieConsentProvider>,
+      );
+    });
+
+    expect(screen.getByText('Allow analytics')).toBeInTheDocument();
+    expect(loadClarityMock).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('deferred-gtm')).not.toBeInTheDocument();
+  });
+
+  it('openConsent re-opens the banner', async () => {
+    storePreference(false);
+    await act(async () => {
+      render(
+        <CookieConsentProvider>
+          <TestConsumer />
+        </CookieConsentProvider>,
+      );
+    });
+    expect(screen.queryByText('Allow analytics')).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByText('open settings'));
-    expect(screen.getByText('Accept cookies')).toBeInTheDocument();
+    expect(screen.getByText('Allow analytics')).toBeInTheDocument();
+  });
+
+  it('rejection after acceptance sends denied consent updates', () => {
+    render(
+      <CookieConsentProvider>
+        <TestConsumer />
+      </CookieConsentProvider>,
+    );
+
+    fireEvent.click(screen.getByText('accept'));
+    expect(screen.getByTestId('deferred-gtm')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('open settings'));
+    fireEvent.click(screen.getByText('reject'));
+
+    expect(screen.queryByTestId('deferred-gtm')).not.toBeInTheDocument();
+    expect(loadClarityMock).toHaveBeenCalledTimes(1);
+    expect(getConsentUpdates().at(-1)).toEqual({
+      analytics_storage: 'denied',
+      ad_storage: 'denied',
+      ad_user_data: 'denied',
+      ad_personalization: 'denied',
+    });
+    expect(localStorage.getItem('cookieConsent')).toBe('false');
+  });
+
+  it('repeated acceptance does not load Clarity more than once', () => {
+    render(
+      <CookieConsentProvider>
+        <TestConsumer />
+      </CookieConsentProvider>,
+    );
+
+    fireEvent.click(screen.getByText('accept'));
+    fireEvent.click(screen.getByText('open settings'));
+    fireEvent.click(screen.getByText('accept'));
+
+    // Provider may call loadClarity twice; loadClarity itself is idempotent.
+    expect(loadClarityMock).toHaveBeenCalled();
+    expect(screen.getAllByTestId('deferred-gtm')).toHaveLength(1);
   });
 });

--- a/app/providers/__tests__/cookie-consent-provider.test.tsx
+++ b/app/providers/__tests__/cookie-consent-provider.test.tsx
@@ -151,6 +151,10 @@ describe('CookieConsentProvider', () => {
     );
     expect(loadClarityMock).toHaveBeenCalledTimes(1);
     expect(screen.getByTestId('deferred-gtm')).toBeInTheDocument();
+    expect(screen.getByTestId('deferred-gtm')).toHaveAttribute(
+      'data-gtm-id',
+      'GTM-TEST123',
+    );
     expect(screen.getByTestId('analytics-allowed')).toHaveTextContent('true');
 
     const updates = getConsentUpdates();

--- a/app/providers/cookie-consent-provider.tsx
+++ b/app/providers/cookie-consent-provider.tsx
@@ -6,7 +6,28 @@ import {
   type ReactNode,
 } from 'react';
 import { CookieConsent } from '../components/cookie-consent';
+import { DeferredGtm } from '~/components/deferred-gtm';
 import { loadClarity } from '~/lib/load-clarity';
+
+/** Bump when consent semantics change so legacy preferences are re-prompted. */
+export const CONSENT_POLICY_VERSION = '2026-07';
+
+const CONSENT_STORAGE_KEY = 'cookieConsent';
+const CONSENT_VERSION_KEY = 'cookieConsentVersion';
+
+const DENIED_CONSENT = {
+  analytics_storage: 'denied',
+  ad_storage: 'denied',
+  ad_user_data: 'denied',
+  ad_personalization: 'denied',
+} as const;
+
+const ANALYTICS_GRANTED_CONSENT = {
+  analytics_storage: 'granted',
+  ad_storage: 'denied',
+  ad_user_data: 'denied',
+  ad_personalization: 'denied',
+} as const;
 
 declare global {
   interface Window {
@@ -15,9 +36,12 @@ declare global {
 }
 
 interface CookieConsentContextType {
-  hasConsent: boolean | null;
-  acceptCookies: () => void;
-  declineCookies: () => void;
+  /** Whether a valid, current-version preference is stored (accepted or rejected). */
+  hasStoredDecision: boolean | null;
+  /** Whether the user has granted analytics (not the same as hasStoredDecision). */
+  isAnalyticsAllowed: boolean;
+  acceptAnalytics: () => void;
+  rejectAnalytics: () => void;
   openConsent: () => void;
 }
 
@@ -25,85 +49,121 @@ const CookieConsentContext = createContext<
   CookieConsentContextType | undefined
 >(undefined);
 
+// GTM specifically looks for the 'arguments' object to be pushed.
+// Use function declaration (not arrow function) to access arguments object.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const gtag: (...args: any[]) => void = function () {
+  if (typeof window !== 'undefined') {
+    window.dataLayer = window.dataLayer || [];
+    // Matches Google's specification; arguments object required for GTM compatibility.
+    window.dataLayer.push(arguments);
+  }
+};
+
+function readStoredAnalyticsPreference(): boolean | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  const savedConsent = localStorage.getItem(CONSENT_STORAGE_KEY);
+  const savedVersion = localStorage.getItem(CONSENT_VERSION_KEY);
+
+  // Legacy PR #358 preferences (boolean without current version) are re-prompted.
+  if (savedVersion !== CONSENT_POLICY_VERSION) {
+    return null;
+  }
+
+  if (savedConsent === 'true') {
+    return true;
+  }
+
+  if (savedConsent === 'false') {
+    return false;
+  }
+
+  return null;
+}
+
+function persistAnalyticsPreference(isAnalyticsAllowed: boolean): void {
+  localStorage.setItem(CONSENT_STORAGE_KEY, String(isAnalyticsAllowed));
+  localStorage.setItem(CONSENT_VERSION_KEY, CONSENT_POLICY_VERSION);
+}
+
+function pushConsentUpdate(
+  consent: typeof DENIED_CONSENT | typeof ANALYTICS_GRANTED_CONSENT,
+): void {
+  gtag('consent', 'update', consent);
+}
+
+function pushAcceptedEventOncePerSession(force = false): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  if (!force && sessionStorage.getItem('gtm_consent_fired')) {
+    return;
+  }
+
+  window.dataLayer = window.dataLayer || [];
+  window.dataLayer.push({ event: 'cookie_consent_accepted' });
+  sessionStorage.setItem('gtm_consent_fired', 'true');
+}
+
 export function CookieConsentProvider({ children }: { children: ReactNode }) {
   const [isBannerVisible, setIsBannerVisible] = useState(false);
+  const [isAnalyticsAllowed, setIsAnalyticsAllowed] = useState(false);
+  const [hasStoredDecision, setHasStoredDecision] = useState<boolean | null>(
+    null,
+  );
+  const gtmId = import.meta.env.VITE_GTM_ID as string | undefined;
 
-  // GTM specifically looks for the 'arguments' object to be pushed
-  // Use function declaration (not arrow function) to access arguments object
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const gtag: (...args: any[]) => void = function () {
-    if (typeof window !== 'undefined') {
-      window.dataLayer = window.dataLayer || [];
-      // This matches the exact specification Google provides
-      // Use arguments object for GTM compatibility
-      window.dataLayer.push(arguments);
-    }
-  };
-
-  // Re-apply consent from localStorage on mount so GTM "remembers" for returning users.
-  // Only push cookie_consent_accepted once per session so Page View fires once; History Change handles subsequent navigations.
-  // Load Clarity only when analytics consent was previously granted.
+  // Restore preference on mount: apply consent signals, load Clarity when granted,
+  // and show the banner when preference is missing, malformed, or outdated.
   useEffect(() => {
-    const savedConsent = localStorage.getItem('cookieConsent');
+    const savedPreference = readStoredAnalyticsPreference();
 
-    if (!savedConsent) {
+    if (savedPreference === null) {
+      setHasStoredDecision(false);
+      setIsAnalyticsAllowed(false);
       setIsBannerVisible(true);
       return;
     }
 
-    if (savedConsent === 'true') {
-      gtag('consent', 'update', {
-        ad_storage: 'granted',
-        analytics_storage: 'granted',
-        ad_user_data: 'granted',
-        ad_personalization: 'granted',
-      });
+    setHasStoredDecision(true);
 
-      if (!sessionStorage.getItem('gtm_consent_fired')) {
-        window.dataLayer.push({ event: 'cookie_consent_accepted' });
-        sessionStorage.setItem('gtm_consent_fired', 'true');
-      }
-
+    if (savedPreference) {
+      pushConsentUpdate(ANALYTICS_GRANTED_CONSENT);
+      pushAcceptedEventOncePerSession();
       loadClarity();
-    } else if (savedConsent === 'false') {
-      gtag('consent', 'update', {
-        ad_storage: 'denied',
-        analytics_storage: 'denied',
-        ad_user_data: 'denied',
-        ad_personalization: 'denied',
-      });
+      setIsAnalyticsAllowed(true);
+      return;
     }
+
+    pushConsentUpdate(DENIED_CONSENT);
+    setIsAnalyticsAllowed(false);
   }, []);
 
-  const handleAcceptCookies = () => {
+  const acceptAnalytics = () => {
     if (typeof window !== 'undefined') {
-      // This will now correctly trigger GTM's internal Consent state
-      gtag('consent', 'update', {
-        ad_storage: 'granted',
-        analytics_storage: 'granted',
-        ad_user_data: 'granted',
-        ad_personalization: 'granted',
-      });
-
-      window.dataLayer.push({ event: 'cookie_consent_accepted' });
-      sessionStorage.setItem('gtm_consent_fired', 'true');
-      localStorage.setItem('cookieConsent', 'true');
+      pushConsentUpdate(ANALYTICS_GRANTED_CONSENT);
+      pushAcceptedEventOncePerSession(true);
+      persistAnalyticsPreference(true);
       loadClarity();
+      setIsAnalyticsAllowed(true);
+      setHasStoredDecision(true);
     }
     setIsBannerVisible(false);
   };
 
-  const handleDeclineCookies = () => {
+  const rejectAnalytics = () => {
     if (typeof window !== 'undefined') {
-      gtag('consent', 'update', {
-        ad_storage: 'denied',
-        analytics_storage: 'denied',
-        ad_user_data: 'denied',
-        ad_personalization: 'denied',
-      });
-
+      // Send denied signals before persisting so a prior grant is revoked immediately.
+      pushConsentUpdate(DENIED_CONSENT);
+      window.dataLayer = window.dataLayer || [];
       window.dataLayer.push({ event: 'cookie_consent_declined' });
-      localStorage.setItem('cookieConsent', 'false');
+      persistAnalyticsPreference(false);
+      setIsAnalyticsAllowed(false);
+      setHasStoredDecision(true);
     }
     setIsBannerVisible(false);
   };
@@ -115,20 +175,19 @@ export function CookieConsentProvider({ children }: { children: ReactNode }) {
   return (
     <CookieConsentContext.Provider
       value={{
-        hasConsent:
-          typeof window !== 'undefined'
-            ? localStorage.getItem('cookieConsent') !== null
-            : null,
-        acceptCookies: handleAcceptCookies,
-        declineCookies: handleDeclineCookies,
+        hasStoredDecision,
+        isAnalyticsAllowed,
+        acceptAnalytics,
+        rejectAnalytics,
         openConsent,
       }}
     >
       {children}
+      {isAnalyticsAllowed && gtmId ? <DeferredGtm gtmId={gtmId} /> : null}
       <CookieConsent
         isVisible={isBannerVisible}
-        onAccept={handleAcceptCookies}
-        onDecline={handleDeclineCookies}
+        onAccept={acceptAnalytics}
+        onDecline={rejectAnalytics}
       />
     </CookieConsentContext.Provider>
   );

--- a/app/providers/cookie-consent-provider.tsx
+++ b/app/providers/cookie-consent-provider.tsx
@@ -115,6 +115,8 @@ export function CookieConsentProvider({ children }: { children: ReactNode }) {
   const [hasStoredDecision, setHasStoredDecision] = useState<boolean | null>(
     null,
   );
+  // Same container ID in every environment (VITE_GTM_ID). Prod vs dev GA4
+  // routing is handled inside GTM via Hostname Filter — not in app code.
   const gtmId = import.meta.env.VITE_GTM_ID as string | undefined;
 
   // Restore preference on mount: apply consent signals, load Clarity when granted,

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -32,14 +32,14 @@ setupDevWebVitalsLogging();
 function buildCsp(nonce: string): string {
   return [
     "default-src 'self'",
-    `script-src 'self' 'nonce-${nonce}' https://www.googletagmanager.com https://fast.wistia.com https://fast.wistia.net https://www.clarity.ms https://*.clarity.ms`,
+    `script-src 'self' 'nonce-${nonce}' https://www.googletagmanager.com https://*.wistia.com https://*.wistia.net https://www.clarity.ms https://*.clarity.ms`,
     "style-src 'self' 'unsafe-inline' https://fast.wistia.com",
     "img-src 'self' data: https: blob:",
     // Algolia search & related APIs: https://support.algolia.com/hc/en-us/articles/8947249849873
     // Microsoft Clarity sends telemetry to *.clarity.ms and c.bing.com
     // GA4 collection (fetch/sendBeacon) + GTM
     "connect-src 'self' https://*.algolia.net https://*.algolianet.com https://*.algolia.io https://*.clarity.ms https://c.bing.com https://*.google-analytics.com https://*.analytics.google.com https://www.googletagmanager.com",
-    'frame-src https://www.googletagmanager.com https://fast.wistia.com',
+    'frame-src https://www.googletagmanager.com https://*.wistia.com https://*.wistia.net',
     "frame-ancestors 'none'",
   ].join('; ');
 }

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -18,7 +18,6 @@ import { CookieConsentProvider } from './providers/cookie-consent-provider';
 import './styles/tailwind.css';
 import { loader as navbarLoader } from './routes/navbar/loader';
 import { NavbarVisibilityProvider } from './providers/navbar-visibility-context';
-import { DeferredGtm } from './components/deferred-gtm';
 import { setupDevWebVitalsLogging } from '~/lib/dev-web-vitals';
 
 export { ErrorBoundary } from './error';
@@ -53,7 +52,6 @@ export async function loader(args: LoaderFunctionArgs) {
 export function Layout({ children }: { children: ReactNode }) {
   const loaderData = useRouteLoaderData<typeof loader>('root');
   const nonce = loaderData?.nonce;
-  const gtmId = import.meta.env.VITE_GTM_ID;
 
   return (
     <html lang='en'>
@@ -84,18 +82,6 @@ export function Layout({ children }: { children: ReactNode }) {
       </head>
       {/* suppressHydrationWarning: extensions (e.g. ColorZilla) inject attrs like cz-shortcut-listen on <body> */}
       <body suppressHydrationWarning>
-        {/* GTM Noscript (Fallback) */}
-        {gtmId && (
-          <noscript>
-            <iframe
-              src={`https://www.googletagmanager.com/ns.html?id=${gtmId}`}
-              height='0'
-              width='0'
-              style={{ display: 'none', visibility: 'hidden' }}
-            />
-          </noscript>
-        )}
-        {gtmId ? <DeferredGtm gtmId={gtmId} /> : null}
         {children}
         <ScrollRestoration nonce={nonce} />
         <Scripts nonce={nonce} />

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -56,8 +56,12 @@ export async function loader(args: LoaderFunctionArgs) {
 // Loader headers from data(..., { headers }) only auto-forward Set-Cookie on
 // document responses. Forward CSP explicitly so the nonce'd policy is enforced.
 export const headers: HeadersFunction = ({ loaderHeaders }) => {
+  const headers = new Headers();
   const csp = loaderHeaders.get('Content-Security-Policy');
-  return csp ? { 'Content-Security-Policy': csp } : {};
+  if (csp) {
+    headers.set('Content-Security-Policy', csp);
+  }
+  return headers;
 };
 
 export function Layout({ children }: { children: ReactNode }) {

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -8,7 +8,10 @@ import {
   useRouteLoaderData,
 } from 'react-router-dom';
 import { type ReactNode } from 'react';
-import { type LoaderFunctionArgs } from 'react-router-dom';
+import {
+  type HeadersFunction,
+  type LoaderFunctionArgs,
+} from 'react-router-dom';
 import { randomUUID } from 'node:crypto';
 
 import { Navbar, Footer } from './components';
@@ -34,7 +37,8 @@ function buildCsp(nonce: string): string {
     "img-src 'self' data: https: blob:",
     // Algolia search & related APIs: https://support.algolia.com/hc/en-us/articles/8947249849873
     // Microsoft Clarity sends telemetry to *.clarity.ms and c.bing.com
-    "connect-src 'self' https://*.algolia.net https://*.algolianet.com https://*.algolia.io https://*.clarity.ms https://c.bing.com",
+    // GA4 collection (fetch/sendBeacon) + GTM
+    "connect-src 'self' https://*.algolia.net https://*.algolianet.com https://*.algolia.io https://*.clarity.ms https://c.bing.com https://*.google-analytics.com https://*.analytics.google.com https://www.googletagmanager.com",
     'frame-src https://www.googletagmanager.com https://fast.wistia.com',
     "frame-ancestors 'none'",
   ].join('; ');
@@ -48,6 +52,13 @@ export async function loader(args: LoaderFunctionArgs) {
     { headers: { 'Content-Security-Policy': buildCsp(nonce) } },
   );
 }
+
+// Loader headers from data(..., { headers }) only auto-forward Set-Cookie on
+// document responses. Forward CSP explicitly so the nonce'd policy is enforced.
+export const headers: HeadersFunction = ({ loaderHeaders }) => {
+  const csp = loaderHeaders.get('Content-Security-Policy');
+  return csp ? { 'Content-Security-Policy': csp } : {};
+};
 
 export function Layout({ children }: { children: ReactNode }) {
   const loaderData = useRouteLoaderData<typeof loader>('root');

--- a/app/routes/author/loader.ts
+++ b/app/routes/author/loader.ts
@@ -1,7 +1,7 @@
 import { LoaderFunction } from 'react-router-dom';
 import { createImageUrlFromGuid } from '~/lib/utils';
 import { format } from 'date-fns';
-import { AuthorLoaderData } from './types';
+import { AuthorArticleProps, AuthorLoaderData } from './types';
 import {
   fetchAuthorData,
   fetchPersonAliasGuid,
@@ -117,7 +117,7 @@ export const getAuthorDetailsByPathname = async (pathname: string) => {
                   coverImage:
                     createImageUrlFromGuid(
                       article.attributeValues?.image?.value || '',
-                    ) || null,
+                    ) || '',
                   summary: article.attributeValues?.summary?.value || '',
                   url: article.attributeValues?.url?.value || '',
                 };
@@ -126,7 +126,9 @@ export const getAuthorDetailsByPathname = async (pathname: string) => {
                 return null;
               }
             })
-            .filter(Boolean),
+            .filter(
+              (article): article is AuthorArticleProps => article != null,
+            ),
           books: [],
           podcasts: [],
         },
@@ -251,7 +253,7 @@ export const getAuthorDetails = async (personId: string) => {
                   coverImage:
                     createImageUrlFromGuid(
                       article.attributeValues?.image?.value || '',
-                    ) || null,
+                    ) || '',
                   summary: article.attributeValues?.summary?.value || '',
                   url: article.attributeValues?.url?.value || '',
                 };
@@ -260,7 +262,9 @@ export const getAuthorDetails = async (personId: string) => {
                 return null;
               }
             })
-            .filter(Boolean),
+            .filter(
+              (article): article is AuthorArticleProps => article != null,
+            ),
           books: [],
           podcasts: [],
         },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -33,6 +33,7 @@ export default [
         AbortController: 'readonly',
         Request: 'readonly',
         Response: 'readonly',
+        Headers: 'readonly',
         URL: 'readonly',
         URLSearchParams: 'readonly',
         FormData: 'readonly',


### PR DESCRIPTION
## Summary

Makes cookie consent accurately control analytics collection for Google Tag Manager and Microsoft Clarity, and splits analytics destinations by hostname so preview/staging never pollute production trackers.

Acceptance grants only `analytics_storage`; advertising consent stays denied. GTM follows basic Consent Mode (load only after analytics grant). Banner copy/controls are clearer, preferences are versioned so legacy PR #358 choices are re-prompted, and Clarity loads only on production hostnames.

Also hardens Content-Security-Policy so consented analytics and Wistia embeds are not blocked once the policy is enforced on document responses.

**Hydration fix:** Enforcing CSP exposed a missing nonce on React Router’s streamed `streamController` scripts. Added `app/entry.server.tsx` to pass the root-loader nonce into `ServerRouter` / `renderToPipeableStream` so those scripts are allowed and hydration works on preview/production.

**Out of scope / follow-up:** Privacy policy copy in `app/lib/legal/privacy-policy-and-terms.data.ts` was not updated — awaiting approved legal language.

## Screenshots

<img width="1679" height="1076" alt="image" src="https://github.com/user-attachments/assets/25292834-4abe-4256-abd0-c491ed9de36e" />

## Testing

### Consent behavior
- [x] Clear site data, load the site — banner visible; no GTM/Clarity network requests before a choice
- [x] Click **Reject analytics** — banner closes; GTM and Clarity still absent; revisit shows no banner and no analytics
- [x] Clear data again, click **Allow analytics** — GTM loads once; advertising consent remains denied in `dataLayer`
- [x] Reload as accepted user — GTM loads without showing the banner; `cookie_consent_accepted` still fires as before
- [x] Footer → **Cookie Settings** — banner reopens; reject after accept sends denied consent updates; reopen and accept again does not inject a duplicate GTM script
- [x] Banner **Learn more in our Privacy Policy.** links to `/privacy-policy`

### Checks
- [x] Ran `pnpm check` (lint / typecheck / prettier) — passes
- [x] Full `pnpm test` — note: 1 pre-existing failure in `yes-devotional-hero.component.test.tsx` (unrelated; fails on `main` too)

## Tickets

[CFDP-4141](https://christfellowshipchurch.atlassian.net/browse/CFDP-4141)

## Changes Made

### New Utilities

- `app/lib/analytics-host.ts` — exports `PRODUCTION_HOSTS` (`www.christfellowship.church`, `christfellowship.church`) and `isProductionHost()` (hostname-based; false during SSR)
- `app/lib/__tests__/analytics-host.test.ts` — unit coverage for production vs preview/local/SSR

### Route Implementation

- No new routes
- `app/root.tsx` — removed unconditional `DeferredGtm` and GTM `<noscript>` iframe; kept inline denied consent defaults in `<head>` (fires on all environments)
- `app/root.tsx` CSP updates:
  - `connect-src` includes GA4/GTM collection endpoints
  - `script-src` / `frame-src` widen Wistia to `https://*.wistia.com` and `https://*.wistia.net`
  - **Header application:** CSP was previously returned only via the root loader’s `data(..., { headers })`, which does not apply non-cookie headers to the HTML document response in React Router v7. Added a root `headers` export so `Content-Security-Policy` is actually set on document responses (with the nonce’d policy from the loader).

### Key Features

- Analytics-only Consent Mode updates (`analytics_storage` granted; `ad_storage`, `ad_user_data`, `ad_personalization` always denied)
- Basic Consent Mode: GTM loads only after analytics acceptance (via `CookieConsentProvider`), using `VITE_GTM_ID` on every environment
- Idempotent GTM script injection (`app/components/deferred-gtm.tsx` + `app/components/deferred-gtm.test.tsx`)
- Consent policy versioning (`cookieConsent` + `cookieConsentVersion=2026-07`); legacy preferences re-prompted
- Banner: analytics-scoped copy, equal-prominence **Reject analytics** / **Allow analytics**, Privacy Policy link
- Footer Cookie Settings still reopens the banner; rejection after acceptance sends denied updates
- Environment-split analytics by hostname (not `VERCEL_ENV`):
  - GTM/consent/`cookie_consent_accepted` work on all hosts; container Hostname Filter routes prod vs dev GA4
  - Clarity (`ojo9prqys0`) loads only when `isProductionHost()` is true — never from preview/staging/local
  - TODO in `loadClarity` for a future hostname-selected dev Clarity project ID
- Document-enforced CSP covering consented GA4/GTM network requests and Wistia embed hosts


[CFDP-4141]: https://christfellowshipchurch.atlassian.net/browse/CFDP-4141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ