### PR TITLE
fix: Rock access layer pre-copy defects (ROCK_API, by-id $expand/$select, auth existence check)

### DIFF
--- a/app/components/modals/auth/initial-signup.component.tsx
+++ b/app/components/modals/auth/initial-signup.component.tsx
@@ -48,7 +48,15 @@ const InitialSignUp: React.FC<InitialSignUpProps> = ({ onSubmit }) => {
       return;
     }
 
-    const userExists = await checkUserExists(identity);
+    let userExists: boolean;
+    try {
+      userExists = await checkUserExists(identity);
+    } catch {
+      // The server did not answer, so we cannot say the account is available.
+      setLoading(false);
+      setError('An error occurred. Please try again.');
+      return;
+    }
 
     if (userExists) {
       setLoading(false);

--- a/app/components/modals/auth/login.component.tsx
+++ b/app/components/modals/auth/login.component.tsx
@@ -46,9 +46,14 @@ const Login: React.FC<LoginProps> = ({ onSubmit }) => {
       return;
     }
 
-    let userExists = false;
-    if (isEmail || isPhoneNumber) {
+    let userExists: boolean;
+    try {
       userExists = await checkUserExists(identity);
+    } catch {
+      // The server did not answer, so we cannot say the account is missing.
+      setLoading(false);
+      setError('An error occurred. Please try again.');
+      return;
     }
 
     if (!userExists) {

--- a/app/lib/.server/__tests__/fetch-rock-data.test.ts
+++ b/app/lib/.server/__tests__/fetch-rock-data.test.ts
@@ -330,6 +330,107 @@ describe('getRockApiBaseUrl', () => {
   });
 });
 
+// ─── by-id $expand / $select guard ──────────────────────────────────────────
+
+/**
+ * Rock silently ignores $expand and $select on Entity/{id} routes: an ignored
+ * $select overfetches the whole entity, and an ignored $expand resolves the
+ * navigation property to null, so the fetch succeeds and the crash lands later
+ * in whatever reads a field off it. The guard has to key on that route shape —
+ * People/GetByAttributeValue also returns one row but does honor $expand, so a
+ * guard keying on "returns one row" would fire on a working endpoint.
+ */
+describe('by-id $expand / $select guard', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => [{ id: 1 }],
+    });
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  const personId = 123;
+
+  it.each([
+    ['numeric id with $select', 'People/1', { $select: 'Email' }],
+    [
+      'interpolated id with $expand',
+      `GroupMembers/${personId}`,
+      { $expand: 'GroupRole' },
+    ],
+    [
+      'guid id with $select',
+      'PersonAlias/6c2a1b70-4f2a-4a5e-9d1c-2f3b4a5c6d7e',
+      { $select: 'Guid' },
+    ],
+    [
+      'leading slash and both params',
+      '/People/1',
+      { $expand: 'Photo', $select: 'Email' },
+    ],
+  ])('fires on %s', async (_label, endpoint, queryParams) => {
+    await expect(fetchRockData({ endpoint, queryParams })).rejects.toThrow(
+      /silently ignores/,
+    );
+    expect(warnSpy).toHaveBeenCalled();
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [
+      'People/GetByAttributeValue, which does honor $expand',
+      'People/GetByAttributeValue',
+      { attributeKey: 'Pathname', value: 'ryan-mcdermott', $expand: 'Photo' },
+    ],
+    [
+      'the collection form of a by-id lookup',
+      'People',
+      { $filter: `Id eq ${personId}`, $select: 'Email' },
+    ],
+    [
+      'a trailing-slash collection endpoint',
+      'DefinedValues/',
+      { $filter: "Guid eq guid'abc'", $select: 'Value' },
+    ],
+    [
+      'ContentChannelItems/GetByAttributeValue',
+      'ContentChannelItems/GetByAttributeValue',
+      { attributeKey: 'Pathname', value: 'some-article', $select: 'Title' },
+    ],
+    ['a by-id endpoint carrying neither param', 'PersonAlias/7', {}],
+  ])('does not fire on %s', async (_label, endpoint, queryParams) => {
+    await expect(
+      fetchRockData({ endpoint, queryParams }),
+    ).resolves.toBeDefined();
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(global.fetch).toHaveBeenCalled();
+  });
+
+  it('warns but still fetches in production, where waste beats an outage', async () => {
+    const nodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+
+    try {
+      await expect(
+        fetchRockData({ endpoint: 'People/1', queryParams: { $select: 'Email' } }),
+      ).resolves.toBeDefined();
+      expect(warnSpy).toHaveBeenCalled();
+      expect(global.fetch).toHaveBeenCalled();
+    } finally {
+      process.env.NODE_ENV = nodeEnv;
+    }
+  });
+});
+
 // ─── deleteCacheKey ─────────────────────────────────────────────────────────
 
 describe('deleteCacheKey', () => {

--- a/app/lib/.server/__tests__/fetch-rock-data.test.ts
+++ b/app/lib/.server/__tests__/fetch-rock-data.test.ts
@@ -421,7 +421,10 @@ describe('by-id $expand / $select guard', () => {
 
     try {
       await expect(
-        fetchRockData({ endpoint: 'People/1', queryParams: { $select: 'Email' } }),
+        fetchRockData({
+          endpoint: 'People/1',
+          queryParams: { $select: 'Email' },
+        }),
       ).resolves.toBeDefined();
       expect(warnSpy).toHaveBeenCalled();
       expect(global.fetch).toHaveBeenCalled();

--- a/app/lib/.server/__tests__/fetch-rock-data.test.ts
+++ b/app/lib/.server/__tests__/fetch-rock-data.test.ts
@@ -3,8 +3,10 @@ import {
   fetchRockData,
   deleteRockData,
   postRockData,
+  putRockData,
   patchRockData,
   deleteCacheKey,
+  getRockApiBaseUrl,
   isItemInDateRange,
   TTL,
 } from '../fetch-rock-data';
@@ -266,6 +268,65 @@ describe('patchRockData', () => {
     await expect(
       patchRockData({ endpoint: 'People/1', body: {} }),
     ).rejects.toThrow('Failed to patch data');
+  });
+});
+
+// ─── ROCK_API validation ────────────────────────────────────────────────────
+
+/**
+ * An absent ROCK_API used to interpolate as the literal string "undefined" and
+ * every request was built against it. Rock answered those URLs in a way that
+ * read as "user does not exist", so the misconfiguration was invisible and the
+ * debugging went after the wrong thing. Missing config must fail as config.
+ */
+describe.each([
+  { label: 'unset', value: undefined },
+  { label: 'empty', value: '' },
+  { label: 'whitespace-only', value: '   ' },
+])('ROCK_API $label', ({ value }: { label: string; value?: string }) => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    if (value === undefined) {
+      delete process.env.ROCK_API;
+    } else {
+      process.env.ROCK_API = value;
+    }
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+  });
+
+  it('makes fetchRockData fail naming the variable, without calling fetch', async () => {
+    await expect(fetchRockData({ endpoint: 'People' })).rejects.toThrow(
+      /ROCK_API/,
+    );
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('explains that a new worktree has no env files', async () => {
+    await expect(fetchRockData({ endpoint: 'People' })).rejects.toThrow(
+      /worktree/,
+    );
+  });
+
+  it.each([
+    ['deleteRockData', () => deleteRockData('People/1')],
+    ['postRockData', () => postRockData({ endpoint: 'People', body: {} })],
+    ['putRockData', () => putRockData({ endpoint: 'People/1', body: {} })],
+    ['patchRockData', () => patchRockData({ endpoint: 'People/1', body: {} })],
+  ])('makes %s fail before it can build a URL', async (_name, call) => {
+    await expect(call()).rejects.toThrow(/ROCK_API/);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+});
+
+describe('getRockApiBaseUrl', () => {
+  it('returns the configured base URL', () => {
+    process.env.ROCK_API = 'https://rock.example.com/api/';
+    expect(getRockApiBaseUrl()).toBe('https://rock.example.com/api/');
   });
 });
 

--- a/app/lib/.server/__tests__/rock-person.test.ts
+++ b/app/lib/.server/__tests__/rock-person.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../fetch-rock-data', () => ({
+  fetchRockData: vi.fn(),
+  patchRockData: vi.fn(),
+  postRockData: vi.fn(),
+  TTL: { NONE: 0 },
+}));
+
+vi.mock('../authentication/sms-authentication', () => ({
+  createPhoneNumberInRock: vi.fn(),
+  parsePhoneNumberUtil: vi.fn(() => ({
+    significantNumber: '5615551234',
+    countryCode: '1',
+  })),
+}));
+
+import { updatePerson } from '../rock-person';
+import { fetchRockData, patchRockData } from '../fetch-rock-data';
+
+const mockFetchRockData = fetchRockData as ReturnType<typeof vi.fn>;
+const mockPatchRockData = patchRockData as ReturnType<typeof vi.fn>;
+
+const fields = { email: 'new@example.com', phoneNumber: '+15615551234' };
+
+/**
+ * Rock ignores $select on People/{id} and returns the whole entity, so the email
+ * lookup uses the collection form. fetchRockData unwraps a single match to an
+ * object and leaves a miss as an empty array — updatePerson has to read both.
+ */
+const mockPersonLookup = (personResult: unknown) => {
+  mockFetchRockData.mockImplementation(async ({ endpoint }) =>
+    endpoint === 'People' ? personResult : [{ personId: 1 }],
+  );
+};
+
+describe('updatePerson email lookup', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('asks for the collection form so Rock honors $select', async () => {
+    mockPersonLookup({ email: 'existing@example.com' });
+
+    await updatePerson('42', fields);
+
+    expect(mockFetchRockData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        endpoint: 'People',
+        queryParams: { $filter: 'Id eq 42', $select: 'Email' },
+      }),
+    );
+    expect(mockFetchRockData).not.toHaveBeenCalledWith(
+      expect.objectContaining({ endpoint: 'People/42' }),
+    );
+  });
+
+  it('leaves an existing email alone', async () => {
+    mockPersonLookup({ email: 'existing@example.com' });
+
+    await updatePerson('42', fields);
+
+    expect(mockPatchRockData).not.toHaveBeenCalled();
+  });
+
+  it('patches the email when the person has none', async () => {
+    mockPersonLookup({ id: 42 });
+
+    await updatePerson('42', fields);
+
+    expect(mockPatchRockData).toHaveBeenCalledWith({
+      endpoint: 'People/42',
+      body: { Email: fields.email },
+    });
+  });
+
+  it('still patches when the collection form returns a single-element array', async () => {
+    mockPersonLookup([{ id: 42 }]);
+
+    await updatePerson('42', fields);
+
+    expect(mockPatchRockData).toHaveBeenCalledWith({
+      endpoint: 'People/42',
+      body: { Email: fields.email },
+    });
+  });
+
+  it('treats an empty result as no email rather than reading a field off it', async () => {
+    mockPersonLookup([]);
+
+    await expect(updatePerson('42', fields)).resolves.not.toThrow();
+    expect(mockPatchRockData).toHaveBeenCalledWith({
+      endpoint: 'People/42',
+      body: { Email: fields.email },
+    });
+  });
+});

--- a/app/lib/.server/fetch-rock-data.ts
+++ b/app/lib/.server/fetch-rock-data.ts
@@ -16,10 +16,34 @@ interface RockDataRequest {
   contentType?: string;
 }
 
-const baseUrl = `${process.env.ROCK_API}`;
 const defaultHeaders = {
   'Content-Type': 'application/json',
   'Authorization-Token': `${process.env.ROCK_TOKEN}`,
+};
+
+/**
+ * Single validated accessor for ROCK_API. Interpolating the env var directly
+ * turns an absent value into the literal string "undefined" and builds every
+ * request against it, which surfaces as Rock answering "user does not exist"
+ * rather than as missing configuration.
+ *
+ * Read lazily rather than at module load: importing this module must not
+ * require env to be present, or the test suite and the build break.
+ */
+export const getRockApiBaseUrl = (): string => {
+  const baseUrl = process.env.ROCK_API?.trim();
+
+  if (!baseUrl) {
+    throw new Error(
+      'ROCK_API is not set, so no Rock request can be built. .env and ' +
+        '.env.local are gitignored, so `git worktree add` creates a tree with ' +
+        'no env files at all and says nothing about it — copy them from your ' +
+        'main checkout and start the app with `netlify dev`, which is what ' +
+        'loads them.',
+    );
+  }
+
+  return baseUrl;
 };
 
 /**
@@ -257,7 +281,7 @@ export const fetchRockData = async ({
     ) as Record<string, string>;
 
     const queryString = new URLSearchParams(definedQueryParams).toString();
-    const url = `${baseUrl}${endpoint}?${queryString}`;
+    const url = `${getRockApiBaseUrl()}${endpoint}?${queryString}`;
 
     const res = await fetch(url, {
       headers: {
@@ -321,7 +345,7 @@ export const fetchRockData = async ({
  */
 export const deleteRockData = async (endpoint: string) => {
   try {
-    const response = await fetch(`${process.env.ROCK_API}/${endpoint}`, {
+    const response = await fetch(`${getRockApiBaseUrl()}/${endpoint}`, {
       method: 'DELETE',
       headers: {
         'Authorization-Token': `${process.env.ROCK_TOKEN}`,
@@ -355,7 +379,7 @@ export const postRockData = async ({
   body,
   contentType = 'application/json',
 }: RockDataRequest) => {
-  const response = await fetch(`${process.env.ROCK_API}${endpoint}`, {
+  const response = await fetch(`${getRockApiBaseUrl()}${endpoint}`, {
     method: 'POST',
     headers: {
       'Content-Type': contentType,
@@ -386,7 +410,7 @@ export const postRockData = async ({
  * @returns response body as JSON
  */
 export const putRockData = async ({ endpoint, body }: RockDataRequest) => {
-  const response = await fetch(`${process.env.ROCK_API}${endpoint}`, {
+  const response = await fetch(`${getRockApiBaseUrl()}${endpoint}`, {
     method: 'PUT',
     headers: {
       'Content-Type': 'application/json',
@@ -413,7 +437,7 @@ export const putRockData = async ({ endpoint, body }: RockDataRequest) => {
  * @returns response status code
  */
 export const patchRockData = async ({ endpoint, body }: RockDataRequest) => {
-  const response = await fetch(`${process.env.ROCK_API}/${endpoint}`, {
+  const response = await fetch(`${getRockApiBaseUrl()}/${endpoint}`, {
     method: 'PATCH',
     headers: {
       ...defaultHeaders,

--- a/app/lib/.server/fetch-rock-data.ts
+++ b/app/lib/.server/fetch-rock-data.ts
@@ -182,6 +182,58 @@ const stripApprovedStatusFilter = (
   return stripped || undefined;
 };
 
+/**
+ * True for Entity/{id} route shapes — a path segment after the first that is
+ * bare digits or a GUID. The defect below belongs to that route shape, not to
+ * single-entity fetches as a class: People/GetByAttributeValue returns one row
+ * and does honor $expand, and its second segment is a word, not an id.
+ */
+const isByIdEndpoint = (endpoint: string): boolean => {
+  const segments = endpoint.replace(/^\/+|\/+$/g, '').split('/');
+  const idPattern =
+    /^(\d+|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/i;
+
+  return segments.slice(1).some((segment) => idPattern.test(segment));
+};
+
+/**
+ * Rock silently ignores $expand and $select on Entity/{id} routes — no error,
+ * no warning, the full entity comes back. An ignored $select is ~17x payload
+ * waste (3.1 KB vs 187 B per row); an ignored $expand of a navigation property
+ * returns null, so the fetch succeeds and the failure surfaces later in
+ * whatever reads a field off it.
+ *
+ * Use the collection form instead, where both are honored:
+ *   People?$filter=Id eq {id}&$select=Email
+ *
+ * Throws outside production because a warning in a server log is exactly what
+ * the next generated call site will slip past. In production it only warns —
+ * the consequence there is waste, which is not worth an outage.
+ */
+const assertByIdEndpointHasNoIgnoredParams = (
+  endpoint: string,
+  queryParams: RockQueryParams,
+): void => {
+  if (!isByIdEndpoint(endpoint)) return;
+
+  const ignoredParams = (['$expand', '$select'] as const).filter(
+    (param) => queryParams[param],
+  );
+  if (ignoredParams.length === 0) return;
+
+  const message =
+    `⚠️ Rock silently ignores ${ignoredParams.join(' and ')} on the by-id ` +
+    `endpoint "${endpoint}" — the full entity is returned and an $expand ` +
+    'resolves to null. Use the collection form instead, e.g. ' +
+    'People?$filter=Id eq 123&$select=Email';
+
+  console.warn(message);
+
+  if (process.env.NODE_ENV !== 'production') {
+    throw new Error(message);
+  }
+};
+
 const applyDateRangeFilter = <T>(data: T, now: Date): T | [] => {
   if (Array.isArray(data)) {
     const filteredData = data.filter((item) =>
@@ -211,6 +263,8 @@ export const fetchRockData = async ({
   filterByDateRange = false,
   filterByStatusApproved = false,
 }: FetchRockDataOptions) => {
+  assertByIdEndpointHasNoIgnoredParams(endpoint, queryParams);
+
   const previewMode = isPreviewMode();
   // Preview mode only bypasses the Status filter — date-range filtering still
   // applies, so a not-yet-scheduled or already-expired item stays hidden.

--- a/app/lib/.server/rock-person.ts
+++ b/app/lib/.server/rock-person.ts
@@ -48,15 +48,23 @@ export const updatePerson = async (
   id: string,
   fields: { email: string; phoneNumber: string },
 ) => {
-  // Update User email if user does not have one in Rock
+  // Update User email if user does not have one in Rock.
+  // Collection form, not People/{id}: Rock ignores $select on by-id routes and
+  // returns the whole entity. fetchRockData unwraps a single match to an object
+  // and leaves a miss as an empty array, so handle both shapes.
   const emailInRock = await fetchRockData({
-    endpoint: `People/${id}`,
+    endpoint: 'People',
     queryParams: {
+      $filter: `Id eq ${id}`,
       $select: 'Email',
     },
     ttl: TTL.NONE, // no cache
   });
-  if (!emailInRock.email) {
+  const personInRock = Array.isArray(emailInRock)
+    ? emailInRock[0]
+    : emailInRock;
+
+  if (!personInRock?.email) {
     await patchRockData({
       endpoint: `People/${id}`,
       body: {

--- a/app/providers/auth-provider/__tests__/index.test.tsx
+++ b/app/providers/auth-provider/__tests__/index.test.tsx
@@ -321,7 +321,11 @@ describe('useAuth - checkUserExists', () => {
   const errorResponses: Array<[string, Record<string, unknown>]> = [
     [
       'a 500 with an error body',
-      { ok: false, status: 500, json: async () => ({ error: 'Rock exploded' }) },
+      {
+        ok: false,
+        status: 500,
+        json: async () => ({ error: 'Rock exploded' }),
+      },
     ],
     [
       'a 200 whose body has no userExists',

--- a/app/providers/auth-provider/__tests__/index.test.tsx
+++ b/app/providers/auth-provider/__tests__/index.test.tsx
@@ -289,6 +289,82 @@ describe('useAuth - checkUserExists', () => {
       expect(screen.getByTestId('result').textContent).toBe('true'),
     );
   });
+
+  /**
+   * A 500, a Rock timeout or a malformed body leaves userExists absent. Reading
+   * that as false told the user their account does not exist on the strength of
+   * a server failure, so the failure has to reach the caller as a failure. The
+   * response itself stays uniform on purpose — it must not become an oracle for
+   * whether an identity has an account.
+   */
+  function CheckUserOutcomeConsumer() {
+    const { checkUserExists } = useAuth();
+    const [outcome, setOutcome] = React.useState('none');
+    return (
+      <div>
+        <span data-testid='outcome'>{outcome}</span>
+        <button
+          onClick={async () => {
+            try {
+              setOutcome(String(await checkUserExists('user@test.com')));
+            } catch {
+              setOutcome('error');
+            }
+          }}
+        >
+          check
+        </button>
+      </div>
+    );
+  }
+
+  const errorResponses: Array<[string, Record<string, unknown>]> = [
+    [
+      'a 500 with an error body',
+      { ok: false, status: 500, json: async () => ({ error: 'Rock exploded' }) },
+    ],
+    [
+      'a 200 whose body has no userExists',
+      { ok: true, status: 200, json: async () => ({ error: 'Rock exploded' }) },
+    ],
+    [
+      'a body that is not JSON at all',
+      {
+        ok: true,
+        status: 200,
+        json: async () => {
+          throw new Error('Unexpected token');
+        },
+      },
+    ],
+  ];
+
+  it.each(errorResponses)(
+    'does not take the userExists === false path on %s',
+    async (_label, response) => {
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+      (global.fetch as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce({ ok: false, status: 401 }) // mount
+        .mockResolvedValueOnce(response);
+
+      await act(async () => {
+        renderWithRouter(
+          <AuthProvider>
+            <CheckUserOutcomeConsumer />
+          </AuthProvider>,
+        );
+      });
+
+      await act(async () => {
+        screen.getByText('check').click();
+      });
+
+      await waitFor(() =>
+        expect(screen.getByTestId('outcome').textContent).toBe('error'),
+      );
+      expect(screen.getByTestId('outcome').textContent).not.toBe('false');
+    },
+  );
 });
 
 describe('AuthProvider - exports', () => {

--- a/app/providers/auth-provider/index.tsx
+++ b/app/providers/auth-provider/index.tsx
@@ -178,6 +178,12 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     revalidate(); // revalidate the loader data to update page
   };
 
+  /**
+   * Rejects rather than answering false when the server did not answer. A 500, a
+   * Rock timeout or a malformed body leaves `userExists` absent, and returning
+   * that (or catching it as false) told the user their account does not exist on
+   * the strength of a server failure. Callers must render a failure as a failure.
+   */
   const checkUserExists = async (identity: string): Promise<boolean> => {
     try {
       const formData = new FormData();
@@ -189,12 +195,20 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
         body: formData,
       });
 
-      const result = await response.json();
+      const result = await response.json().catch(() => null);
+
+      if (!response.ok || typeof result?.userExists !== 'boolean') {
+        throw new Error(
+          `Could not determine whether the user exists (status ${response.status})`,
+        );
+      }
 
       return result.userExists;
     } catch (error) {
-      handleError(error, 'Error checking user existence:');
-      return false;
+      // Logged and rethrown rather than routed through handleError: a failed
+      // existence check is not a reason to clear the auth cookie.
+      console.error('Error checking user existence:', error);
+      throw error;
     }
   };
 

--- a/app/routes/auth/userExists.tsx
+++ b/app/routes/auth/userExists.tsx
@@ -16,9 +16,23 @@ export const checkUserExists = async (identity: string): Promise<boolean> => {
   return false;
 };
 
+/** Never include the identity — the logs must not become an account oracle. */
+const rockHost = (): string => {
+  try {
+    return new URL(`${process.env.ROCK_API}`).host;
+  } catch {
+    return 'unknown (ROCK_API unset or malformed)';
+  }
+};
+
 export const userExists = async (identity: string) => {
   try {
+    // Reaching here means Rock answered, so a false is "no such person" — a real
+    // answer. It is deliberately not logged: it happens on any typo'd email, and
+    // the lint config allows only error/warn, which would mislabel it. The two
+    // cases are told apart by whether the catch below logged.
     const userExists = await checkUserExists(identity as string);
+
     return new Response(JSON.stringify({ userExists }), {
       status: 200,
       headers: {
@@ -26,6 +40,18 @@ export const userExists = async (identity: string) => {
       },
     });
   } catch (error) {
+    // Rock did not answer. The response below stays identical to every other
+    // failure on purpose — a client that could tell a lookup failure from a
+    // real not-found would leak whether the identity has an account.
+    const statusCode = (error as { statusCode?: unknown })?.statusCode;
+    console.error(
+      `[auth/checkUserExists] Rock lookup failed: ${
+        error instanceof Error ? error.name : typeof error
+      }, status ${typeof statusCode === 'number' ? statusCode : 'none'}, ` +
+        `host ${rockHost()}`,
+      error,
+    );
+
     if (error instanceof Error) {
       return data({ error: error.message }, { status: 400 });
     }

--- a/app/routes/volunteer/outreach-opportunity/__tests__/outreach-mission-rock.server.test.ts
+++ b/app/routes/volunteer/outreach-opportunity/__tests__/outreach-mission-rock.server.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('~/lib/.server/fetch-rock-data', () => ({
+  fetchRockData: vi.fn(),
+  TTL: { NONE: 0, SHORT: 300 },
+}));
+
+import { fetchRockData } from '~/lib/.server/fetch-rock-data';
+import { fetchVolunteerMissionDetailFromRock } from '../outreach-mission-rock.server';
+
+const mockFetchRockData = fetchRockData as ReturnType<typeof vi.fn>;
+
+const GROUP_GUID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+
+const groupRow = {
+  id: 9,
+  name: 'Feed the City',
+  attributeValues: {
+    contactPersonId: { value: '77' },
+    contactPerson: { value: '', valueFormatted: 'Jane Formatted' },
+  },
+};
+
+/**
+ * The contact lookup uses the collection form because Rock ignores $select on
+ * People/{id}. fetchRockData unwraps a single match to an object and leaves a
+ * miss as an empty array, so the call site has to handle both.
+ */
+const mockRock = (personResult: unknown) => {
+  mockFetchRockData.mockImplementation(async ({ endpoint }) => {
+    if (endpoint === 'Groups') return [groupRow];
+    if (endpoint === 'People') return personResult;
+    return [];
+  });
+};
+
+const person = {
+  nickName: 'Janie',
+  firstName: 'Jane',
+  lastName: 'Doe',
+  email: 'jane@example.com',
+};
+
+describe('fetchVolunteerMissionDetailFromRock contact lookup', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('asks for the collection form so Rock honors $select', async () => {
+    mockRock(person);
+
+    await fetchVolunteerMissionDetailFromRock(GROUP_GUID);
+
+    expect(mockFetchRockData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        endpoint: 'People',
+        queryParams: {
+          $filter: 'Id eq 77',
+          $select: 'FirstName,LastName,NickName,Email',
+        },
+      }),
+    );
+    expect(mockFetchRockData).not.toHaveBeenCalledWith(
+      expect.objectContaining({ endpoint: 'People/77' }),
+    );
+  });
+
+  it('reads the contact off an unwrapped single match', async () => {
+    mockRock(person);
+
+    const detail = await fetchVolunteerMissionDetailFromRock(GROUP_GUID);
+
+    expect(detail?.contactName).toBe('Janie Doe');
+    expect(detail?.contactEmail).toBe('jane@example.com');
+  });
+
+  it('reads the contact off a single-element array', async () => {
+    mockRock([person]);
+
+    const detail = await fetchVolunteerMissionDetailFromRock(GROUP_GUID);
+
+    expect(detail?.contactName).toBe('Janie Doe');
+    expect(detail?.contactEmail).toBe('jane@example.com');
+  });
+
+  it('falls back to the formatted attribute name when the person is not found', async () => {
+    mockRock([]);
+
+    const detail = await fetchVolunteerMissionDetailFromRock(GROUP_GUID);
+
+    expect(detail?.contactName).toBe('Jane Formatted');
+    expect(detail?.contactEmail).toBeUndefined();
+  });
+});

--- a/app/routes/volunteer/outreach-opportunity/outreach-mission-rock.server.ts
+++ b/app/routes/volunteer/outreach-opportunity/outreach-mission-rock.server.ts
@@ -233,13 +233,18 @@ async function fetchPersonNameEmail(
   personId: string,
 ): Promise<{ name?: string; email?: string }> {
   try {
-    const p = await fetchRockData({
-      endpoint: `People/${personId}`,
+    // Collection form, not People/{id}: Rock ignores $select on by-id routes and
+    // returns the whole entity. A single match arrives unwrapped as an object, a
+    // miss as an empty array.
+    const res = await fetchRockData({
+      endpoint: 'People',
       queryParams: {
+        $filter: `Id eq ${personId}`,
         $select: 'FirstName,LastName,NickName,Email',
       },
       ttl: TTL.NONE,
     });
+    const p = Array.isArray(res) ? res[0] : res;
     if (!p || typeof p !== 'object') return {};
     const nick = typeof p.nickName === 'string' ? p.nickName.trim() : '';
     const first = typeof p.firstName === 'string' ? p.firstName.trim() : '';


### PR DESCRIPTION
## Summary

Three Rock access-layer defects that would otherwise get copied into the My Groups project and fixed twice. Missing `ROCK_API` no longer interpolates as the literal string `"undefined"`; by-id Rock endpoints that carry `$expand`/`$select` are guarded (Rock silently ignores those params); and an unanswered `/auth` existence check is treated as an error rather than "user not found," without leaking whether an identity has an account.

## Screenshots

N/A — server/auth plumbing; no UI design changes.

## Testing

- [ ] Unset / empty `ROCK_API` (e.g. fresh worktree without `.env`) and confirm Rock helpers throw naming `ROCK_API` / worktree, and that `"undefined"` never appears in a request URL
- [ ] Confirm by-id calls with `$expand`/`$select` warn (and throw outside production); confirm `People/GetByAttributeValue` and collection-form `$select` still work
- [ ] Login / sign-up with a typo'd identity → still shows not-found messaging; with Rock/API forced to fail → shows generic retry message, not "does not exist" / "already exists"
- [x] `pnpm vitest run` — 106 files, 934 tests passed
- [ ] `pnpm check` — lint and typecheck pass; prettier still warns on two **pre-existing** unrelated files on `main` (`.github/workflows/dependency-review.yml`, `app/routes/class-finder/finder/components/group-class-type-hits.ts`). All files in this PR are prettier-clean.

## Tickets

N/A (pre-copy hardening before My Groups)

## Changes Made

### New Components Added

- None

### New Utilities

- `getRockApiBaseUrl()` in `app/lib/.server/fetch-rock-data.ts` — single validated accessor for `ROCK_API` (lazy; fails loudly when absent/empty)
- `assertByIdEndpointHasNoIgnoredParams` / `isByIdEndpoint` in the same file — warn always, throw outside production when `$expand`/`$select` are used on `Entity/{id}` routes

### New Assets

- None

### Dependencies

- None

### Route Implementation

- No new routes. Call-site updates only:
  - `app/lib/.server/rock-person.ts` — email lookup uses collection form `People?$filter=Id eq {id}&$select=Email`
  - `app/routes/volunteer/outreach-opportunity/outreach-mission-rock.server.ts` — contact person lookup same pattern
  - `app/routes/auth/userExists.tsx` — logs Rock lookup failures (error class, status, host; never the identity)
  - `app/providers/auth-provider/index.tsx` + login/sign-up modals — missing/`non-boolean` `userExists` rejects; callers show generic retry message

### Key Features

- Missing `ROCK_API` fails as configuration, not as "user does not exist"
- By-id `$expand`/`$select` misuse is caught at the access layer so regenerated call sites cannot recreate the defect
- Auth existence failures no longer present as definitive account not-found, while keeping the uniform client-facing response (no account-oracle leak)


Made with [Cursor](https://cursor.com)