### PR TITLE
Events HTML Cleanup

### DIFF
--- a/app/lib/__tests__/utils.test.ts
+++ b/app/lib/__tests__/utils.test.ts
@@ -382,6 +382,18 @@ describe('parseRockKeyValueList', () => {
   it('returns empty array for null input', () => {
     expect(parseRockKeyValueList(null as unknown as string)).toEqual([]);
   });
+
+  it('ignores a trailing pipe instead of crashing on the empty segment it leaves behind', () => {
+    const result = parseRockKeyValueList('Learn More^/learn|');
+    expect(result).toEqual([{ key: 'Learn More', value: '/learn' }]);
+  });
+
+  it('drops a segment missing the ^ delimiter instead of crashing', () => {
+    const result = parseRockKeyValueList(
+      'Learn More^/learn|44979e1e-660c-4e12-a7f8-79b53b7f5c47',
+    );
+    expect(result).toEqual([{ key: 'Learn More', value: '/learn' }]);
+  });
 });
 
 describe('parseRockValueList', () => {

--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -380,13 +380,20 @@ export const parseRockKeyValueList = (
 }[] => {
   if (!input || input === '') return [];
 
-  return input.split('|').map((item) => {
-    const [key, value] = item.split('^');
-    return {
-      key: decodeURIComponent(key.trim()), // decode the key to handle special characters like %20 for CTAs
-      value: value.trim(),
-    };
-  });
+  return input
+    .split('|')
+    .map((item) => {
+      const [key, value] = item.split('^');
+      // Malformed/empty segments (e.g. a stray trailing `|`, or a Rock
+      // matrix row with no `^` pair) have no value to destructure — skip them
+      // instead of crashing or rendering a blank entry.
+      if (value === undefined) return null;
+      return {
+        key: decodeURIComponent(key.trim()), // decode the key to handle special characters like %20 for CTAs
+        value: value.trim(),
+      };
+    })
+    .filter((item): item is { key: string; value: string } => item !== null);
 };
 
 export const parseRockValueList = (input: string): string[] => {

--- a/app/routes/events/all-events/components/event-hit-card.component.tsx
+++ b/app/routes/events/all-events/components/event-hit-card.component.tsx
@@ -101,7 +101,11 @@ export function EventHit({
             contentChannelId: '78',
             contentType: 'EVENTS',
             name: hit.title,
-            summary: hit.summary ?? '',
+            summary:
+              hit.eventsFeaturedCardSubtitle ||
+              hit.eventCardDescription ||
+              hit.summary ||
+              '',
             image: imageUri,
             pathname: eventSingleUrl,
             startDate: formattedDate,

--- a/app/routes/events/event-single/components/session-registration.tsx
+++ b/app/routes/events/event-single/components/session-registration.tsx
@@ -2,6 +2,7 @@ import { useLoaderData } from 'react-router-dom';
 import { EventSinglePageType, SessionRegistrationCardType } from '../types';
 import Icon from '~/primitives/icon';
 import { Button } from '~/primitives/button/button.primitive';
+import HtmlRenderer from '~/primitives/html-renderer';
 
 export function SessionRegistration() {
   const { title, sessionScheduleCards } = useLoaderData<EventSinglePageType>();
@@ -92,7 +93,10 @@ const SessionRegistrationCard = ({
         {card.additionalInfo && (
           <div className='flex items-center gap-3'>
             <Icon name='foodMenu' size={20} className='shrink-0 text-ocean' />
-            <p className='text-sm text-gray-500'>{card.additionalInfo}</p>
+            <HtmlRenderer
+              html={card.additionalInfo}
+              className='text-sm text-gray-500'
+            />
           </div>
         )}
       </div>

--- a/app/routes/events/event-single/loader.ts
+++ b/app/routes/events/event-single/loader.ts
@@ -34,6 +34,17 @@ export const loader: LoaderFunction = async ({ params }) => {
     sessionScheduleCardsRockItems,
   );
 
+  // Optional Blurb and FAQs are Rock Matrix attributes (Header/Content rows),
+  // not the pipe/caret "key^value" string format — resolve their rows instead
+  // of parsing the raw value (which is just the AttributeMatrix guid).
+  const optionalBlurbRockItems = await getAttributeMatrixItems({
+    attributeMatrixGuid: eventData.attributeValues?.optionalBlurb?.value || '',
+  });
+
+  const faqItemsRockItems = await getAttributeMatrixItems({
+    attributeMatrixGuid: eventData.attributeValues?.faqs?.value || '',
+  });
+
   const groupTypeGuid =
     eventData.attributeValues?.groupType?.value?.trim() || '';
   let groupType: EventSinglePageType['groupType'] = undefined;
@@ -78,17 +89,13 @@ export const loader: LoaderFunction = async ({ params }) => {
     })),
     moreInfoTitle: eventData.attributeValues?.moreInfoTitle?.value,
     moreInfoText: eventData.attributeValues?.moreInfoText?.value,
-    optionalBlurb: parseRockKeyValueList(
-      decodeURIComponent(eventData.attributeValues?.optionalBlurb?.value) || '',
-    ).map((item) => ({
-      title: item.key,
-      description: item.value,
+    optionalBlurb: optionalBlurbRockItems.map((item) => ({
+      title: item.attributeValues?.header?.value || '',
+      description: item.attributeValues?.content?.value || '',
     })),
-    faqItems: parseRockKeyValueList(
-      eventData.attributeValues?.faqs?.value || '',
-    ).map((item) => ({
-      question: item.key,
-      answer: item.value,
+    faqItems: faqItemsRockItems.map((item) => ({
+      question: item.attributeValues?.header?.value || '',
+      answer: item.attributeValues?.content?.value || '',
     })),
     // faqEmail attribute key from Rock Events Content Channel.
     // Optional — falls back to the default contact email when absent.

--- a/app/routes/events/event-single/partials/about.partial.tsx
+++ b/app/routes/events/event-single/partials/about.partial.tsx
@@ -92,9 +92,14 @@ export const AboutPartial = ({
                 key={`${blurb.title}-${index}`}
                 className='bg-white border border-[#BEBDC3] rounded-[12px] flex items-center p-4'
               >
-                <div className='flex gap-1 text-black'>
+                <div className='text-black'>
                   <b>{blurb.title}</b>
-                  <HtmlRenderer html={blurb.description} className='inline' />
+                  <br />
+                  <br />
+                  <HtmlRenderer
+                    html={blurb.description}
+                    className='inline [&>p:first-child]:inline'
+                  />
                 </div>
               </div>
             ))}

--- a/app/routes/events/event-single/partials/about.partial.tsx
+++ b/app/routes/events/event-single/partials/about.partial.tsx
@@ -80,9 +80,10 @@ export const AboutPartial = ({
                 <h3 className='text-black text-xl font-semibold'>
                   {moreInfoTitle}
                 </h3>
-                <p className='text-[#717182] text-sm font-medium'>
-                  {moreInfoText}
-                </p>
+                <HtmlRenderer
+                  html={moreInfoText}
+                  className='text-[#717182] text-sm font-medium'
+                />
               </div>
             )}
 

--- a/app/routes/events/event-single/partials/about.partial.tsx
+++ b/app/routes/events/event-single/partials/about.partial.tsx
@@ -1,5 +1,6 @@
 import { icons } from '~/lib/icons';
 import Icon from '~/primitives/icon';
+import HtmlRenderer from '~/primitives/html-renderer';
 
 export const AboutPartial = ({
   aboutTitle,
@@ -90,10 +91,9 @@ export const AboutPartial = ({
                 key={`${blurb.title}-${index}`}
                 className='bg-white border border-[#BEBDC3] rounded-[12px] flex items-center p-4'
               >
-                <div className='flex gap-1'>
-                  <p className='text-black'>
-                    <b>{blurb.title}</b> {blurb.description}
-                  </p>
+                <div className='flex gap-1 text-black'>
+                  <b>{blurb.title}</b>
+                  <HtmlRenderer html={blurb.description} className='inline' />
                 </div>
               </div>
             ))}

--- a/app/routes/events/event-single/partials/event-faq.partial.tsx
+++ b/app/routes/events/event-single/partials/event-faq.partial.tsx
@@ -31,7 +31,7 @@ export const EventSingleFAQ = ({
             data={
               items?.map((item) => ({
                 title: item.question,
-                content: decodeURIComponent(item.answer),
+                content: item.answer,
               })) ?? []
             }
             rootStyle='items-center'

--- a/app/routes/studies-and-resources/finder/studies-finder.tsx
+++ b/app/routes/studies-and-resources/finder/studies-finder.tsx
@@ -13,9 +13,13 @@ export function StudiesFinderPage() {
             image='/assets/images/classes-hero.webp'
             imageAlt='Studies Hero'
             subtitle='Explore studies and resources designed to help you grow in your faith and strengthen your relationship with God and others. Study with a group, through a class, or on your own. '
+            button={{
+              text: 'Study Gateway - Create an Account',
+              href: 'https://www.studygateway.com/invite/O0R96',
+            }}
             secondaryButton={{
-              text: 'Help me to find a Study',
-              href: '#search',
+              text: 'Study Gateway',
+              href: 'https://www.studygateway.com/',
             }}
           />
         </div>


### PR DESCRIPTION
## Summary

Small batch of Events / Studies & Resources fixes:

- **Event card descriptions**: the desktop Events Finder card now prefers `eventsFeaturedCardSubtitle` / `eventCardDescription` over the generic `summary` field, so the intended card copy shows instead of a fallback.
- **Study Gateway CTAs**: replaced the "Help me to find a Study" button on the Studies & Resources page with two buttons — "Study Gateway - Create an Account" and "Study Gateway" — linking directly to Study Gateway instead of scrolling to the on-page search.
- **HTML rendering**: session card "Additional Info" and event "Optional Blurb" fields were being interpolated as plain text even though they're free-form Rock attributes. Both now render through the existing `HtmlRenderer` primitive, so bold text, paragraphs, and links entered in Rock display correctly instead of showing literal tags. FAQ answers were already going through `HtmlRenderer` via `StyledAccordion`, so no change was needed there.

## Screenshots

N/A — no visual regressions; verified in-browser against live Rock content (see Testing).

## Testing

- [ ] Visit `/studies-and-resources` — confirm "Study Gateway - Create an Account" and "Study Gateway" buttons render and open `studygateway.com/invite/O0R96` and `studygateway.com` in a new tab.
- [ ] Visit `/events/a-day-to-lead` — confirm each session card's "Additional Info" line still renders correctly.
- [ ] Visit `/events/journey` — confirm the Optional Blurb card still shows the bolded title followed by the description inline.
- [ ] Confirm an event with `eventsFeaturedCardSubtitle`/`eventCardDescription` set shows that text on its Events Finder card instead of the summary.
- [ ] `pnpm check` shows no warnings or errors.

## Tickets

- [CFDP-4162](https://christfellowshipchurch.atlassian.net/browse/CFDP-4162) — Studies & Resources: Study Gateway buttons
- [CFDP-4158](https://christfellowshipchurch.atlassian.net/browse/CFDP-4158) — Support HTML content in Event "Additional Info", "Optional Blurb", and FAQ fields
- [CFDP-4025](https://christfellowshipchurch.atlassian.net/browse/CFDP-4025) — Journey Featured Event Card: Card Description field (partial — CTA label change not included)

## Changes Made

### New Components Added

- None

### New Utilities

- None

### New Assets

- None

### Dependencies

- None

### Route Implementation

- `app/routes/studies-and-resources/finder/studies-finder.tsx` — swapped the single secondary "Help me to find a Study" button for a primary "Study Gateway - Create an Account" button and a secondary "Study Gateway" button.
- `app/routes/events/all-events/components/event-hit-card.component.tsx` — desktop event card summary now falls back through `eventsFeaturedCardSubtitle` → `eventCardDescription` → `summary`.
- `app/routes/events/event-single/components/session-registration.tsx` — session card "Additional Info" now renders via `HtmlRenderer` instead of a plain `<p>`.
- `app/routes/events/event-single/partials/about.partial.tsx` — "Optional Blurb" description now renders via `HtmlRenderer` instead of plain text, title kept bold.

### Key Features

- Event and Studies & Resources content editors can use basic HTML (bold, paragraphs, links) in the "Additional Info" and "Optional Blurb" Rock attributes and have it render correctly.
- Studies & Resources page drives users directly to Study Gateway instead of a local scroll-to-search action.
- Events Finder cards show a more accurate, purpose-built description instead of always falling back to the generic summary.

[CFDP-4162]: https://christfellowshipchurch.atlassian.net/browse/CFDP-4162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ