### PR TITLE
Temporarily disable content security policy

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -27,27 +27,10 @@ export { ErrorBoundary } from './error';
 // client bundles can still evaluate oddly; window check inside setup is authoritative.
 setupDevWebVitalsLogging();
 
-function buildCsp(nonce: string): string {
-  return [
-    "default-src 'self'",
-    `script-src 'self' 'nonce-${nonce}' https://www.googletagmanager.com https://fast.wistia.com https://fast.wistia.net https://www.clarity.ms https://*.clarity.ms`,
-    "style-src 'self' 'unsafe-inline' https://fast.wistia.com",
-    "img-src 'self' data: https: blob:",
-    // Algolia search & related APIs: https://support.algolia.com/hc/en-us/articles/8947249849873
-    // Microsoft Clarity sends telemetry to *.clarity.ms and c.bing.com
-    "connect-src 'self' https://*.algolia.net https://*.algolianet.com https://*.algolia.io https://*.clarity.ms https://c.bing.com",
-    'frame-src https://www.googletagmanager.com https://fast.wistia.com',
-    "frame-ancestors 'none'",
-  ].join('; ');
-}
-
 export async function loader(args: LoaderFunctionArgs) {
   const nonce = randomUUID();
   const navbarData = await navbarLoader(args);
-  return data(
-    { ...navbarData, nonce },
-    { headers: { 'Content-Security-Policy': buildCsp(nonce) } },
-  );
+  return data({ ...navbarData, nonce });
 }
 
 export function Layout({ children }: { children: ReactNode }) {


### PR DESCRIPTION
## Summary

- temporarily remove the root Content Security Policy generator
- stop attaching `Content-Security-Policy` to root loader responses
- retain nonce generation and all other root loader behavior

## Why

PR #361 forwarded the root loader's CSP to rendered documents, activating a policy that blocked production Wistia and Algolia traffic. Reverting #361 removed that forwarding, but removing CSP generation entirely is the safest emergency recovery measure while clients and deployments converge.

A second permissive CSP header would not reliably override the restrictive policy because browsers enforce multiple CSP policies together.

## Impact

Production document and root loader responses will not emit this application CSP. Wistia and Algolia requests will no longer be constrained by it.

This is temporary. A follow-up should introduce a tested report-only policy before CSP enforcement is restored.

## Validation

- `pnpm build` — passed
- built-server document request — HTTP 200 with no `Content-Security-Policy` header
- confirmed `Clear-Site-Data` is not reintroduced
- full typecheck was not rerun; current `main` has the previously identified unrelated `app/routes/author/loader.ts:299` type error
