### PR TITLE
TEMP: Clear stale browser caches

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -50,6 +50,17 @@ export async function loader(args: LoaderFunctionArgs) {
   );
 }
 
+export function headers({
+  loaderHeaders,
+}: {
+  loaderHeaders: Headers;
+}): Headers {
+  const headers = new Headers(loaderHeaders);
+  headers.set('Clear-Site-Data', '"cache"');
+  headers.set('Cache-Control', 'no-cache');
+  return headers;
+}
+
 export function Layout({ children }: { children: ReactNode }) {
   const loaderData = useRouteLoaderData<typeof loader>('root');
   const nonce = loaderData?.nonce;


### PR DESCRIPTION
## Summary

- send `Clear-Site-Data: "cache"` on rendered document responses
- require document revalidation with `Cache-Control: no-cache`
- preserve the existing loader-generated Content Security Policy and nonce

## Why

A reverted production deployment left some users with stale browser-cached resources from the breaking release. Vercel CDN purges cannot remove responses already stored in users' browsers, so this temporary response header asks supported browsers to clear the origin's HTTP cache on their next document load.

## Impact

Users who visit or reload the site will clear the site's HTTP cache and download current assets. Cookies and local storage are not cleared.

This header is intentionally temporary and should be removed in a follow-up deployment after the recovery window.

## Validation

- `pnpm build` — passed
- built-server document request — returned HTTP 200 with `Clear-Site-Data: "cache"`, `Cache-Control: no-cache`, and the existing CSP
- `pnpm typecheck` — blocked by a pre-existing unrelated error in `app/routes/author/loader.ts:299`: `publications.articles` may include `null`
