### PR TITLE
Classes registration url

### DIFF
--- a/app/routes/class-finder/class-single/components/__tests__/upcoming-session-card.test.tsx
+++ b/app/routes/class-finder/class-single/components/__tests__/upcoming-session-card.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+
+import type { ClassHitType } from '../../../types';
+import { UpcomingSessionCard } from '../upcoming-session-card.component';
+
+const REGISTRATION_URL =
+  'https://rock.gocf.org/page/414?EventOccurrenceId=1547';
+
+const baseHit = {
+  objectID: '89472701000',
+  title: 'Financial Peace University - CFEverywhere',
+  classType: 'Financial Peace University',
+  pathName: 'financial-peace-university',
+  campus: 'CFEverywhere',
+  groupId: 1834253,
+  subtitle: '',
+  summary: '',
+  coverImage: { sources: [] },
+  _geoloc: { lat: 0, lng: 0 },
+  startDate: 'January 1',
+  endDate: 'February 5',
+  schedule: 'Sunday at 9:45 AM',
+  topic: 'Finances',
+  language: 'English',
+  format: 'In-Person',
+} as unknown as ClassHitType;
+
+function renderCard(overrides: Partial<ClassHitType> = {}) {
+  return render(
+    <MemoryRouter>
+      <UpcomingSessionCard hit={{ ...baseHit, ...overrides }} />
+    </MemoryRouter>,
+  );
+}
+
+describe('UpcomingSessionCard', () => {
+  it('registers through the signup modal when no registration URL is set', () => {
+    renderCard();
+
+    // Sessions without an override must keep using the in-app group signup flow.
+    expect(
+      screen.getByRole('button', { name: /Sign up — Financial Peace/ }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('links to the Rock registration URL instead of the signup modal when set', () => {
+    renderCard({ registrationURL: REGISTRATION_URL });
+
+    // The external Rock page owns registration for this session, so opening the
+    // in-app form would create a duplicate/incorrect registration.
+    const link = screen.getByRole('link', {
+      name: /Sign up — Financial Peace/,
+    });
+    expect(link).toHaveAttribute('href', REGISTRATION_URL);
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('ignores a whitespace-only registration URL', () => {
+    // Rock ships the attribute on every record; blank values must not swallow
+    // the signup modal.
+    renderCard({ registrationURL: '   ' });
+
+    expect(
+      screen.getByRole('button', { name: /Sign up — Financial Peace/ }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+});

--- a/app/routes/class-finder/class-single/components/upcoming-session-card.component.tsx
+++ b/app/routes/class-finder/class-single/components/upcoming-session-card.component.tsx
@@ -118,6 +118,27 @@ const FullCardModalTrigger = forwardRef<HTMLButtonElement, ButtonProps>(
 
 export const UpcomingSessionCard = ({ hit }: { hit: ClassHitType }) => {
   const displayClassType = hit.classType?.trim() ?? '';
+  const registrationUrl = hit.registrationURL?.trim() ?? '';
+
+  // A Rock-provided registration URL takes precedence over the signup modal:
+  // these sessions register through an external Rock page, so the in-app form
+  // would create a duplicate/incorrect registration.
+  if (registrationUrl) {
+    return (
+      <a
+        href={registrationUrl}
+        target='_blank'
+        rel='noopener noreferrer'
+        aria-label={`Sign up — ${displayClassType}`}
+        className={cn(
+          cardShellClassName,
+          'cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-ocean focus-visible:ring-offset-2',
+        )}
+      >
+        <UpcomingSessionCardBody hit={hit} />
+      </a>
+    );
+  }
 
   if (hit.groupId) {
     return (

--- a/app/routes/class-finder/types.ts
+++ b/app/routes/class-finder/types.ts
@@ -37,6 +37,13 @@ export interface ClassHitType {
   language: 'English' | 'Español' | 'Multiple Languages';
   format: 'In-Person' | 'Virtual';
   /**
+   * Rock-managed registration override. Present but empty on most records; when
+   * populated, the session card links here instead of opening the signup modal.
+   * Spelled `registrationURL` to match the Algolia record (CFDP-4174 describes it
+   * as `registrationUrl`).
+   */
+  registrationURL?: string;
+  /**
    * True for synthetic cards built from a Rock 387 class with the "I'm Interested"
    * toggle on but no Algolia sessions. Not present on real Algolia records.
    */

--- a/app/routes/ministries/loader.ts
+++ b/app/routes/ministries/loader.ts
@@ -49,7 +49,7 @@ const hardCodedMinistries: Ministry[] = [
     title: 'CFSEU',
     description:
       'Earn your degree through Southeastern University at Christ Fellowship.',
-    image: getImageUrl('2966341'),
+    image: getImageUrl('3203078'),
     url: 'https://www.cfseu.com',
   },
 ];


### PR DESCRIPTION
## Summary

Class Finder session cards always opened the in-app group signup modal. Some sessions register through an external Rock page instead, so the in-app form creates a duplicate or incorrect registration.

The classes index already carries a Rock-managed `registrationURL` attribute on every record (empty on most). When it's populated, `UpcomingSessionCard` now renders the card as an external link to that URL instead of the modal trigger.

Two prod records are populated today, so this is live-visible immediately:

| Class page | Session | Registration URL |
| --- | --- | --- |
| `/class-finder/before-you-say-i-do` | Preparación Para El Matrimonio – CFE Palm Beach Gardens | `rock.gocf.org/page/414?EventOccurrenceId=1574` |
| `/class-finder/financial-peace-university` | Financial Peace University – CFEverywhere – At Your Own Pace | `rock.gocf.org/page/414?EventOccurrenceId=1547` |


## Screenshots
N/A

## Testing

- [x] Open `/class-finder/before-you-say-i-do`, scroll to **Join a Class**.
- [x] Click the **Preparación Para El Matrimonio – CFE Palm Beach Gardens** card → opens the Rock registration page in a new tab.
- [x] Click any other session card → the in-app signup modal opens as before.

## Tickets

[CFDP-4174](https://christfellowshipchurch.atlassian.net/browse/CFDP-4174)

## Changes Made

### New Components Added

None. Existing components only.

### New Utilities

None.

### New Assets

None.

### Dependencies

None.

### Route Implementation

- `app/routes/class-finder/types.ts` — added optional `registrationURL?: string` to `ClassHitType`, documenting that the spelling matches the Algolia record rather than the ticket's `registrationUrl`.
- `app/routes/class-finder/class-single/components/upcoming-session-card.component.tsx` — `UpcomingSessionCard` returns an external anchor when `registrationURL` is non-empty after trimming; the existing `GroupConnectModal` and no-`groupId` branches are untouched.
- `app/routes/class-finder/class-single/components/__tests__/upcoming-session-card.test.tsx` — new: signup modal when the attribute is absent, external link (`href` / `target` / `rel`) when set, and modal preserved for whitespace-only values (Rock ships the attribute on every record, so blanks must not swallow the modal).

### Key Features

- Rock content editors can redirect any class session's registration without a deploy.
- Opens in a new tab (`target="_blank"` with `rel="noopener noreferrer"`) so the class page stays open.
- Accessibility: the anchor keeps the `aria-label="Sign up — <class type>"` the modal trigger had, and carries the same `focus-visible` ring so keyboard focus stays visible.
- Blank values are treated as absent, so the ~45 records with an empty `registrationURL` keep the existing flow.

### Unrelated change included

This branch also carries commit `ad068e0d` ("seu image update"), a one-line CFSEU ministry image swap in `app/routes/ministries/loader.ts` (`getImageUrl('2966341')` → `getImageUrl('3203078')`). It predates the Class Finder work and is not part of

[CFDP-4174]: https://christfellowshipchurch.atlassian.net/browse/CFDP-4174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ