### PR TITLE
feat(navbar): support latest podcast episode in nav card [CFDP-4152]

### DIFF
--- a/app/routes/navbar/loader.tsx
+++ b/app/routes/navbar/loader.tsx
@@ -11,6 +11,7 @@ import { getServerAlgoliaIndexes } from '~/lib/.server/algolia-indexes.server';
 import type { AlgoliaIndexMap } from '~/lib/algolia-indexes';
 import { ContentChannelIds } from '~/lib/rock-config';
 import type { RockContentChannelItem } from '~/lib/types/rock-types';
+import { buildPodcastRoutingIndex } from '~/routes/podcasts/podcast-routing.server';
 
 // Define the return type for the loader
 export interface RootLoaderData {
@@ -55,27 +56,124 @@ export const mapSiteBannerFromRockItem = (
   };
 };
 
+/** Latest podcast episode found across every show's episode channel, plus the show's URL slug needed to build its link. */
+interface LatestPodcastEpisode {
+  episode: RockContentChannelItem;
+  showPath: string;
+}
+
+/**
+ * Podcast episodes live on a separate ContentChannel per show (resolved via
+ * buildPodcastRoutingIndex), so "latest episode" requires querying across
+ * every show's episode channel rather than a single fixed ContentChannelId.
+ */
+const fetchLatestPodcastEpisode =
+  async (): Promise<LatestPodcastEpisode | null> => {
+    try {
+      const { byEpisodeChannelId } = await buildPodcastRoutingIndex();
+      const channelIds = Array.from(byEpisodeChannelId.keys());
+
+      if (channelIds.length === 0) {
+        return null;
+      }
+
+      const channelFilter = channelIds
+        .map((id) => `ContentChannelId eq ${id}`)
+        .join(' or ');
+
+      const latestEpisodeData = await fetchRockData({
+        endpoint: 'ContentChannelItems',
+        queryParams: {
+          $filter: `(${channelFilter}) and Status eq 'Approved'`,
+          $orderby: 'StartDateTime desc',
+          $top: '1',
+          loadAttributes: 'simple',
+        },
+      });
+
+      const episode = (
+        Array.isArray(latestEpisodeData)
+          ? latestEpisodeData[0]
+          : latestEpisodeData
+      ) as RockContentChannelItem | undefined;
+
+      const showPath = episode
+        ? byEpisodeChannelId.get(String(episode.contentChannelId))?.showPath
+        : undefined;
+
+      if (!episode || !showPath) {
+        return null;
+      }
+
+      return { episode, showPath };
+    } catch (error) {
+      console.error('Error fetching latest podcast episode:', error);
+      return null;
+    }
+  };
+
+/** Picks whichever of the latest article/podcast episode has the more recent startDateTime. */
+const pickMostRecentContentItem = (
+  article: RockContentChannelItem | undefined,
+  podcast: LatestPodcastEpisode | null,
+) => {
+  if (!article)
+    return podcast
+      ? {
+          ...podcast.episode,
+          contentType: 'podcast' as const,
+          showPath: podcast.showPath,
+        }
+      : null;
+  if (!podcast) return { ...article, contentType: 'article' as const };
+
+  const articleDate = new Date(article.startDateTime).getTime();
+  const podcastDate = new Date(podcast.episode.startDateTime).getTime();
+
+  return podcastDate > articleDate
+    ? {
+        ...podcast.episode,
+        contentType: 'podcast' as const,
+        showPath: podcast.showPath,
+      }
+    : { ...article, contentType: 'article' as const };
+};
+
 const fetchFeatureCards = async () => {
   try {
-    const latestArticleData = await fetchRockData({
-      endpoint: 'ContentChannelItems',
-      queryParams: {
-        $filter: `ContentChannelId eq 43 and Status eq 'Approved'`,
-        $orderby: 'StartDateTime desc',
-        $top: '1',
-        loadAttributes: 'simple',
-      },
-    });
+    const [latestArticleData, latestPodcastEpisode, latestSermonData] =
+      await Promise.all([
+        fetchRockData({
+          endpoint: 'ContentChannelItems',
+          queryParams: {
+            $filter: `ContentChannelId eq ${ContentChannelIds.articles} and Status eq 'Approved'`,
+            $orderby: 'StartDateTime desc',
+            $top: '1',
+            loadAttributes: 'simple',
+          },
+        }),
+        fetchLatestPodcastEpisode(),
+        fetchRockData({
+          endpoint: 'ContentChannelItems',
+          queryParams: {
+            $filter: `ContentChannelId eq 63 and Status eq 'Approved'`,
+            $orderby: 'StartDateTime desc',
+            $top: '1',
+            loadAttributes: 'simple',
+          },
+        }),
+      ]);
 
-    const latestSermonData = await fetchRockData({
-      endpoint: 'ContentChannelItems',
-      queryParams: {
-        $filter: `ContentChannelId eq 63 and Status eq 'Approved'`,
-        $orderby: 'StartDateTime desc',
-        $top: '1',
-        loadAttributes: 'simple',
-      },
-    });
+    const article = (
+      Array.isArray(latestArticleData)
+        ? latestArticleData[0]
+        : latestArticleData
+    ) as RockContentChannelItem | undefined;
+
+    const latestArticleOrPodcastCard = pickMostRecentContentItem(
+      article,
+      latestPodcastEpisode,
+    );
 
     // TODO: remove this once we have the real data for the get involved card(s)
     const mockGetInvolvedData = {
@@ -89,7 +187,11 @@ const fetchFeatureCards = async () => {
       navMenu: 'get involved',
     };
 
-    return [latestSermonData, latestArticleData, mockGetInvolvedData];
+    return [
+      latestSermonData,
+      latestArticleOrPodcastCard,
+      mockGetInvolvedData,
+    ].filter(Boolean);
   } catch (error) {
     console.error('Error fetching feature cards:', error);
     return [];
@@ -204,7 +306,24 @@ export async function loader({
       }
 
       const attributes = card.attributeValues;
-      const isArticle = card.contentChannelId === 43;
+
+      if (card.contentType === 'podcast') {
+        const episodePath =
+          attributes.pathname?.value || attributes.url?.value || '';
+
+        return {
+          title: card.title || '',
+          subtitle: 'New Podcast Episode',
+          callToAction: {
+            title: 'Listen Now',
+            url: `/podcasts/${card.showPath}/${episodePath}`,
+          },
+          image: createImageUrlFromGuid(attributes.image?.value || ''),
+          navMenu: 'media',
+        };
+      }
+
+      const isArticle = card.contentType === 'article';
 
       return {
         title: card.title || '',

--- a/app/routes/yes/components/__tests__/yes-devotional-hero.component.test.tsx
+++ b/app/routes/yes/components/__tests__/yes-devotional-hero.component.test.tsx
@@ -27,7 +27,7 @@ describe('YesHero', () => {
     render(<YesHero />);
 
     const devotionalLink = getCardLink(
-      'A three-week devotional to start your relationship with Jesus.',
+      'A three-week course to start your relationship with Jesus.',
     );
     expect(devotionalLink).toHaveAttribute('href', '#devo');
     expect(devotionalLink).not.toHaveAttribute('target', '_blank');


### PR DESCRIPTION
## Summary

Updates the "Latest Article" nav menu card to also support podcast episodes, per CFDP-4152. The card now shows whichever of the latest article or latest podcast episode (across all shows) was published most recently, rather than always defaulting to the latest article.

Podcast episodes live on a per-show Rock ContentChannel (unlike articles, which have one fixed channel), so there's no single `ContentChannelId` to query for "latest episode." This reuses the existing `buildPodcastRoutingIndex()` helper (already used for podcast page-builder routing) to resolve every show's episode channel, queries across all of them in a single Rock request ordered by `StartDateTime desc`, and compares the result's date against the latest article to pick the winner.

## Screenshots

[Paste your screenshots here]

## Testing

- [x] `pnpm check` shows no errors or warnings.
- [x] Load the site nav → Media menu and confirm the feature card shows either the latest article or latest podcast episode, whichever is newer
- [x] Confirm the podcast card links to the correct `/podcasts/:showPath/:episodePath` URL and loads that episode
- [x] Confirm the article card still links correctly when the article is newer
- [x] Confirm the "Latest Message" (sermon) card is unaffected

## Tickets

[CFDP-4152](https://christfellowshipchurch.atlassian.net/browse/CFDP-4152)

## Changes Made

### New Components Added

- N/A

### New Utilities

- `fetchLatestPodcastEpisode()` in `app/routes/navbar/loader.tsx` — queries Rock across every podcast show's episode channel (via `buildPodcastRoutingIndex()`) and returns the single latest approved episode plus its show's URL slug.
- `pickMostRecentContentItem()` in `app/routes/navbar/loader.tsx` — compares the latest article and latest podcast episode by `startDateTime` and returns whichever is newer, tagged with an explicit `contentType`.

### New Assets

- N/A

### Dependencies

- None

### Route Implementation

- `app/routes/navbar/loader.tsx` — root navbar loader:
  - `fetchFeatureCards()` now fetches the latest article, latest podcast episode, and latest sermon in parallel, and picks the more recent of article/podcast for the "media" feature card.
  - Card-mapping logic now branches on an explicit `contentType` (`'article' | 'podcast'`) instead of the old hardcoded `contentChannelId === 43` check, since podcast episode channel IDs vary per show.
  - Added a `'podcast'` mapping branch that builds the `/podcasts/:showPath/:episodePath` URL and a "New Podcast Episode" / "Listen Now" label.

### Key Features

- The nav "Latest Article" media card now surfaces whichever of the latest article or latest podcast episode was actually published most recently, instead of always showing an article.
- No new Rock content channel or config changes required — reuses the existing podcast routing index rather than introducing a parallel lookup.

[CFDP-4152]: https://christfellowshipchurch.atlassian.net/browse/CFDP-4152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ