### PR TITLE
Content Preview

### DIFF
--- a/app/lib/.server/__tests__/fetch-rock-data.test.ts
+++ b/app/lib/.server/__tests__/fetch-rock-data.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   fetchRockData,
   deleteRockData,
@@ -691,5 +691,120 @@ describe('fetchRockData TTL behavior', () => {
     );
     expect(requestFilter).not.toContain('StartDateTime le datetime');
     expect(cachedValue).toMatchObject({ id: 123 });
+  });
+});
+
+// ─── preview mode (CFDP-4143) ───────────────────────────────────────────────
+
+describe('fetchRockData preview mode', () => {
+  const mockRedis = {
+    get: vi.fn(),
+    set: vi.fn(),
+    del: vi.fn(),
+  };
+
+  beforeEach(async () => {
+    vi.useRealTimers();
+    vi.resetModules();
+    vi.clearAllMocks();
+    mockRedis.get.mockResolvedValue(null);
+    mockRedis.set.mockResolvedValue('OK');
+    mockRedis.del.mockResolvedValue(1);
+    vi.doMock('../redis-config', () => ({ default: mockRedis }));
+    process.env.SHOW_UNAPPROVED_CONTENT = 'true';
+  });
+
+  afterEach(() => {
+    delete process.env.SHOW_UNAPPROVED_CONTENT;
+  });
+
+  it("strips a hardcoded Status eq 'Approved' clause embedded in $filter", async () => {
+    const { fetchRockData: fetchPreview } =
+      await import('../fetch-rock-data');
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: async () => [{ id: 1 }],
+    });
+
+    await fetchPreview({
+      endpoint: 'ContentChannelItems/GetByAttributeValue',
+      queryParams: {
+        attributeKey: 'Pathname',
+        $filter: "ContentChannelId eq 43 and Status eq 'Approved'",
+        value: 'example',
+        loadAttributes: 'simple',
+      },
+      filterByDateRange: true,
+    });
+
+    const requestUrl = (global.fetch as ReturnType<typeof vi.fn>).mock
+      .calls[0][0] as string;
+    const requestFilter = new URL(requestUrl).searchParams.get('$filter');
+    expect(requestFilter).toBe('ContentChannelId eq 43');
+  });
+
+  it('skips filterByStatusApproved instead of merging it into $filter', async () => {
+    const { fetchRockData: fetchPreview } =
+      await import('../fetch-rock-data');
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: async () => [{ id: 1 }],
+    });
+
+    await fetchPreview({
+      endpoint: 'ContentChannelItems',
+      queryParams: { $filter: 'ContentChannelId eq 78' },
+      filterByStatusApproved: true,
+    });
+
+    const requestUrl = (global.fetch as ReturnType<typeof vi.fn>).mock
+      .calls[0][0] as string;
+    const requestFilter = new URL(requestUrl).searchParams.get('$filter');
+    expect(requestFilter).toBe('ContentChannelId eq 78');
+  });
+
+  it('does not filter out a not-yet-started or expired item', async () => {
+    const { fetchRockData: fetchPreview } =
+      await import('../fetch-rock-data');
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: async () => [
+        {
+          id: 123,
+          startDateTime: '2099-01-01T00:00:00.000Z',
+          expireDateTime: null,
+        },
+      ],
+    });
+
+    const result = await fetchPreview({
+      endpoint: 'ContentChannelItems/GetByAttributeValue',
+      queryParams: {
+        attributeKey: 'Pathname',
+        value: 'future-example',
+        loadAttributes: 'simple',
+      },
+      filterByDateRange: true,
+    });
+
+    expect(result).toMatchObject({ id: 123 });
+  });
+
+  it('never reads or writes the shared Redis cache', async () => {
+    const { fetchRockData: fetchPreview } =
+      await import('../fetch-rock-data');
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: async () => [{ id: 1 }],
+    });
+
+    await fetchPreview({ endpoint: 'People' });
+
+    expect(mockRedis.get).not.toHaveBeenCalled();
+    expect(mockRedis.set).not.toHaveBeenCalled();
   });
 });

--- a/app/lib/.server/__tests__/fetch-rock-data.test.ts
+++ b/app/lib/.server/__tests__/fetch-rock-data.test.ts
@@ -719,8 +719,7 @@ describe('fetchRockData preview mode', () => {
   });
 
   it("strips a hardcoded Status eq 'Approved' clause embedded in $filter", async () => {
-    const { fetchRockData: fetchPreview } =
-      await import('../fetch-rock-data');
+    const { fetchRockData: fetchPreview } = await import('../fetch-rock-data');
 
     (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       ok: true,
@@ -745,8 +744,7 @@ describe('fetchRockData preview mode', () => {
   });
 
   it('skips filterByStatusApproved instead of merging it into $filter', async () => {
-    const { fetchRockData: fetchPreview } =
-      await import('../fetch-rock-data');
+    const { fetchRockData: fetchPreview } = await import('../fetch-rock-data');
 
     (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       ok: true,
@@ -765,9 +763,8 @@ describe('fetchRockData preview mode', () => {
     expect(requestFilter).toBe('ContentChannelId eq 78');
   });
 
-  it('does not filter out a not-yet-started or expired item', async () => {
-    const { fetchRockData: fetchPreview } =
-      await import('../fetch-rock-data');
+  it('still filters out a not-yet-started item — only Status is bypassed', async () => {
+    const { fetchRockData: fetchPreview } = await import('../fetch-rock-data');
 
     (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       ok: true,
@@ -790,12 +787,11 @@ describe('fetchRockData preview mode', () => {
       filterByDateRange: true,
     });
 
-    expect(result).toMatchObject({ id: 123 });
+    expect(result).toEqual([]);
   });
 
   it('never reads or writes the shared Redis cache', async () => {
-    const { fetchRockData: fetchPreview } =
-      await import('../fetch-rock-data');
+    const { fetchRockData: fetchPreview } = await import('../fetch-rock-data');
 
     (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       ok: true,

--- a/app/lib/.server/fetch-rock-data.ts
+++ b/app/lib/.server/fetch-rock-data.ts
@@ -188,11 +188,11 @@ export const fetchRockData = async ({
   filterByStatusApproved = false,
 }: FetchRockDataOptions) => {
   const previewMode = isPreviewMode();
-  // Preview mode shows Pending/unapproved content, so neither filter applies:
-  // Status is meant to be bypassed, and date-range would otherwise hide
-  // not-yet-scheduled or already-expired items a manager still wants to check.
-  const effectiveFilterByDateRange = filterByDateRange && !previewMode;
-  const effectiveFilterByStatusApproved = filterByStatusApproved && !previewMode;
+  // Preview mode only bypasses the Status filter — date-range filtering still
+  // applies, so a not-yet-scheduled or already-expired item stays hidden.
+  const effectiveFilterByDateRange = filterByDateRange;
+  const effectiveFilterByStatusApproved =
+    filterByStatusApproved && !previewMode;
 
   const mergedQueryParams = { ...queryParams };
   const shouldFilterDateRangeInMemory =
@@ -219,8 +219,7 @@ export const fetchRockData = async ({
     mergedQueryParams as Record<string, string>,
   );
   // Preview never reads or writes the shared Redis cache — this deployment's
-  // results (unapproved content, no date-range filtering) must never be
-  // served to or poison prod's cache.
+  // results (unapproved content) must never be served to or poison prod's cache.
   const effectiveTtl: number = previewMode
     ? TTL.NONE
     : ttl !== undefined

--- a/app/lib/.server/fetch-rock-data.ts
+++ b/app/lib/.server/fetch-rock-data.ts
@@ -23,6 +23,13 @@ const defaultHeaders = {
 };
 
 /**
+ * When true, this deployment shows Pending/unapproved content and skips the
+ * shared Redis cache — used by the preview domain (CFDP-4143). Never set on prod.
+ */
+export const isPreviewMode = (): boolean =>
+  process.env.SHOW_UNAPPROVED_CONTENT === 'true';
+
+/**
  *
  * @param endpoint - the Rock endpoint to fetch data from
  * @param queryParams - query parameters to append to the request
@@ -133,6 +140,24 @@ const isSingleItemAttributeValueFetch = (endpoint: string): boolean =>
   endpoint.replace(/^\/+|\/+$/g, '') ===
   'ContentChannelItems/GetByAttributeValue';
 
+/**
+ * Removes a literal Status eq 'Approved' clause from a caller-built $filter
+ * string. Several loaders embed this clause directly rather than going
+ * through `filterByStatusApproved`, so preview mode strips it here instead
+ * of touching every call site.
+ */
+const stripApprovedStatusFilter = (
+  filter: string | undefined,
+): string | undefined => {
+  if (!filter) return filter;
+  const stripped = filter
+    .replace(/\s+and\s+Status eq 'Approved'/gi, '')
+    .replace(/Status eq 'Approved'\s+and\s+/gi, '')
+    .replace(/Status eq 'Approved'/gi, '')
+    .trim();
+  return stripped || undefined;
+};
+
 const applyDateRangeFilter = <T>(data: T, now: Date): T | [] => {
   if (Array.isArray(data)) {
     const filteredData = data.filter((item) =>
@@ -162,15 +187,30 @@ export const fetchRockData = async ({
   filterByDateRange = false,
   filterByStatusApproved = false,
 }: FetchRockDataOptions) => {
+  const previewMode = isPreviewMode();
+  // Preview mode shows Pending/unapproved content, so neither filter applies:
+  // Status is meant to be bypassed, and date-range would otherwise hide
+  // not-yet-scheduled or already-expired items a manager still wants to check.
+  const effectiveFilterByDateRange = filterByDateRange && !previewMode;
+  const effectiveFilterByStatusApproved = filterByStatusApproved && !previewMode;
+
   const mergedQueryParams = { ...queryParams };
   const shouldFilterDateRangeInMemory =
-    filterByDateRange && isSingleItemAttributeValueFetch(endpoint);
+    effectiveFilterByDateRange && isSingleItemAttributeValueFetch(endpoint);
 
-  if (filterByDateRange || filterByStatusApproved) {
+  if (effectiveFilterByDateRange || effectiveFilterByStatusApproved) {
     mergedQueryParams.$filter = buildMergedFilter(
       queryParams.$filter,
-      shouldFilterDateRangeInMemory ? false : filterByDateRange,
-      filterByStatusApproved,
+      shouldFilterDateRangeInMemory ? false : effectiveFilterByDateRange,
+      effectiveFilterByStatusApproved,
+    );
+  }
+
+  // Some loaders embed Status eq 'Approved' directly in their $filter string
+  // instead of using filterByStatusApproved — strip it here too.
+  if (previewMode) {
+    mergedQueryParams.$filter = stripApprovedStatusFilter(
+      mergedQueryParams.$filter,
     );
   }
 
@@ -178,8 +218,16 @@ export const fetchRockData = async ({
     endpoint,
     mergedQueryParams as Record<string, string>,
   );
-  const effectiveTtl: number =
-    ttl !== undefined ? ttl : cache === false ? TTL.NONE : TTL.DEFAULT;
+  // Preview never reads or writes the shared Redis cache — this deployment's
+  // results (unapproved content, no date-range filtering) must never be
+  // served to or poison prod's cache.
+  const effectiveTtl: number = previewMode
+    ? TTL.NONE
+    : ttl !== undefined
+      ? ttl
+      : cache === false
+        ? TTL.NONE
+        : TTL.DEFAULT;
 
   // Try to use Redis cache if available and TTL > 0
   if (redis && effectiveTtl > 0) {

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -20,6 +20,7 @@ import { loader as navbarLoader } from './routes/navbar/loader';
 import { NavbarVisibilityProvider } from './providers/navbar-visibility-context';
 import { DeferredGtm } from './components/deferred-gtm';
 import { setupDevWebVitalsLogging } from '~/lib/dev-web-vitals';
+import { isPreviewMode } from '~/lib/.server/fetch-rock-data';
 
 export { ErrorBoundary } from './error';
 
@@ -44,10 +45,15 @@ function buildCsp(nonce: string): string {
 export async function loader(args: LoaderFunctionArgs) {
   const nonce = randomUUID();
   const navbarData = await navbarLoader(args);
-  return data(
-    { ...navbarData, nonce },
-    { headers: { 'Content-Security-Policy': buildCsp(nonce) } },
-  );
+  const headers: Record<string, string> = {
+    'Content-Security-Policy': buildCsp(nonce),
+  };
+  // Preview deployments render Pending/unapproved content — keep it out of
+  // search indexes even if Deployment Protection is ever misconfigured.
+  if (isPreviewMode()) {
+    headers['X-Robots-Tag'] = 'noindex, nofollow';
+  }
+  return data({ ...navbarData, nonce }, { headers });
 }
 
 export function Layout({ children }: { children: ReactNode }) {

--- a/app/routes/robots[.]txt.ts
+++ b/app/routes/robots[.]txt.ts
@@ -1,4 +1,5 @@
 import type { LoaderFunctionArgs } from 'react-router-dom';
+import { isPreviewMode } from '~/lib/.server/fetch-rock-data';
 
 /**
  * Resource route: serves valid robots.txt so crawlers and check-site-meta get
@@ -6,6 +7,19 @@ import type { LoaderFunctionArgs } from 'react-router-dom';
  */
 export async function loader({ request }: LoaderFunctionArgs) {
   const { origin } = new URL(request.url);
+
+  // Preview deployments render Pending/unapproved content and must never be
+  // crawled — this is defense-in-depth alongside Vercel Deployment Protection.
+  if (isPreviewMode()) {
+    return new Response('User-agent: *\nDisallow: /\n', {
+      status: 200,
+      headers: {
+        'Content-Type': 'text/plain; charset=utf-8',
+        'Cache-Control': 'public, max-age=3600',
+      },
+    });
+  }
+
   const sitemapUrl = `${origin}/sitemap.xml`;
   const body = `User-agent: *
 Allow: /

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,0 @@
-User-agent: *
-Allow: /
-
-Sitemap: https://christfellowship.com/sitemap.xml


### PR DESCRIPTION
## Summary

Adds a `SHOW_UNAPPROVED_CONTENT` env flag so a separate preview deployment (same repo, same Rock instance, different domain/env — see CFDP-4143) can render Rock content that's still Pending/unapproved, so content managers can review it before it goes live.

Every content-fetching loader funnels through the single `fetchRockData()` helper before hitting Rock's API, so the bypass is centralized there instead of being spread across the ~16 call sites that hardcode `Status eq 'Approved'` in their `$filter`, plus the ~5 that use the `filterByStatusApproved` option. When the flag is on, `fetchRockData()`:

- Strips any `Status eq 'Approved'` clause from the outgoing filter (both the hardcoded-literal and the `filterByStatusApproved`-option forms)
- Leaves `filterByDateRange` filtering untouched — a Pending item still has to fall within its scheduled Start/Expire window to preview, same as an Approved item would
- Forces the shared Redis cache to be bypassed entirely (no read, no write) — the preview deployment must never read stale prod cache or write unapproved content into the cache prod reads from

Two supporting changes so the preview domain can't leak into search:
- `root.tsx` adds an `X-Robots-Tag: noindex, nofollow` response header when the flag is on
- `robots[.]txt.ts` serves `Disallow: /` instead of the normal sitemap-linked robots.txt when the flag is on

When the flag is unset (i.e. everywhere in prod), none of this code path executes — behavior is unchanged.

## Screenshots

N/A — this is server-side loader/response-header logic, no UI changes.

## Testing

This touches a function used by nearly every content route on the site, so testing covered both the new behavior and a regression check on everything else that calls `fetchRockData()`.

**Automated (all done, all passing):**
- [x] `pnpm check` (typecheck + lint) — clean, no new errors or warnings

**Manual — before merge / before the preview domain goes live:**
- [x] With `SHOW_UNAPPROVED_CONTENT` unset (current prod state), spot-check a few content types (article, event, message, podcast) still load normally and only Approved items are ever returned
- [x] With `SHOW_UNAPPROVED_CONTENT=true` set locally, confirm a Pending (not-yet-approved) Rock content item is now reachable at its content-single route. Example one: `/ministries/test-ministry-page`
- [x] With the flag on, confirm a not-yet-scheduled or already-expired Pending item is still correctly hidden (date-range filtering unaffected)
- [x] With the flag on, confirm `/robots.txt` returns `Disallow: /`
- [x] With the flag on, confirm the response includes `X-Robots-Tag: noindex, nofollow`
- [x] With the flag on, confirm no new `rock:*` keys are written to Redis while browsing (cache bypass holding)


## Tickets

https://christfellowshipchurch.atlassian.net/browse/CFDP-4143

## Changes Made

### New Components Added

N/A

### New Utilities

- `isPreviewMode()` in [app/lib/.server/fetch-rock-data.ts](app/lib/.server/fetch-rock-data.ts) — reads `process.env.SHOW_UNAPPROVED_CONTENT`, exported for reuse in `root.tsx` and `robots[.]txt.ts`
- `stripApprovedStatusFilter()` in the same file — removes a literal `Status eq 'Approved'` clause from a caller-supplied `$filter` string

### New Assets

N/A

### Dependencies

None added.

### Route Implementation

- [app/root.tsx](app/root.tsx) — root loader conditionally adds `X-Robots-Tag: noindex, nofollow`
- [app/routes/robots[.]txt.ts](app/routes/robots[.]txt.ts) — serves `Disallow: /` when preview mode is on

### Key Features

- Single centralized preview-mode bypass in `fetchRockData()` ([app/lib/.server/fetch-rock-data.ts](app/lib/.server/fetch-rock-data.ts)) — no changes needed to any individual content loader
- Preview mode never touches the shared Redis cache, protecting prod from stale/poisoned cache entries
- Preview domain is blocked from indexing via both `robots.txt` and response headers, as defense-in-depth alongside Vercel Deployment Protection (tracked separately)

## Known Limitation — Algolia-backed routes

This fix only covers content fetched directly from Rock. A handful of routes resolve their content (or related-content sections) via an Algolia search instead of a direct Rock fetch — `group-single`, `studies-single`, `class-finder/class-single` (sessions/related groups), `locations/location-single` (campus record), plus several listing pages and "related content" widgets. Algolia's index is populated by a pipeline outside this repo that only indexes Approved content, so a Pending item on any of these paths won't show up in preview, regardless of this change.

Accepted as out of scope for now: campuses are added infrequently, and the rest of the affected routes are group-type content (groups, classes, studies) rather than the primary content types this preview feature targets (articles, events, messages). Flagged here rather than silently left unhandled, in case that priority changes later.