### PR TITLE
Spanish Connect Card (re-added)

### DIFF
--- a/app/components/modals/connect-card/__tests__/connect-form.test.tsx
+++ b/app/components/modals/connect-card/__tests__/connect-form.test.tsx
@@ -1,7 +1,7 @@
 import * as Form from '@radix-ui/react-form';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { MemoryRouter, useLocation } from 'react-router-dom';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
 import ConnectCardForm, {
   renderInputField,
   renderCheckboxField,
@@ -54,7 +54,16 @@ function LocationProbe() {
 function renderForm(onSuccess = vi.fn(), initialEntry = '/connect-card') {
   return render(
     <MemoryRouter initialEntries={[initialEntry]}>
-      <ConnectCardForm onSuccess={onSuccess} />
+      <Routes>
+        <Route
+          path='/connect-card'
+          element={<ConnectCardForm onSuccess={onSuccess} />}
+        />
+        <Route
+          path='/locations/:location'
+          element={<ConnectCardForm onSuccess={onSuccess} />}
+        />
+      </Routes>
       <LocationProbe />
     </MemoryRouter>,
   );
@@ -161,8 +170,12 @@ describe('ConnectCardForm', () => {
       state: 'idle',
       data: {
         campuses: [
-          { guid: 'guid-1', name: 'Palm Beach Gardens' },
-          { guid: 'guid-2', name: 'Stuart' },
+          {
+            guid: 'guid-1',
+            name: 'Palm Beach Gardens',
+            url: 'palm-beach-gardens',
+          },
+          { guid: 'guid-2', name: 'Stuart', url: 'stuart' },
         ],
         allThatApplies: [],
       },
@@ -170,6 +183,31 @@ describe('ConnectCardForm', () => {
     renderForm();
     expect(screen.getByText('Palm Beach Gardens')).toBeInTheDocument();
     expect(screen.getByText('Stuart')).toBeInTheDocument();
+  });
+
+  it('locks campus when opened from a location page', () => {
+    mockFormFetcherState = {
+      state: 'idle',
+      data: {
+        campuses: [
+          {
+            guid: 'guid-pbg',
+            name: 'Palm Beach Gardens',
+            url: 'palm-beach-gardens',
+          },
+          { guid: 'guid-stuart', name: 'Stuart', url: 'stuart' },
+        ],
+        allThatApplies: [],
+      },
+    };
+
+    renderForm(vi.fn(), '/locations/palm-beach-gardens');
+
+    expect(screen.getByRole('combobox', { name: 'Campus' })).toBeDisabled();
+    expect(screen.getByText('Palm Beach Gardens')).toBeInTheDocument();
+    expect(document.querySelector('input[name="campus"]')).toHaveValue(
+      'guid-pbg',
+    );
   });
 
   it("shows 'I am looking to:' section with checkboxes from fetcher data", () => {
@@ -215,10 +253,9 @@ describe('ConnectCardForm', () => {
       },
     };
     renderForm();
-    const checkbox = document.querySelector(
-      "input[type='checkbox'][value='guid-other']",
-    ) as HTMLInputElement;
+    const checkbox = screen.getByLabelText('Other') as HTMLInputElement;
     expect(checkbox).toBeInTheDocument();
+    expect(checkbox.value).toBe('guid-other');
     // otherContent field is not present before toggling
     expect(
       document.querySelector("input[name='otherContent']"),
@@ -321,24 +358,29 @@ describe('ConnectCardForm', () => {
     expect(screen.getByDisplayValue('Janet')).toBeInTheDocument();
   });
 
-  it('still submits to connect-card when prefill fails', async () => {
-    mockPrefillFetcherState = {
-      state: 'idle',
-      data: { status: 'error', message: 'Unable to load prefill data' },
-    };
+  it('logs submission payload and posts to the connect-card action', () => {
+    const consoleGroupSpy = vi
+      .spyOn(console, 'group')
+      .mockImplementation(() => {});
+    const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const consoleGroupEndSpy = vi
+      .spyOn(console, 'groupEnd')
+      .mockImplementation(() => {});
 
     renderForm(vi.fn(), '/connect-card?rckipid=token-123');
 
-    expect(
-      screen.getByText(
-        'Fill out the form below and someone from our team will follow up with you!',
-      ),
-    ).toBeInTheDocument();
-
     fireEvent.submit(document.querySelector('form') as HTMLFormElement);
+
     expect(mockSubmit).toHaveBeenCalledWith(expect.any(FormData), {
       method: 'post',
       action: '/connect-card',
     });
+    expect(consoleGroupSpy).toHaveBeenCalledWith(
+      '[Connect Card] Submit preview',
+    );
+
+    consoleGroupSpy.mockRestore();
+    consoleLogSpy.mockRestore();
+    consoleGroupEndSpy.mockRestore();
   });
 });

--- a/app/components/modals/connect-card/connect-card-flow.component.tsx
+++ b/app/components/modals/connect-card/connect-card-flow.component.tsx
@@ -9,8 +9,10 @@ enum ConnectCardStep {
 
 const ConnectCardFlow = ({
   setOpenModal,
+  isEspanol,
 }: {
   setOpenModal: (open: boolean) => void;
+  isEspanol?: boolean;
 }) => {
   const [step, setStep] = useState<ConnectCardStep>(
     ConnectCardStep.CONNECT_CARD,
@@ -22,6 +24,7 @@ const ConnectCardFlow = ({
         return (
           <ConnectCardForm
             onSuccess={() => setStep(ConnectCardStep.CONFIRMATION)}
+            isEspanol={isEspanol}
           />
         );
       case ConnectCardStep.CONFIRMATION:

--- a/app/components/modals/connect-card/connect-card-modal.tsx
+++ b/app/components/modals/connect-card/connect-card-modal.tsx
@@ -46,7 +46,7 @@ export function ConnectCardModal({
         </Modal.Button>
       )}
       <Modal.Content>
-        <ConnectCardFlow setOpenModal={setOpenModal} />
+        <ConnectCardFlow setOpenModal={setOpenModal} isEspanol={isEspanol} />
       </Modal.Content>
     </Modal>
   );

--- a/app/components/modals/connect-card/connect-form.component.tsx
+++ b/app/components/modals/connect-card/connect-form.component.tsx
@@ -13,16 +13,19 @@ import {
   radixSelectClassName,
 } from '~/primitives/inputs/form-radix-field';
 import { formFieldInvalidControlStyles } from '~/primitives/inputs/form-control.styles';
-import { useFetcher, useSearchParams } from 'react-router-dom';
+import { useFetcher, useParams, useSearchParams } from 'react-router-dom';
 import type {
   ConnectCardLoaderReturnType,
   ConnectCardPrefill,
   ConnectCardPrefillResponse,
 } from '~/routes/connect-card/types';
+import { buildConnectCardSubmission } from '~/routes/connect-card/build-submission';
+import { getSpanishRockSubmitValue } from '~/routes/connect-card/connect-card-rock-values';
 import { pushFormEvent } from '~/lib/gtm';
 
 interface ConnectCardProps {
   onSuccess: () => void;
+  isEspanol?: boolean;
 }
 
 export const renderInputField = (
@@ -73,6 +76,22 @@ interface CheckboxOption {
 // the existing `Other` handling.
 const NEXT_STEP_VALUES = ['The Journey class', 'Baptism'];
 
+const CONNECT_CARD_OPTION_LABELS_ES: Record<string, string> = {
+  'The Journey class': 'la clase Journey',
+  Baptism: 'bautismo',
+  'Find community': 'Encontrar comunidad',
+  'Make a difference by serving as a volunteer':
+    'Hacer la diferencia ayudando como voluntario',
+  'Make a difference by volunteering':
+    'Hacer la diferencia ayudando como voluntario',
+  'Discover a place where my kids feel at home':
+    'Descubrir un lugar donde mis hijos se sientan en casa',
+  Other: 'Otro',
+};
+
+const getConnectCardOptionLabel = (value: string, isEspanol?: boolean) =>
+  isEspanol ? (CONNECT_CARD_OPTION_LABELS_ES[value] ?? value) : value;
+
 const emptyPrefill: Required<ConnectCardPrefill> = {
   firstName: '',
   lastName: '',
@@ -122,17 +141,20 @@ const getRockPersonIdSearchParam = (searchParams: URLSearchParams) => {
 export const renderCheckboxField = (
   checkbox: CheckboxOption,
   index: number,
+  label = checkbox.value,
+  namePrefix = 'allThatApplies',
+  submitValue = checkbox.guid,
 ) => (
   <Form.Field
     key={index}
-    name={`allThatApplies-${index}`}
+    name={`${namePrefix}-${index}`}
     className={cn('flex gap-2 md:items-center', formFieldInvalidControlStyles)}
   >
     <Form.Control asChild>
       <input
         type='checkbox'
         id={checkbox.guid}
-        value={checkbox.guid}
+        value={submitValue}
         className={radixCheckboxClassName}
       />
     </Form.Control>
@@ -140,7 +162,7 @@ export const renderCheckboxField = (
       htmlFor={checkbox.guid}
       className={radixCheckboxOptionLabelClassName}
     >
-      {checkbox.value}
+      {label}
     </Form.Label>
   </Form.Field>
 );
@@ -148,12 +170,21 @@ export const renderCheckboxField = (
 const CONNECT_CARD_INTRO =
   'Fill out the form below and someone from our team will follow up with you!';
 
-const ConnectCardForm: React.FC<ConnectCardProps> = ({ onSuccess }) => {
+const CONNECT_CARD_INTRO_ES =
+  'Completa el formulario a continuación y alguien de nuestro equipo se comunicará contigo.';
+
+const ConnectCardForm: React.FC<ConnectCardProps> = ({
+  onSuccess,
+  isEspanol,
+}) => {
   const [isOther, setIsOther] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [prefillValues, setPrefillValues] =
     useState<Required<ConnectCardPrefill>>(emptyPrefill);
+  const [campusSelectKey, setCampusSelectKey] = useState(0);
+  const { location: campusUrlFromPath } = useParams();
+  const isCampusLocked = Boolean(campusUrlFromPath);
   const fetcher = useFetcher({ key: 'connect-card-form' });
   const prefillFetcher = useFetcher({ key: 'connect-card-prefill' });
   const [searchParams, setSearchParams] = useSearchParams();
@@ -223,9 +254,15 @@ const ConnectCardForm: React.FC<ConnectCardProps> = ({ onSuccess }) => {
       lastName: response.prefill.lastName ?? current.lastName,
       email: response.prefill.email ?? current.email,
       phone: response.prefill.phone ?? current.phone,
-      campus: response.prefill.campus ?? current.campus,
+      campus: isCampusLocked
+        ? current.campus
+        : (response.prefill.campus ?? current.campus),
     }));
-  }, [prefillFetcher.state, prefillFetcher.data]);
+
+    if (response.prefill.campus && !isCampusLocked) {
+      setCampusSelectKey((key) => key + 1);
+    }
+  }, [isCampusLocked, prefillFetcher.state, prefillFetcher.data]);
 
   // Effect for handling form data and submissions
   useEffect(() => {
@@ -254,7 +291,24 @@ const ConnectCardForm: React.FC<ConnectCardProps> = ({ onSuccess }) => {
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     const formData = new FormData(event.currentTarget);
+    const rawFormData = Object.fromEntries(formData.entries());
+    const submission = buildConnectCardSubmission(rawFormData);
 
+    // Debug: log payload before submitting
+    // eslint-disable-next-line no-console -- temporary connect card debug
+    console.group('[Connect Card] Submit preview');
+    // eslint-disable-next-line no-console -- temporary connect card debug
+    console.log('Raw form fields:', submission.rawFormData);
+    // eslint-disable-next-line no-console -- temporary connect card debug
+    console.log('Workflow type ID:', submission.workflowTypeId);
+    // eslint-disable-next-line no-console -- temporary connect card debug
+    console.log('Rock endpoint:', submission.endpoint);
+    // eslint-disable-next-line no-console -- temporary connect card debug
+    console.log('Rock body:', submission.body);
+    // eslint-disable-next-line no-console -- temporary connect card debug
+    console.groupEnd();
+
+    // --- Live form submission ---
     try {
       fetcher.submit(formData, {
         method: 'post',
@@ -282,6 +336,9 @@ const ConnectCardForm: React.FC<ConnectCardProps> = ({ onSuccess }) => {
     };
 
   const { campuses, allThatApplies } = formFieldData;
+  const lockedCampus = campusUrlFromPath
+    ? campuses.find((campus) => campus.url === campusUrlFromPath)
+    : undefined;
 
   const otherCheckbox = allThatApplies.find(
     (checkbox) => checkbox.value === 'Other',
@@ -302,41 +359,48 @@ const ConnectCardForm: React.FC<ConnectCardProps> = ({ onSuccess }) => {
 
   return (
     <>
-      <h2 className='mb-6 text-3xl text-navy font-bold'>Get Connected</h2>
-      <p className='text-center md:text-left mb-10 col-span-2 text-sm text-text-secondary'>
-        {CONNECT_CARD_INTRO}
+      <h2 className='mb-6 text-3xl text-navy font-bold'>
+        {isEspanol ? 'Conéctate' : 'Get Connected'}
+      </h2>
+      <p className='text-center mb-10 col-span-2 text-sm text-text-secondary'>
+        {isEspanol ? CONNECT_CARD_INTRO_ES : CONNECT_CARD_INTRO}
       </p>
       <Form.Root
         onSubmit={handleSubmit}
         className='flex flex-col md:grid text-left grid-cols-1 gap-y-3 gap-x-6 md:grid-cols-2'
       >
+        {isEspanol && <input type='hidden' name='language' value='Spanish' />}
         {renderInputField(
           'firstName',
-          'First Name',
+          isEspanol ? 'Nombre' : 'First Name',
           'text',
-          'Please enter your first name',
+          isEspanol ? 'Nombre es obligatorio.' : 'Please enter your first name',
           undefined,
-          'First Name',
+          isEspanol ? 'Nombre' : 'First Name',
           '',
           prefillValues.firstName,
           handlePrefillValueChange('firstName'),
         )}
         {renderInputField(
           'lastName',
-          'Last Name',
+          isEspanol ? 'Apellido' : 'Last Name',
           'text',
-          'Please enter your last name',
+          isEspanol
+            ? 'Apellido es obligatorio.'
+            : 'Please enter your last name',
           undefined,
-          'Last Name',
+          isEspanol ? 'Apellido' : 'Last Name',
           '',
           prefillValues.lastName,
           handlePrefillValueChange('lastName'),
         )}
         {renderInputField(
           'phone',
-          'Phone',
+          isEspanol ? 'Teléfono' : 'Phone',
           'tel',
-          'Please enter a valid number',
+          isEspanol
+            ? 'Teléfono es obligatorio.'
+            : 'Please enter a valid number',
           undefined,
           'xxx-xxx-xxxx',
           '',
@@ -347,39 +411,61 @@ const ConnectCardForm: React.FC<ConnectCardProps> = ({ onSuccess }) => {
           'email',
           'Email',
           'text',
-          'Please enter a valid email',
+          isEspanol ? 'Email es obligatorio.' : 'Please enter a valid email',
           undefined,
-          'Example@gmail.com',
+          isEspanol ? 'Email' : 'Example@gmail.com',
           '',
           prefillValues.email,
           handlePrefillValueChange('email'),
         )}
 
         <Form.Field name='campus' className={radixFormFieldStackClassName}>
-          <Form.Label className={radixCompactFormLabelClassName}>
+          <Form.Label
+            className={radixCompactFormLabelClassName}
+            htmlFor={lockedCampus ? 'connect-card-campus' : undefined}
+          >
             Campus
           </Form.Label>
-          {campuses && (
-            <RadixFormSelectShell>
-              <Form.Control asChild>
+          {lockedCampus ? (
+            <>
+              <input type='hidden' name='campus' value={lockedCampus.guid} />
+              <RadixFormSelectShell>
                 <select
+                  id='connect-card-campus'
                   className={radixSelectClassName}
-                  required
-                  value={prefillValues.campus}
-                  onChange={handlePrefillValueChange('campus')}
+                  disabled
+                  aria-readonly
                 >
-                  <option value=''>Select a Campus</option>
-                  {campuses.map(({ guid, name }, index) => (
-                    <option key={index} value={guid}>
-                      {name}
-                    </option>
-                  ))}
+                  <option>{lockedCampus.name}</option>
                 </select>
-              </Form.Control>
-            </RadixFormSelectShell>
+              </RadixFormSelectShell>
+            </>
+          ) : (
+            campuses && (
+              <RadixFormSelectShell>
+                <Form.Control asChild>
+                  <select
+                    key={`campus-${campusSelectKey}`}
+                    name='campus'
+                    className={radixSelectClassName}
+                    required
+                    defaultValue={prefillValues.campus}
+                  >
+                    <option value=''>
+                      {isEspanol ? 'Seleccione un campus' : 'Select a Campus'}
+                    </option>
+                    {campuses.map(({ guid, name }, index) => (
+                      <option key={index} value={guid}>
+                        {name}
+                      </option>
+                    ))}
+                  </select>
+                </Form.Control>
+              </RadixFormSelectShell>
+            )
           )}
           <RadixFormErrorMessage match='valueMissing'>
-            Please select a campus
+            {isEspanol ? 'Campus es obligatorio.' : 'Please select a campus'}
           </RadixFormErrorMessage>
         </Form.Field>
 
@@ -395,7 +481,11 @@ const ConnectCardForm: React.FC<ConnectCardProps> = ({ onSuccess }) => {
               type='checkbox'
               id='decision'
               name='decision'
-              value='I made a decision to follow Christ today.'
+              value={
+                isEspanol
+                  ? 'Hoy tomé la decisión de seguir a Cristo.'
+                  : 'I made a decision to follow Christ today.'
+              }
               className={radixCheckboxClassName}
             />
           </Form.Control>
@@ -403,34 +493,72 @@ const ConnectCardForm: React.FC<ConnectCardProps> = ({ onSuccess }) => {
             htmlFor='decision'
             className={radixCheckboxOptionLabelClassName}
           >
-            I made a decision to follow Christ today
+            {isEspanol
+              ? 'Hoy tomé la decisión de seguir a Cristo.'
+              : 'I made a decision to follow Christ today'}
           </Form.Label>
         </Form.Field>
 
         <h3 className='col-span-2 mt-6 md:mt-8 text-lg font-bold italic text-navy'>
-          I am looking to:
+          {isEspanol ? 'Estoy buscondo:' : 'I am looking to:'}
         </h3>
         {nextStepCheckboxes.length > 0 && (
           <div className='col-span-2 flex flex-col gap-3 border-b border-gray-200 pb-4'>
             <p className='italic text-navy'>
-              Take the next step in my faith through…
+              {isEspanol
+                ? 'Tomar mi siguiente paso en la fe a través de...'
+                : 'Take the next step in my faith through…'}
             </p>
-            <div className='grid grid-cols-1 gap-y-2 md:grid-cols-2 md:gap-x-6'>
-              {nextStepCheckboxes.map(({ checkbox, index }) =>
-                renderCheckboxField(checkbox, index),
-              )}
-            </div>
+            {isEspanol ? (
+              <div className='flex flex-wrap gap-x-6 gap-y-2'>
+                {nextStepCheckboxes.map(({ checkbox }) => (
+                  <label
+                    key={checkbox.guid}
+                    className={cn(
+                      'flex gap-2 md:items-center',
+                      radixCheckboxOptionLabelClassName,
+                    )}
+                  >
+                    <input
+                      type='radio'
+                      name='nextStep'
+                      value={getSpanishRockSubmitValue(checkbox.guid)}
+                      className={radixCheckboxClassName}
+                    />
+                    {getConnectCardOptionLabel(checkbox.value, isEspanol)}
+                  </label>
+                ))}
+              </div>
+            ) : (
+              <div className='grid grid-cols-1 gap-y-2 md:grid-cols-2 md:gap-x-6'>
+                {nextStepCheckboxes.map(({ checkbox, index }) =>
+                  renderCheckboxField(
+                    checkbox,
+                    index,
+                    getConnectCardOptionLabel(checkbox.value, isEspanol),
+                  ),
+                )}
+              </div>
+            )}
           </div>
         )}
         <div className='col-span-2 grid grid-cols-1 gap-y-2 md:grid-cols-2 md:gap-x-6'>
           {generalCheckboxes.map(({ checkbox, index }) =>
-            renderCheckboxField(checkbox, index),
+            renderCheckboxField(
+              checkbox,
+              index,
+              getConnectCardOptionLabel(checkbox.value, isEspanol),
+              isEspanol ? 'selection' : 'allThatApplies',
+              isEspanol
+                ? getSpanishRockSubmitValue(checkbox.guid)
+                : checkbox.guid,
+            ),
           )}
         </div>
 
         {otherCheckbox && (
           <Form.Field
-            name='other'
+            name={isEspanol ? 'selection-other' : otherCheckbox.guid}
             className={cn(
               'flex gap-2 md:items-center',
               formFieldInvalidControlStyles,
@@ -440,8 +568,11 @@ const ConnectCardForm: React.FC<ConnectCardProps> = ({ onSuccess }) => {
               <input
                 type='checkbox'
                 id={otherCheckbox.guid}
-                name={otherCheckbox.guid}
-                value={otherCheckbox.guid}
+                value={
+                  isEspanol
+                    ? getSpanishRockSubmitValue(otherCheckbox.guid)
+                    : otherCheckbox.guid
+                }
                 className={radixCheckboxClassName}
                 onChange={(_e) => setIsOther(!isOther)}
               />
@@ -450,7 +581,7 @@ const ConnectCardForm: React.FC<ConnectCardProps> = ({ onSuccess }) => {
               htmlFor={otherCheckbox.guid}
               className={radixCheckboxOptionLabelClassName}
             >
-              {otherCheckbox.value}
+              {getConnectCardOptionLabel(otherCheckbox.value, isEspanol)}
             </Form.Label>
           </Form.Field>
         )}
@@ -465,7 +596,9 @@ const ConnectCardForm: React.FC<ConnectCardProps> = ({ onSuccess }) => {
               <Form.Control asChild>
                 <input
                   type='text'
-                  placeholder='Please specify'
+                  placeholder={
+                    isEspanol ? 'Porfavor especifique' : 'Please specify'
+                  }
                   className={radixInputClassName}
                 />
               </Form.Control>
@@ -482,7 +615,7 @@ const ConnectCardForm: React.FC<ConnectCardProps> = ({ onSuccess }) => {
             type='submit'
             disabled={loading}
           >
-            {loading ? 'Loading...' : 'Submit'}
+            {loading ? 'Loading...' : isEspanol ? 'Complete' : 'Submit'}
           </Button>
         </Form.Submit>
       </Form.Root>

--- a/app/routes/connect-card/__tests__/action.test.ts
+++ b/app/routes/connect-card/__tests__/action.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+vi.mock('~/lib/.server/rock-workflow', () => ({
+  postRockWorkflowLaunchWithApiInitiator: vi.fn(),
+  buildRockWorkflowLaunchEndpoint: (
+    workflowTypeId: string,
+    workflowName: string,
+  ) =>
+    `Workflows/LaunchWorkflow/0?workflowTypeId=${workflowTypeId}&workflowName=${encodeURIComponent(workflowName)}`,
+}));
+
+import { postRockWorkflowLaunchWithApiInitiator } from '~/lib/.server/rock-workflow';
+import { buildConnectCardSubmission } from '../build-submission';
+import { action } from '../action';
+
+const mockPostRockWorkflowLaunchWithApiInitiator =
+  postRockWorkflowLaunchWithApiInitiator as ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockPostRockWorkflowLaunchWithApiInitiator.mockResolvedValue(undefined);
+});
+
+function makeRequest(fields: Record<string, string>) {
+  const formData = new FormData();
+  Object.entries(fields).forEach(([key, value]) => formData.set(key, value));
+
+  return new Request('http://localhost/connect-card', {
+    method: 'POST',
+    body: formData,
+  });
+}
+
+describe('buildConnectCardSubmission', () => {
+  it('maps Spanish submissions to workflow 403 attribute keys', () => {
+    const submission = buildConnectCardSubmission({
+      language: 'Spanish',
+      firstName: 'Test',
+      lastName: 'Form',
+      email: 'test@example.com',
+      phone: '555-123-4567',
+      campus: 'campus-guid',
+      nextStep: '1',
+      'selection-0': 'Encontrar comunidad',
+      'selection-1': 'Hacer la diferencia ayudando como voluntario',
+      'selection-other': 'Otro',
+      otherContent: 'Something else',
+      decision: 'Hoy tomé la decisión de seguir a Cristo.',
+    });
+
+    expect(submission.workflowTypeId).toBe('403');
+    expect(submission.workflowName).toBe('CFDP Web Connect Card');
+    expect(submission.body).toEqual({
+      FirstName: 'Test',
+      LastName: 'Form',
+      Campus: 'campus-guid',
+      PhoneNumber: '555-123-4567',
+      EmailAddress: 'test@example.com',
+      LaunchSource: 'app',
+      NextStep: '1',
+      Selection:
+        'Encontrar comunidad,Hacer la diferencia ayudando como voluntario,Otro',
+      Decision: 'Hoy tomé la decisión de seguir a Cristo.',
+      Other: 'Something else',
+    });
+  });
+
+  it('maps English submissions to workflow 902 attribute keys', () => {
+    const submission = buildConnectCardSubmission({
+      firstName: 'Jane',
+      lastName: 'Doe',
+      email: 'jane@example.com',
+      phone: '555-000-0000',
+      campus: 'campus-guid',
+      'allThatApplies-0': 'guid-a',
+      'allThatApplies-1': 'guid-b',
+      'allThatApplies-4': 'journey-guid',
+      'allThatApplies-5': 'baptism-guid',
+    });
+
+    expect(submission.workflowTypeId).toBe('902');
+    expect(submission.workflowName).toBe('CFDP Web Connect Card');
+    expect(submission.body).toEqual({
+      FirstName: 'Jane',
+      LastName: 'Doe',
+      Campus: 'campus-guid',
+      PhoneNumber: '555-000-0000',
+      Email: 'jane@example.com',
+      AllThatApplies: 'guid-a,guid-b,journey-guid,baptism-guid',
+    });
+  });
+});
+
+describe('connect-card action', () => {
+  it('launches Spanish and English through the same Rock workflow path', async () => {
+    await action({
+      request: makeRequest({
+        language: 'Spanish',
+        firstName: 'Test',
+        lastName: 'Form',
+        email: 'test@example.com',
+        phone: '555-123-4567',
+        campus: 'campus-guid',
+      }),
+    } as Parameters<typeof action>[0]);
+
+    expect(mockPostRockWorkflowLaunchWithApiInitiator).toHaveBeenCalledWith({
+      workflowTypeId: '403',
+      workflowName: 'CFDP Web Connect Card',
+      body: {
+        FirstName: 'Test',
+        LastName: 'Form',
+        Campus: 'campus-guid',
+        PhoneNumber: '555-123-4567',
+        EmailAddress: 'test@example.com',
+        LaunchSource: 'app',
+      },
+      instanceName: 'Test Form',
+    });
+
+    vi.clearAllMocks();
+
+    await action({
+      request: makeRequest({
+        firstName: 'Jane',
+        lastName: 'Doe',
+        email: 'jane@example.com',
+        phone: '555-000-0000',
+        campus: 'campus-guid',
+      }),
+    } as Parameters<typeof action>[0]);
+
+    expect(mockPostRockWorkflowLaunchWithApiInitiator).toHaveBeenCalledWith({
+      workflowTypeId: '902',
+      workflowName: 'CFDP Web Connect Card',
+      body: {
+        FirstName: 'Jane',
+        LastName: 'Doe',
+        Campus: 'campus-guid',
+        PhoneNumber: '555-000-0000',
+        Email: 'jane@example.com',
+        AllThatApplies: '',
+      },
+      instanceName: 'Jane Doe',
+    });
+  });
+});

--- a/app/routes/connect-card/__tests__/connect-card-rock-values.test.ts
+++ b/app/routes/connect-card/__tests__/connect-card-rock-values.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { getSpanishRockSubmitValue } from '../connect-card-rock-values';
+
+const COMMUNITY_GUID = '288ca790-1fb1-4386-9cfa-5fa1c4fbb7cf';
+const JOURNEY_GUID = 'e9abcf96-cbe4-4d6f-8d22-fa5c44736b2c';
+const BAPTISM_GUID = '2c0481e1-6228-4828-8273-7199ff908028';
+const OTHER_GUID = '1d408930-f300-46f8-8200-b465a51049e3';
+
+describe('getSpanishRockSubmitValue', () => {
+  it('maps general options to Spanish Rock checkbox labels', () => {
+    expect(getSpanishRockSubmitValue(COMMUNITY_GUID)).toBe(
+      'Encontrar comunidad',
+    );
+    expect(getSpanishRockSubmitValue(OTHER_GUID)).toBe('Otro');
+  });
+
+  it('maps next-step options to Rock single-select values', () => {
+    expect(getSpanishRockSubmitValue(JOURNEY_GUID)).toBe('1');
+    expect(getSpanishRockSubmitValue(BAPTISM_GUID)).toBe('2');
+  });
+});

--- a/app/routes/connect-card/action.ts
+++ b/app/routes/connect-card/action.ts
@@ -1,45 +1,20 @@
 import { ActionFunction, data } from 'react-router-dom';
-import { ConnectFormType } from './types';
-import { postRockData } from '~/lib/.server/fetch-rock-data';
+import { buildConnectCardSubmission } from './build-submission';
+import { postRockWorkflowLaunchWithApiInitiator } from '~/lib/.server/rock-workflow';
 
 export const action: ActionFunction = async ({ request }) => {
   try {
     const formData = Object.fromEntries(await request.formData());
+    const submission = buildConnectCardSubmission(formData);
+    const instanceName =
+      `${submission.body.FirstName} ${submission.body.LastName}`.trim();
 
-    const allThatAppliesValues: string = Object.keys(formData)
-      .filter((key) => key.includes('allThatApplies'))
-      .map((key) => formData[key])
-      .join(',');
-
-    const {
-      email,
-      firstName,
-      lastName,
-      phone,
-      otherContent,
-      campus,
-      decision,
-    } = formData;
-
-    const connectFormSubmission: ConnectFormType = {
-      FirstName: firstName as string,
-      LastName: lastName as string,
-      Campus: campus as string,
-      Email: email as string,
-      PhoneNumber: phone as string,
-      AllThatApplies: allThatAppliesValues,
-    };
-
-    if (decision) {
-      connectFormSubmission.Decision = decision as string;
-    }
-    if (otherContent) {
-      connectFormSubmission.Other = otherContent as string;
-    }
-
-    await postRockData({
-      endpoint: `Workflows/LaunchWorkflow/0?workflowTypeId=902&workflowName=CFDP%20Web%20Connect%20Card`,
-      body: connectFormSubmission,
+    // --- Live Rock submission ---
+    await postRockWorkflowLaunchWithApiInitiator({
+      workflowTypeId: submission.workflowTypeId,
+      workflowName: submission.workflowName,
+      body: submission.body,
+      instanceName,
     });
 
     return new Response(JSON.stringify({ success: true }), {

--- a/app/routes/connect-card/build-submission.ts
+++ b/app/routes/connect-card/build-submission.ts
@@ -1,0 +1,93 @@
+import type { ConnectFormType } from './types';
+
+const ENGLISH_WORKFLOW_NAME = 'CFDP Web Connect Card';
+
+const buildWorkflowLaunchEndpointPreview = (
+  workflowTypeId: string,
+  workflowName: string,
+): string =>
+  `Workflows/LaunchWorkflow/0?workflowTypeId=${workflowTypeId}&workflowName=${encodeURIComponent(workflowName)}`;
+
+const joinFormFieldValues = (
+  formData: Record<string, unknown>,
+  keyMatcher: (key: string) => boolean,
+): string =>
+  Object.keys(formData)
+    .filter(keyMatcher)
+    .map((key) => String(formData[key]))
+    .join(',');
+
+export type ConnectCardSubmissionPreview = {
+  workflowTypeId: '403' | '902';
+  workflowName: string;
+  endpoint: string;
+  body: ConnectFormType;
+  rawFormData: Record<string, string>;
+};
+
+export function buildConnectCardSubmission(
+  formData: Record<string, unknown>,
+): ConnectCardSubmissionPreview {
+  const {
+    email,
+    firstName,
+    lastName,
+    phone,
+    otherContent,
+    campus,
+    decision,
+    language,
+  } = formData;
+
+  const isSpanish = language === 'Spanish';
+  const workflowTypeId = isSpanish ? '403' : '902';
+  const workflowName = ENGLISH_WORKFLOW_NAME;
+
+  const body: ConnectFormType = {
+    FirstName: String(firstName ?? ''),
+    LastName: String(lastName ?? ''),
+    Campus: String(campus ?? ''),
+    PhoneNumber: String(phone ?? ''),
+  };
+
+  if (isSpanish) {
+    body.EmailAddress = String(email ?? '');
+    body.LaunchSource = 'app';
+
+    const nextStep = formData.nextStep;
+    const selection = joinFormFieldValues(formData, (key) =>
+      key.startsWith('selection-'),
+    );
+
+    if (nextStep !== undefined && String(nextStep) !== '') {
+      body.NextStep = String(nextStep);
+    }
+    if (selection) {
+      body.Selection = selection;
+    }
+  } else {
+    body.Email = String(email ?? '');
+    body.AllThatApplies = joinFormFieldValues(formData, (key) =>
+      key.includes('allThatApplies'),
+    );
+  }
+
+  if (decision) {
+    body.Decision = String(decision);
+  }
+  if (otherContent) {
+    body.Other = String(otherContent);
+  }
+
+  const rawFormData = Object.fromEntries(
+    Object.entries(formData).map(([key, value]) => [key, String(value ?? '')]),
+  );
+
+  return {
+    workflowTypeId,
+    workflowName,
+    endpoint: buildWorkflowLaunchEndpointPreview(workflowTypeId, workflowName),
+    body,
+    rawFormData,
+  };
+}

--- a/app/routes/connect-card/connect-card-rock-values.ts
+++ b/app/routes/connect-card/connect-card-rock-values.ts
@@ -1,0 +1,21 @@
+/**
+ * Spanish workflow 403 stores checkbox/radio values differently from DefinedValue
+ * GUIDs. English workflow 902 uses GUIDs for all AllThatApplies options (unchanged).
+ */
+const SPANISH_ROCK_VALUES_BY_GUID: Record<string, string> = {
+  '288ca790-1fb1-4386-9cfa-5fa1c4fbb7cf': 'Encontrar comunidad',
+  '81771787-4dd5-4be5-85e4-f3edf770fd94':
+    'Hacer la diferencia ayudando como voluntario',
+  '2ae99b0a-e0c4-4cf3-823f-459cd74e021a':
+    'Descubrir un lugar donde mis hijos se sientan en casa',
+  '1d408930-f300-46f8-8200-b465a51049e3': 'Otro',
+  'e9abcf96-cbe4-4d6f-8d22-fa5c44736b2c': '1',
+  '2c0481e1-6228-4828-8273-7199ff908028': '2',
+};
+
+export function getSpanishRockSubmitValue(definedValueGuid: string): string {
+  return (
+    SPANISH_ROCK_VALUES_BY_GUID[definedValueGuid.toLowerCase()] ??
+    definedValueGuid
+  );
+}

--- a/app/routes/connect-card/loader.ts
+++ b/app/routes/connect-card/loader.ts
@@ -19,7 +19,7 @@ export const loader: LoaderFunction = async () => {
     queryParams: {
       $filter: 'IsActive eq true',
       $orderby: 'Order',
-      $select: 'Name, Guid',
+      $select: 'Name, Guid, Url',
     },
   });
 

--- a/app/routes/connect-card/types.ts
+++ b/app/routes/connect-card/types.ts
@@ -2,15 +2,20 @@ export type ConnectFormType = {
   FirstName: string;
   LastName: string;
   Campus: string; // campus guid
-  Email: string;
+  Email?: string;
+  EmailAddress?: string;
   PhoneNumber: string;
   Decision?: string;
   AllThatApplies?: string;
+  Selection?: string;
+  NextStep?: string;
   Other?: string;
+  /** Present on Spanish workflow 403 only (matches other Rock form launches). */
+  LaunchSource?: 'app';
 };
 
 export type ConnectCardLoaderReturnType = {
-  campuses: { guid: string; name: string }[];
+  campuses: { guid: string; name: string; url?: string }[];
   allThatApplies: { guid: string; value: string }[];
 };
 

--- a/app/routes/locations/location-single/components/ctas.component.tsx
+++ b/app/routes/locations/location-single/components/ctas.component.tsx
@@ -58,7 +58,7 @@ export const CTAs = ({
           />
         </div>
         <div className={ctaSlotClassName}>
-          <ConnectCardModal>
+          <ConnectCardModal isEspanol={isSpanish}>
             <CTAButtonContent
               icon='mobileAlt'
               title={isSpanish ? 'Contáctanos' : 'Contact Us'}

--- a/app/routes/locations/location-single/partials/faq.partial.tsx
+++ b/app/routes/locations/location-single/partials/faq.partial.tsx
@@ -40,7 +40,7 @@ export const LocationFAQ = ({
                 ? `Alguien de nuestro equipo estará encatado de responder a tus preguntas`
                 : `Someone from our team is happy to answer any of your questions!`}
             </p>
-            <ConnectCardModal>
+            <ConnectCardModal isEspanol={isEspanol}>
               <Button
                 className='w-full max-w-[200px] rounded-sm'
                 intent='secondary'


### PR DESCRIPTION
## Summary

Adds Spanish Connect Card support for Español campus/location pages. Spanish submissions now use Rock workflow **403** (instead of English **902**) with the correct attribute keys (`EmailAddress`, `NextStep`, `Selection`) and Spanish form copy matching [rock.gocf.org/conectate](https://rock.gocf.org/conectate). Also locks campus from the location URL when opened from a campus page, and omits `startDate` for ministry pages in resource collections (those items don’t have a meaningful start date).

## Screenshots

[Paste screenshots of the Spanish Connect Card modal on an Español location page — filled form + success confirmation]

## Testing

- [x] Open an Español location page (e.g. Christ Fellowship Español Royal Palm Beach)
- [x] Click **Conéctate** / Contact Us — confirm Spanish Connect Card page opens
- [x] Confirm campus is prefilled/locked to the current location campus
- [x] Fill required fields (Nombre, Apellido, Teléfono, Email)
- [x] Optionally check decision + next step (Journey/bautismo radio) + Selection checkboxes (including Otro + text)
- [x] Submit and confirm success confirmation appears
- [x] In Rock, confirm workflow **403** launches with correct attribute values (`EmailAddress`, `NextStep`, `Selection`, `Decision`, `Other`, campus, contact fields)
- [x] Open an English location / footer Connect Card and confirm English flow still uses workflow **902** with `Email` + `AllThatApplies` (GUIDs) unchanged
- [x] Ran `pnpm check` and `pnpm test` — no new linter/type/prettier/test errors or warnings

## Tickets

[CFDP-4184](https://christfellowshipchurch.atlassian.net/browse/CFDP-4184)


## Changes Made

### New Components Added

- None

### New Utilities

- `app/routes/connect-card/build-submission.ts` — builds Rock payload for English (902) vs Spanish (403), including attribute key mapping
- `app/routes/connect-card/connect-card-rock-values.ts` — maps Spanish DefinedValue GUIDs to Rock-stored values (`1`/`2` for NextStep; Spanish labels for Selection)

### New Assets

- None

### Dependencies

- None

### Route Implementation

- `app/routes/connect-card/action.ts` — launches workflow **403** for Spanish and **902** for English via shared Rock launch path
- `app/routes/connect-card/types.ts` — Spanish attribute keys (`EmailAddress`, `NextStep`, `Selection`)
- `app/routes/connect-card/loader.ts` — minor loader update for form field data
- Location CTAs/FAQ wire `isEspanol` into Connect Card modal:
  - `app/routes/locations/location-single/components/ctas.component.tsx`
  - `app/routes/locations/location-single/partials/faq.partial.tsx`
- `app/routes/page-builder/loader.tsx` — omit `startDate` for `MINISTRY_PAGE` collection items

### Key Features

- Spanish Connect Card UI copy (labels, validation, checkbox/radio options, Complete CTA)
- Campus prefill/lock from location URL on Spanish campus pages
- Spanish next-step options as radios (`NextStep`: Journey=`1`, Baptism=`2`); no “None” option in UI
- Spanish interest checkboxes map to Rock `Selection` text values; English `AllThatApplies` remains GUID-based
- Separate English/Spanish Rock attribute mapping while keeping one shared launch mechanism
- Ministry cards in collections no longer display an incorrect start date

[CFDP-4133]: https://christfellowshipchurch.atlassian.net/browse/CFDP-4133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CFDP-4184]: https://christfellowshipchurch.atlassian.net/browse/CFDP-4184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ