### PR TITLE
Navbar Media Cards Fix

### DIFF
--- a/.infisical.json
+++ b/.infisical.json
@@ -1,5 +1,5 @@
 {
-    "workspaceId": "104f27e7-c992-44e9-bbff-7bab7acd26b2",
-    "defaultEnvironment": "",
-    "gitBranchToEnvironmentMapping": null
+  "workspaceId": "104f27e7-c992-44e9-bbff-7bab7acd26b2",
+  "defaultEnvironment": "",
+  "gitBranchToEnvironmentMapping": null
 }

--- a/app/routes/navbar/__tests__/feature-cards.test.ts
+++ b/app/routes/navbar/__tests__/feature-cards.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('~/lib/.server/fetch-rock-data', () => ({
+  fetchRockData: vi.fn(),
+}));
+
+vi.mock('~/lib/.server/authentication/get-user-from-request', () => ({
+  getUserFromRequest: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('~/lib/.server/algolia-indexes.server', () => ({
+  getServerAlgoliaIndexes: vi.fn(() => ({})),
+}));
+
+vi.mock('~/routes/podcasts/podcast-routing.server', () => ({
+  buildPodcastRoutingIndex: vi.fn().mockResolvedValue({
+    byEpisodeChannelId: new Map([['777', { showPath: 'the-show' }]]),
+  }),
+}));
+
+import { fetchRockData } from '~/lib/.server/fetch-rock-data';
+import { loader } from '../loader';
+
+const mockFetchRockData = fetchRockData as ReturnType<typeof vi.fn>;
+
+const ARTICLE = {
+  title: 'Latest Article',
+  startDateTime: '2026-07-29T10:00:00',
+  contentChannelId: '43',
+  attributeValues: { url: { value: 'latest-article' }, image: { value: '' } },
+};
+
+const FUTURE_EPISODE = {
+  title: 'Episode Scheduled For Monday',
+  startDateTime: '2026-08-03T10:00:00',
+  contentChannelId: '777',
+  attributeValues: { url: { value: 'monday-episode' }, image: { value: '' } },
+};
+
+/**
+ * Routes each Rock query to a fixture by its channel filter, since the article,
+ * podcast and sermon fetches all run concurrently and have no fixed call order.
+ * `episodes` is what Rock returns for the podcast episode channels — the tests
+ * use `[]` to represent an episode excluded by the approved/in-window filters.
+ */
+function mockRockResponses({ episodes }: { episodes: unknown }) {
+  mockFetchRockData.mockImplementation(
+    ({ queryParams }: { queryParams: { $filter?: string } }) => {
+      const filter = queryParams?.$filter ?? '';
+      if (filter.includes('ContentChannelId eq 43')) return ARTICLE;
+      if (filter.includes('ContentChannelId eq 777')) return episodes;
+      if (filter.includes('ContentChannelId eq 63')) return [];
+      return [];
+    },
+  );
+}
+
+const makeArgs = () =>
+  ({
+    params: {},
+    request: new Request('http://localhost/'),
+    context: {},
+  }) as unknown as Parameters<typeof loader>[0];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('navbar feature cards', () => {
+  it('asks Rock only for approved content whose scheduled window is currently open', async () => {
+    mockRockResponses({ episodes: [] });
+
+    await loader(makeArgs());
+
+    expect(mockFetchRockData).toHaveBeenCalled();
+    for (const [options] of mockFetchRockData.mock.calls) {
+      expect(options.filterByDateRange).toBe(true);
+      expect(options.filterByStatusApproved).toBe(true);
+      // The flags above are what apply the date window; an inline Status clause
+      // would satisfy approval without it and let future-dated items through.
+      expect(options.queryParams?.$filter ?? '').not.toContain('Status eq');
+    }
+  });
+
+  it('falls back to the latest article when the newest podcast episode is not live yet', async () => {
+    // Rock returns nothing for the episode channels because the only episode is
+    // scheduled for a future date, so it fails the in-window filter.
+    mockRockResponses({ episodes: [] });
+
+    const { watchReadListen } = await loader(makeArgs());
+
+    expect(watchReadListen.featureCards).toHaveLength(1);
+    expect(watchReadListen.featureCards[0]).toMatchObject({
+      title: 'Latest Article',
+      subtitle: 'New Article',
+      callToAction: { title: 'Read Now', url: '/articles/latest-article' },
+    });
+  });
+
+  it('shows the podcast episode once it is live and newer than the latest article', async () => {
+    mockRockResponses({ episodes: FUTURE_EPISODE });
+
+    const { watchReadListen } = await loader(makeArgs());
+
+    expect(watchReadListen.featureCards[0]).toMatchObject({
+      title: 'Episode Scheduled For Monday',
+      subtitle: 'New Podcast Episode',
+      callToAction: {
+        title: 'Listen Now',
+        url: '/podcasts/the-show/monday-episode',
+      },
+    });
+  });
+});

--- a/app/routes/navbar/loader.tsx
+++ b/app/routes/navbar/loader.tsx
@@ -84,11 +84,13 @@ const fetchLatestPodcastEpisode =
       const latestEpisodeData = await fetchRockData({
         endpoint: 'ContentChannelItems',
         queryParams: {
-          $filter: `(${channelFilter}) and Status eq 'Approved'`,
+          $filter: `(${channelFilter})`,
           $orderby: 'StartDateTime desc',
           $top: '1',
           loadAttributes: 'simple',
         },
+        filterByDateRange: true,
+        filterByStatusApproved: true,
       });
 
       const episode = (
@@ -146,21 +148,25 @@ const fetchFeatureCards = async () => {
         fetchRockData({
           endpoint: 'ContentChannelItems',
           queryParams: {
-            $filter: `ContentChannelId eq ${ContentChannelIds.articles} and Status eq 'Approved'`,
+            $filter: `ContentChannelId eq ${ContentChannelIds.articles}`,
             $orderby: 'StartDateTime desc',
             $top: '1',
             loadAttributes: 'simple',
           },
+          filterByDateRange: true,
+          filterByStatusApproved: true,
         }),
         fetchLatestPodcastEpisode(),
         fetchRockData({
           endpoint: 'ContentChannelItems',
           queryParams: {
-            $filter: `ContentChannelId eq 63 and Status eq 'Approved'`,
+            $filter: `ContentChannelId eq 63`,
             $orderby: 'StartDateTime desc',
             $top: '1',
             loadAttributes: 'simple',
           },
+          filterByDateRange: true,
+          filterByStatusApproved: true,
         }),
       ]);
 
@@ -169,6 +175,13 @@ const fetchFeatureCards = async () => {
         ? latestArticleData[0]
         : latestArticleData
     ) as RockContentChannelItem | undefined;
+
+    // A date-range-filtered fetch can come back as an empty array, which
+    // `.filter(Boolean)` would keep (empty arrays are truthy) and then break
+    // the card mapping below — so unwrap to a single item or undefined.
+    const sermon = Array.isArray(latestSermonData)
+      ? latestSermonData[0]
+      : latestSermonData;
 
     const latestArticleOrPodcastCard = pickMostRecentContentItem(
       article,
@@ -187,11 +200,9 @@ const fetchFeatureCards = async () => {
       navMenu: 'get involved',
     };
 
-    return [
-      latestSermonData,
-      latestArticleOrPodcastCard,
-      mockGetInvolvedData,
-    ].filter(Boolean);
+    return [sermon, latestArticleOrPodcastCard, mockGetInvolvedData].filter(
+      Boolean,
+    );
   } catch (error) {
     console.error('Error fetching feature cards:', error);
     return [];


### PR DESCRIPTION
## Summary

The feature card under the navbar's **Media** menu was showing a podcast episode that isn't scheduled to go live until Monday. It now shows the latest article instead, and more generally will only ever surface content that is both approved **and** inside its scheduled publish window.

The three feature-card queries in `app/routes/navbar/loader.tsx` (latest article, latest podcast episode, latest message) filtered on `Status eq 'Approved'` inline and applied **no date-range filter at all**. Since those queries also sort by `StartDateTime desc`, a future-dated-but-approved item sorts straight to the top and wins `pickMostRecentContentItem` — so a not-yet-published episode rendered in the nav as though it were live.

## Screenshots

N/A — server-side loader/data change. See note in Testing: the rendered card can't be verified locally without Rock credentials, so this is best eyeballed on a deployed preview.

## Testing

- [x] Open the site and hover/tap the **Media** nav menu.
- [x] Confirm the feature card is the latest **article** ("New Article" / "Read Now"), not the podcast episode scheduled for Monday.
- [x] Confirm the "Latest Message" card still renders and links correctly.
- [x] `pnpm run check` shows no warnings or errors.

## Tickets

[CFDP-4180](https://christfellowshipchurch.atlassian.net/browse/CFDP-4180)

## Changes Made

### New Components Added

None.

### New Utilities

None — this PR deliberately reuses the existing `filterByDateRange` / `filterByStatusApproved` options on `fetchRockData` rather than introducing a new helper.

### New Assets

None.

### Dependencies

None.

### Route Implementation

- `app/routes/navbar/loader.tsx` — replaced inline `Status eq 'Approved'` with `filterByDateRange: true` + `filterByStatusApproved: true` on all three feature-card fetches (latest article, latest podcast episode across all show channels, latest message); unwrapped the sermon result so an empty-array response can't break the card mapping.
- `app/routes/navbar/__tests__/feature-cards.test.ts` — **new**, 3 tests: (1) every nav content query requests approved + in-window and carries no inline `Status eq` that would bypass the window; (2) a not-yet-live episode falls back to the latest article; (3) a live, newer episode still wins.

### Key Features

- Unpublished/scheduled content no longer leaks into the navbar — the Media card respects the content's publish window, not just its approval state.
- Expired content is excluded too, via the same `ExpireDateTime` guard.
- Removes a crash path that could blank the entire navbar (all menus, not just Media) whenever a date-filtered fetch returned no rows.
- No caching regression: date-range cache-key stabilization was already in place.

[CFDP-4180]: https://christfellowshipchurch.atlassian.net/browse/CFDP-4180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ