### PR TITLE
Restore private missions events finder

### DIFF
--- a/.infisical.json
+++ b/.infisical.json
@@ -1,5 +1,5 @@
 {
-    "workspaceId": "104f27e7-c992-44e9-bbff-7bab7acd26b2",
-    "defaultEnvironment": "",
-    "gitBranchToEnvironmentMapping": null
+  "workspaceId": "104f27e7-c992-44e9-bbff-7bab7acd26b2",
+  "defaultEnvironment": "",
+  "gitBranchToEnvironmentMapping": null
 }

--- a/app/lib/__tests__/algolia-indexes.test.ts
+++ b/app/lib/__tests__/algolia-indexes.test.ts
@@ -14,6 +14,7 @@ describe('algolia index naming', () => {
       classes: 'dev_webv3_classes',
       locations: 'dev_webv3_locations',
       missions: 'dev_webv3_missions',
+      missionsPrivate: 'dev_webv3_missionsPrivate',
       studiesAndResources: 'dev_webv3_studiesAndResources',
       eventFinderItems: 'dev_webv3_eventFinderItems',
     });
@@ -26,6 +27,7 @@ describe('algolia index naming', () => {
       classes: 'prod_webv3_classes',
       locations: 'prod_webv3_locations',
       missions: 'prod_webv3_missions',
+      missionsPrivate: 'prod_webv3_missionsPrivate',
       studiesAndResources: 'prod_webv3_studiesAndResources',
       eventFinderItems: 'prod_webv3_eventFinderItems',
     });
@@ -49,6 +51,7 @@ describe('algolia index naming', () => {
         'groups',
         'locations',
         'missions',
+        'missionsPrivate',
         'studiesAndResources',
       ].sort(),
     );

--- a/app/lib/algolia-indexes.ts
+++ b/app/lib/algolia-indexes.ts
@@ -6,6 +6,7 @@ export type AlgoliaIndexName =
   | 'classes'
   | 'locations'
   | 'missions'
+  | 'missionsPrivate'
   | 'studiesAndResources'
   | 'eventFinderItems';
 
@@ -17,6 +18,7 @@ export const ALGOLIA_INDEX_NAMES = [
   'classes',
   'locations',
   'missions',
+  'missionsPrivate',
   'studiesAndResources',
   'eventFinderItems',
 ] as const satisfies readonly AlgoliaIndexName[];

--- a/app/routes/missions-private-events/loader.ts
+++ b/app/routes/missions-private-events/loader.ts
@@ -1,0 +1,16 @@
+import { getServerAlgoliaIndexes } from '~/lib/.server/algolia-indexes.server';
+import type { AlgoliaIndexMap } from '~/lib/algolia-indexes';
+
+export type PrivateMissionEventsLoaderData = {
+  ALGOLIA_APP_ID: string;
+  ALGOLIA_SEARCH_API_KEY: string;
+  algoliaIndexes: AlgoliaIndexMap;
+};
+
+export async function loader() {
+  return Response.json({
+    ALGOLIA_APP_ID: process.env.ALGOLIA_APP_ID ?? '',
+    ALGOLIA_SEARCH_API_KEY: process.env.ALGOLIA_SEARCH_API_KEY ?? '',
+    algoliaIndexes: getServerAlgoliaIndexes(),
+  } satisfies PrivateMissionEventsLoaderData);
+}

--- a/app/routes/missions-private-events/meta.test.ts
+++ b/app/routes/missions-private-events/meta.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+
+import { meta } from './meta';
+
+describe('missions-private-events metadata', () => {
+  it('prevents search engines from indexing the privately shared finder', () => {
+    const robots = (meta({} as never) ?? []).find(
+      (entry) => 'name' in entry && entry.name === 'robots',
+    );
+
+    expect(robots).toMatchObject({ content: 'noindex, nofollow' });
+  });
+});

--- a/app/routes/missions-private-events/meta.ts
+++ b/app/routes/missions-private-events/meta.ts
@@ -1,0 +1,11 @@
+import type { MetaFunction } from 'react-router-dom';
+
+import { createMeta } from '~/lib/meta-utils';
+
+export const meta: MetaFunction = () =>
+  createMeta({
+    title: 'Christ Fellowship Missions | Private Events',
+    description: 'Browse private mission events at Christ Fellowship Church.',
+    path: '/missions-private-events',
+    noIndex: true,
+  });

--- a/app/routes/missions-private-events/route.tsx
+++ b/app/routes/missions-private-events/route.tsx
@@ -1,0 +1,58 @@
+import { useState } from 'react';
+import { useLoaderData } from 'react-router-dom';
+
+import { cn } from '~/lib/utils';
+import { VolunteerAlgolia } from '~/routes/volunteer/components/volunteer-algolia.component';
+import { VolunteerAlgoliaSkeleton } from '~/routes/volunteer/components/volunteer-algolia-skeleton.component';
+
+import type { PrivateMissionEventsLoaderData } from './loader';
+
+export { loader } from './loader';
+export { meta } from './meta';
+
+export default function PrivateMissionEventsPage() {
+  const { ALGOLIA_APP_ID, ALGOLIA_SEARCH_API_KEY, algoliaIndexes } =
+    useLoaderData<PrivateMissionEventsLoaderData>();
+  const [finderUiReady, setFinderUiReady] = useState(false);
+
+  return (
+    <main className='bg-gray py-12 md:py-16'>
+      <div className='content-padding'>
+        <div className='mx-auto max-w-[1280px]'>
+          <h1 className='text-[40px] font-extrabold leading-tight text-text-primary md:text-[52px]'>
+            Christ Fellowship Missions
+          </h1>
+          <p className='mt-2 text-xl font-semibold text-text-secondary md:text-2xl'>
+            Private Events
+          </p>
+          <p className='mt-4 max-w-2xl text-base leading-relaxed text-text-secondary md:text-lg'>
+            This page has been shared privately. Please be mindful before
+            sharing it with others.
+          </p>
+        </div>
+      </div>
+
+      <div
+        className='relative mt-6 min-h-[min(580px,85vh)]'
+        aria-busy={finderUiReady ? undefined : true}
+      >
+        <div
+          className={cn(
+            !finderUiReady && 'pointer-events-none select-none opacity-0',
+          )}
+        >
+          <VolunteerAlgolia
+            appId={ALGOLIA_APP_ID}
+            apiKey={ALGOLIA_SEARCH_API_KEY}
+            indexName={algoliaIndexes.missionsPrivate}
+            resultsLayout='list'
+            onVolunteerUiReady={() => setFinderUiReady(true)}
+          />
+        </div>
+        {!finderUiReady ? (
+          <VolunteerAlgoliaSkeleton resultsLayout='list' />
+        ) : null}
+      </div>
+    </main>
+  );
+}

--- a/app/routes/volunteer/components/__tests__/volunteer-algolia.component.test.tsx
+++ b/app/routes/volunteer/components/__tests__/volunteer-algolia.component.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+
+import { VolunteerAlgolia } from '../volunteer-algolia.component';
+import type { Volunteer } from '../../types';
+
+const mocks = vi.hoisted(() => ({
+  hits: [] as Volunteer[],
+}));
+
+vi.mock('react-instantsearch', () => ({
+  Configure: () => null,
+  InstantSearch: ({ children }: { children: ReactNode }) => <>{children}</>,
+  useHits: () => ({ items: mocks.hits }),
+  useInstantSearch: () => ({ status: 'idle' }),
+  useRefinementList: () => ({ items: [], refine: vi.fn() }),
+}));
+
+vi.mock('~/lib/create-search-client', () => ({
+  createSearchClient: () => ({}),
+}));
+
+vi.mock('~/components/finders/finder-sticky-bar.component', () => ({
+  FinderStickyBar: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('~/components/finders/search-filters', () => ({
+  SearchFilters: () => null,
+}));
+
+vi.mock('~/components/finders/search-filters/active-filter.component', () => ({
+  ActiveFilters: () => null,
+}));
+
+vi.mock('~/components/hubs-tags-refinement', () => ({
+  HubsTagsRefinementList: () => null,
+}));
+
+vi.mock('~/routes/group-finder/components/clear-all-button.component', () => ({
+  AlgoliaFinderClearAllButton: () => null,
+}));
+
+const volunteer: Volunteer = {
+  objectID: 'mission-event-1',
+  groupId: 1,
+  groupGuid: 'mission-guid-1',
+  title: 'Serve Our Neighbors',
+  coverImage: { sources: [] },
+  summary: '',
+  campusList: ['Boynton Beach'],
+  eventDateStr: 'July 20',
+  eventEndDateStr: '',
+  eventTimeStr: '9:00 AM',
+  eventEndTimeStr: '',
+  category: 'Outreach',
+  checkInLocation: '',
+  location: { street: '', city: '', state: '', zip: '' },
+  opportunityType: [],
+  spotsLeft: 8,
+  missionsUrl: '',
+  contactName: '',
+  contactEmail: '',
+};
+
+describe('VolunteerAlgolia', () => {
+  it('renders private mission results as list rows when requested', () => {
+    mocks.hits = [volunteer];
+
+    render(
+      <MemoryRouter
+        initialEntries={['/missions-private-events?category=Outreach']}
+      >
+        <VolunteerAlgolia
+          appId='test-app-id'
+          apiKey='test-api-key'
+          indexName='dev_webv3_missionsPrivate'
+          resultsLayout='list'
+        />
+      </MemoryRouter>,
+    );
+
+    const link = screen.getByRole('link', { name: /Serve Our Neighbors/ });
+    expect(link).toHaveAttribute('href', '/volunteer/outreach/mission-guid-1');
+    expect(link.closest('li')).toBeInTheDocument();
+  });
+});

--- a/app/routes/volunteer/components/__tests__/volunteer-list-card.component.test.tsx
+++ b/app/routes/volunteer/components/__tests__/volunteer-list-card.component.test.tsx
@@ -1,0 +1,63 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+
+import { VOLUNTEER_FINDER_BACK_STORAGE_KEY } from '../../outreach-opportunity/components/outreach-finder-return-href';
+import { VolunteerListCard } from '../volunteer-list-card.component';
+import type { Volunteer } from '../../types';
+
+const volunteer: Volunteer = {
+  objectID: 'mission-event-1',
+  groupId: 1,
+  groupGuid: 'mission-guid-1',
+  title: 'Serve Our Neighbors',
+  coverImage: { sources: [{ uri: 'https://images.example/mission.jpg' }] },
+  summary: '',
+  campusList: ['Boynton Beach'],
+  eventDateStr: 'July 20',
+  eventEndDateStr: 'July 21',
+  eventTimeStr: '9:00 AM',
+  eventEndTimeStr: '12:00 PM',
+  category: 'Outreach',
+  checkInLocation: '',
+  location: { street: '', city: '', state: '', zip: '' },
+  opportunityType: ['Family Friendly', 'Outdoor'],
+  spotsLeft: 8,
+  missionsUrl: '',
+  contactName: '',
+  contactEmail: '',
+};
+
+describe('VolunteerListCard', () => {
+  it('keeps mission details visible and saves finder filters before navigating', () => {
+    render(
+      <MemoryRouter>
+        <VolunteerListCard
+          volunteer={volunteer}
+          listingSearch='?category=Outreach'
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('Serve Our Neighbors')).toBeVisible();
+    expect(screen.getByText('8 spots left')).toBeVisible();
+    expect(screen.getByText('Family Friendly')).toBeVisible();
+    expect(screen.getByText('July 20 – July 21')).toBeVisible();
+    expect(screen.getByText('9:00 AM – 12:00 PM')).toBeVisible();
+
+    const link = screen.getByRole('link', { name: /Serve Our Neighbors/ });
+    expect(link).toHaveAttribute('href', '/volunteer/outreach/mission-guid-1');
+
+    fireEvent.click(link);
+
+    expect(
+      window.sessionStorage.getItem(VOLUNTEER_FINDER_BACK_STORAGE_KEY),
+    ).toBe(
+      JSON.stringify({
+        missionGroupGuid: 'mission-guid-1',
+        volunteerListSearch: '?category=Outreach',
+        origin: 'missions-private-events',
+      }),
+    );
+  });
+});

--- a/app/routes/volunteer/components/volunteer-algolia-skeleton.component.tsx
+++ b/app/routes/volunteer/components/volunteer-algolia-skeleton.component.tsx
@@ -6,8 +6,10 @@ import { cn } from '~/lib/utils';
  */
 export function VolunteerAlgoliaSkeleton({
   className,
+  resultsLayout = 'carousel',
 }: {
   className?: string;
+  resultsLayout?: 'carousel' | 'list';
 }) {
   return (
     <div className={cn('animate-pulse', className)} aria-hidden>
@@ -23,6 +25,18 @@ export function VolunteerAlgoliaSkeleton({
         </div>
       </div>
 
+      {resultsLayout === 'list' ? (
+        <VolunteerListSkeleton />
+      ) : (
+        <VolunteerCarouselSkeleton />
+      )}
+    </div>
+  );
+}
+
+function VolunteerCarouselSkeleton() {
+  return (
+    <>
       <div className='pl-5 md:pl-12 lg:pl-18 2xl:pl-0!'>
         <div className='mt-8 flex py-2 items-stretch gap-6 overflow-hidden max-w-[1280px] mx-auto'>
           {[0, 1, 2].map((i) => (
@@ -51,7 +65,6 @@ export function VolunteerAlgoliaSkeleton({
           ))}
         </div>
       </div>
-
       <div className='pl-5 md:pl-12 lg:pl-18 2xl:pl-0!'>
         <div className='max-w-[1280px] mx-auto relative mt-8 min-h-[4.5rem] pb-14 sm:pb-16 md:pb-8'>
           <div className='absolute left-4 top-1 flex gap-2 md:left-0 md:top-7'>
@@ -63,6 +76,32 @@ export function VolunteerAlgoliaSkeleton({
             ))}
           </div>
         </div>
+      </div>
+    </>
+  );
+}
+
+function VolunteerListSkeleton() {
+  return (
+    <div className='content-padding py-6'>
+      <div className='mx-auto flex max-w-[1280px] flex-col gap-4'>
+        {[0, 1, 2].map((i) => (
+          <div
+            key={i}
+            className='flex min-h-36 overflow-hidden rounded-lg border border-neutral-lighter bg-white shadow-sm'
+          >
+            <div className='w-32 shrink-0 bg-neutral-light sm:w-48' />
+            <div className='flex flex-1 flex-col gap-3 p-4 md:p-6'>
+              <div className='h-6 w-2/5 rounded bg-neutral-light' />
+              <div className='flex gap-2'>
+                <div className='h-7 w-24 rounded-full bg-neutral-light' />
+                <div className='h-7 w-28 rounded bg-neutral-light' />
+              </div>
+              <div className='h-4 w-4/5 rounded bg-neutral-light' />
+              <div className='h-4 w-3/5 rounded bg-neutral-light' />
+            </div>
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/app/routes/volunteer/components/volunteer-algolia.component.tsx
+++ b/app/routes/volunteer/components/volunteer-algolia.component.tsx
@@ -25,6 +25,7 @@ import {
 } from '~/primitives/shadcn-primitives/carousel';
 
 import { VolunteerCard } from './volunteer-card.component';
+import { VolunteerListCard } from './volunteer-list-card.component';
 import type { Volunteer } from '../types';
 import {
   parseVolunteerAlgoliaUrlState,
@@ -130,6 +131,34 @@ function VolunteerHitsCarousel() {
   );
 }
 
+function VolunteerHitsList() {
+  const { items: hits } = useHits<Volunteer>();
+  const location = useLocation();
+
+  if (hits.length === 0) {
+    return (
+      <p className='text-neutral-default content-padding py-8 text-center text-lg 2xl:px-0'>
+        No volunteer opportunities match your filters right now. Try clearing a
+        filter or check back soon.
+      </p>
+    );
+  }
+
+  return (
+    <div className='content-padding py-6'>
+      <ul className='mx-auto flex w-full max-w-[1280px] flex-col gap-4'>
+        {hits.map((hit) => (
+          <VolunteerListCard
+            key={hit.objectID}
+            volunteer={hit}
+            listingSearch={location.search}
+          />
+        ))}
+      </ul>
+    </div>
+  );
+}
+
 function CampusFilterSelect() {
   const { items, refine } = useRefinementList({
     attribute: FACET_CAMPUS,
@@ -188,12 +217,14 @@ export function VolunteerAlgolia({
   apiKey,
   indexName,
   onVolunteerUiReady,
+  resultsLayout = 'carousel',
 }: {
   appId: string;
   apiKey: string;
   indexName: string;
   /** Called once when credentials are missing, or when the first Algolia search reaches `idle`. */
   onVolunteerUiReady?: () => void;
+  resultsLayout?: 'carousel' | 'list';
 }) {
   const [searchParams, setSearchParams] = useSearchParams();
   const location = useLocation();
@@ -307,7 +338,11 @@ export function VolunteerAlgolia({
         </div>
       </div>
 
-      <VolunteerHitsCarousel />
+      {resultsLayout === 'list' ? (
+        <VolunteerHitsList />
+      ) : (
+        <VolunteerHitsCarousel />
+      )}
     </InstantSearch>
   );
 }

--- a/app/routes/volunteer/components/volunteer-list-card.component.tsx
+++ b/app/routes/volunteer/components/volunteer-list-card.component.tsx
@@ -1,0 +1,131 @@
+import { Link } from 'react-router-dom';
+
+import { RockCampuses } from '~/lib/rock-config';
+import { withRockGetImageSizing } from '~/lib/utils';
+import { Icon } from '~/primitives/icon/icon';
+
+import type { Volunteer } from '../types';
+import { volunteerCategoryPillClassName } from '../volunteer-category-pill';
+import {
+  persistVolunteerFinderBackFromCard,
+  type VolunteerFinderBackPayload,
+} from '../outreach-opportunity/components/outreach-finder-return-href';
+
+const ROCK_CAMPUS_NAME_SET = new Set<string>(
+  RockCampuses.map((campus) => campus.name),
+);
+
+function firstRockCampusFromList(campusList: string[] | undefined): string {
+  for (const raw of campusList ?? []) {
+    const name = raw?.trim();
+    if (name && ROCK_CAMPUS_NAME_SET.has(name)) return name;
+  }
+  return '—';
+}
+
+export function VolunteerListCard({
+  volunteer,
+  listingSearch,
+}: {
+  volunteer: Volunteer;
+  listingSearch: string;
+}) {
+  const finderBackPayload: VolunteerFinderBackPayload = {
+    missionGroupGuid: volunteer.groupGuid,
+    volunteerListSearch: listingSearch,
+    origin: 'missions-private-events',
+  };
+  const coverImageUri =
+    (volunteer.coverImage?.sources?.[0]?.uri ?? '').trim() ||
+    (volunteer.eventTypeImageUrl ?? '').trim();
+
+  return (
+    <li className='overflow-hidden rounded-lg border border-neutral-lighter bg-white shadow-sm transition-shadow hover:shadow-md'>
+      <Link
+        to={`/volunteer/outreach/${volunteer.groupGuid}`}
+        prefetch='intent'
+        onClick={() => persistVolunteerFinderBackFromCard(finderBackPayload)}
+        className='group flex w-full flex-col sm:min-h-40 sm:flex-row'
+      >
+        <div className='relative aspect-video w-full shrink-0 overflow-hidden bg-neutral-lighter sm:aspect-auto sm:w-48 md:w-56'>
+          {coverImageUri ? (
+            <img
+              src={withRockGetImageSizing(coverImageUri, {
+                maxwidth: 800,
+                maxheight: 500,
+                quality: 85,
+              })}
+              alt=''
+              className='size-full object-cover transition-transform duration-300 group-hover:scale-[1.02]'
+            />
+          ) : null}
+        </div>
+
+        <div className='flex min-w-0 flex-1 flex-col gap-3 px-4 py-3 text-left md:px-6 md:py-3'>
+          <h3 className='text-lg font-extrabold leading-tight text-text-primary group-hover:text-ocean'>
+            {volunteer.title}
+          </h3>
+
+          <div className='flex flex-wrap items-center gap-2'>
+            <span
+              className={volunteerCategoryPillClassName(
+                volunteer.category?.trim() ?? '',
+              )}
+            >
+              {volunteer.category?.trim() ?? ''}
+            </span>
+            <span className='text-sm text-neutral-default'>
+              {volunteer.spotsLeft} spots left
+            </span>
+          </div>
+
+          {volunteer.opportunityType?.length ? (
+            <div className='flex flex-wrap gap-2'>
+              {volunteer.opportunityType
+                .slice(0, 2)
+                .map((opportunity, index) => (
+                  <span
+                    key={`${opportunity}-${index}`}
+                    className='rounded-[4px] bg-gray px-2.5 py-1 text-xs text-neutral-default'
+                  >
+                    {opportunity}
+                  </span>
+                ))}
+            </div>
+          ) : null}
+
+          <ul className='flex flex-wrap gap-x-6 gap-y-2 text-sm text-neutral-darker'>
+            <li className='flex min-w-0 items-center gap-2'>
+              <Icon name='map' size={20} className='shrink-0' />
+              <span className='truncate'>
+                {firstRockCampusFromList(volunteer.campusList)}
+              </span>
+            </li>
+            <li className='flex min-w-0 items-center gap-2'>
+              <Icon name='calendarAlt' size={20} className='shrink-0' />
+              <span className='truncate'>
+                {volunteer.eventDateStr?.trim() &&
+                volunteer.eventEndDateStr?.trim() &&
+                volunteer.eventDateStr.trim() !==
+                  volunteer.eventEndDateStr.trim()
+                  ? `${volunteer.eventDateStr.trim()} – ${volunteer.eventEndDateStr.trim()}`
+                  : volunteer.eventDateStr?.trim() || '—'}
+              </span>
+            </li>
+            <li className='flex min-w-0 items-center gap-2'>
+              <Icon name='timeFive' size={20} className='shrink-0' />
+              <span className='truncate'>
+                {volunteer.eventTimeStr?.trim() &&
+                volunteer.eventEndTimeStr?.trim()
+                  ? `${volunteer.eventTimeStr.trim()} – ${volunteer.eventEndTimeStr.trim()}`
+                  : volunteer.eventTimeStr?.trim() ||
+                    volunteer.eventEndTimeStr?.trim() ||
+                    '—'}
+              </span>
+            </li>
+          </ul>
+        </div>
+      </Link>
+    </li>
+  );
+}

--- a/app/routes/volunteer/outreach-opportunity/components/outreach-finder-return-href.ts
+++ b/app/routes/volunteer/outreach-opportunity/components/outreach-finder-return-href.ts
@@ -3,8 +3,10 @@
  */
 export type VolunteerFinderBackPayload = {
   missionGroupGuid: string;
-  /** `location.search` on `/volunteer` (`""` or `?category=…`). */
+  /** `location.search` on the originating finder (`""` or `?category=…`). */
   volunteerListSearch: string;
+  /** Omitted by existing volunteer cards; they continue to use the volunteer finder. */
+  origin?: 'missions-private-events';
 };
 
 export const VOLUNTEER_FINDER_BACK_STORAGE_KEY =
@@ -21,9 +23,13 @@ function parseFinderBackPayload(
     return null;
   }
   if (typeof o.volunteerListSearch !== 'string') return null;
+  if (o.origin !== undefined && o.origin !== 'missions-private-events') {
+    return null;
+  }
   return {
     missionGroupGuid: o.missionGroupGuid,
     volunteerListSearch: o.volunteerListSearch,
+    origin: o.origin,
   };
 }
 

--- a/app/routes/volunteer/outreach-opportunity/outreach-opportunity-page.tsx
+++ b/app/routes/volunteer/outreach-opportunity/outreach-opportunity-page.tsx
@@ -63,6 +63,10 @@ export function OutreachOpportunityPage() {
         navigate('/volunteer#community');
         return;
       }
+      if (payload.origin === 'missions-private-events') {
+        navigate(`/missions-private-events${payload.volunteerListSearch}`);
+        return;
+      }
       if (payload.volunteerListSearch.trim().length > 1) {
         navigate(-1);
         return;


### PR DESCRIPTION
## Summary

Restores `/missions-private-events`, which was accidentally removed when PR #364 merged (stale branch wipe). Brings back the privately shared Missions finder (Algolia `missionsPrivate`, list layout, `noindex`) and back-navigation from outreach detail pages.

Spanish Connect Card regression from the same wipe is tracked separately in #378 and is out of scope here.

## Screenshots

[Paste your screenshots here]

## Testing

- [x] Open `/missions-private-events` and confirm private mission events list loads from Algolia
- [x] Filter by cause/location and open an opportunity detail page
- [x] Use Back and confirm return to `/missions-private-events` (with filters when present)
- [x] Confirm public `/volunteer` community finder still uses carousel layout
- [x] Confirm page meta includes `noindex, nofollow`
- [x] Ran `pnpm check` (lint / typecheck / prettier) and related unit tests — passed

## Tickets

N/A (regression restore from accidental deletion in #364)

## Changes Made

### New Components Added

- `app/routes/volunteer/components/volunteer-list-card.component.tsx` — list-row card for private missions finder
- Tests for list card + list layout Algolia rendering

### New Utilities

- Extended `VolunteerFinderBackPayload` with optional `origin: 'missions-private-events'` in `outreach-finder-return-href.ts`

### New Assets

- None

### Dependencies

- None

### Route Implementation

- `app/routes/missions-private-events/` — private finder page (`loader`, `meta` with `noIndex`, list layout UI)
- Algolia index key `missionsPrivate` restored in `app/lib/algolia-indexes.ts`

### Key Features

- Privately shareable missions events finder at `/missions-private-events`
- List layout via `resultsLayout='list'` on shared `VolunteerAlgolia`
- Outreach detail Back returns to private finder when opened from that page
- Search engines blocked via `noindex, nofollow`


Made with [Cursor](https://cursor.com)