### PR TITLE
Redirect for Wrong Group Finder Link

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -25,6 +25,11 @@
       "source": "/young-adults",
       "destination": "/ministries/young-adults",
       "statusCode": 301
+    },
+    {
+      "source": "/groups",
+      "destination": "/group-finder",
+      "statusCode": 301
     }
   ]
 }


### PR DESCRIPTION
## Summary

Email for Group Finder was sent to `/group` instead of `/group-finder`

## Testing

- [x] `/groups` goes to `/group-finder`