### PR TITLE
Misc changes

### DIFF
--- a/app/components/navbar/desktop/search/search-popup.component.tsx
+++ b/app/components/navbar/desktop/search/search-popup.component.tsx
@@ -1,7 +1,9 @@
 import type { SearchClient } from 'algoliasearch';
 import { useCallback, useEffect, useState } from 'react';
 import { useHits, useInstantSearch, useSearchBox } from 'react-instantsearch';
+import { useRouteLoaderData } from 'react-router-dom';
 
+import type { RootLoaderData } from '~/routes/navbar/loader';
 import type { ContentItemHit } from '~/routes/search/types';
 
 import {
@@ -43,12 +45,15 @@ export const SearchPopup = ({
   const { query } = useSearchBox();
   const { indexUiState } = useInstantSearch();
   const { setHasMatchingLocations } = useGlobalSearchLocationMatches();
+  const rootData = useRouteLoaderData('root') as RootLoaderData | undefined;
   const [contentHits, setContentHits] = useState<ContentItemHit[]>([]);
   const [locationHits, setLocationHits] = useState<ContentItemHit[]>([]);
 
   const selectedContentTypes =
     (indexUiState?.refinementList?.contentType as string[]) || [];
   const trimmedQuery = query.trim();
+  const isSearching =
+    trimmedQuery.length > 0 || selectedContentTypes.length > 0;
   const shouldShowLocations =
     trimmedQuery.length > 0 &&
     shouldIncludeLocationResultsInGlobalSearch(selectedContentTypes);
@@ -100,6 +105,12 @@ export const SearchPopup = ({
     ? [...contentHits, ...locationHits]
     : contentHits;
 
+  // Before a query is typed, show the curated latest-content list instead of the
+  // index's default ranking.
+  const displayedHits = isSearching
+    ? combinedHits
+    : (rootData?.defaultSearchHits ?? []);
+
   return (
     <div className='absolute left-0 top-[52px] w-full bg-gray rounded-b-lg shadow-lg px-12 z-4 popup-search-container transition-all duration-800 ease-in-out max-h-0 overflow-hidden'>
       <div className='flex items-center gap-2 pb-4'>
@@ -115,7 +126,7 @@ export const SearchPopup = ({
 
       <div className='mt-2 space-y-4'>
         <div className='flex flex-col overflow-y-scroll max-h-[300px] scrollbar-thin [&::-webkit-scrollbar]:w-1 [&::-webkit-scrollbar-thumb]:bg-neutral-default/60 [&::-webkit-scrollbar-track]:bg-gray'>
-          {combinedHits.map((hit) => (
+          {displayedHits.map((hit) => (
             <div
               key={hit.objectID}
               onClick={() => setIsSearchOpen(false)}

--- a/app/routes/class-finder/finder/components/cant-find-class-card.component.tsx
+++ b/app/routes/class-finder/finder/components/cant-find-class-card.component.tsx
@@ -37,11 +37,12 @@ export function CantFindClassCard({
 
       <div className='flex flex-col gap-2'>
         <h3 className='text-lg font-bold leading-tight'>
-          Tell Us What You&apos;re Looking For
+          Looking for this class?
         </h3>
         <p className='text-sm text-black'>
-          If enough people are interested, we may offer this class in a future
-          season. Let us know and we&apos;ll keep you posted.
+          If this class isn&apos;t currently offered at your campus, let us know
+          you&apos;re interested. We&apos;ll reach out when it&apos;s scheduled
+          at your location.
         </p>
       </div>
 

--- a/app/routes/events/all-events/loader.tsx
+++ b/app/routes/events/all-events/loader.tsx
@@ -14,9 +14,11 @@ import {
   parseEventsFinderUrlState,
   type EventsFinderUrlState,
 } from '../events-url-state';
-
-const FEATURED_FILTER = 'contentType:"Event" AND eventIsFeatured:true';
-const FEATURED_HITS_PER_PAGE = 4;
+import {
+  FEATURED_EVENTS_FILTER,
+  FEATURED_EVENTS_HITS_PER_PAGE,
+  moveFeaturedJourneyCardFirst,
+} from '../featured-events';
 
 export type EventFinderFacetItem = {
   value: string;
@@ -79,21 +81,6 @@ function buildMainEventsSearchParams(urlState: EventsFinderUrlState): {
   return params;
 }
 
-/** Single featured "Journey" card (title match) moved to the front when present. */
-function moveFeaturedJourneyCardFirst(
-  hits: ContentItemHit[],
-): ContentItemHit[] {
-  const i = hits.findIndex((h) =>
-    (h.title ?? '').toLowerCase().includes('journey'),
-  );
-  if (i < 1) {
-    return hits;
-  }
-  const copy = [...hits];
-  const [journey] = copy.splice(i, 1);
-  return [journey, ...copy];
-}
-
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   const appId = process.env.ALGOLIA_APP_ID ?? '';
   const searchApiKey = process.env.ALGOLIA_SEARCH_API_KEY ?? '';
@@ -116,8 +103,8 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
           {
             indexName: algoliaIndexes.contentItems,
             params: {
-              filters: FEATURED_FILTER,
-              hitsPerPage: FEATURED_HITS_PER_PAGE,
+              filters: FEATURED_EVENTS_FILTER,
+              hitsPerPage: FEATURED_EVENTS_HITS_PER_PAGE,
             },
           },
         ]),

--- a/app/routes/events/featured-events.ts
+++ b/app/routes/events/featured-events.ts
@@ -1,0 +1,20 @@
+import type { ContentItemHit } from '~/routes/search/types';
+
+export const FEATURED_EVENTS_FILTER =
+  'contentType:"Event" AND eventIsFeatured:true';
+export const FEATURED_EVENTS_HITS_PER_PAGE = 4;
+
+/** Single featured "Journey" card (title match) moved to the front when present. */
+export function moveFeaturedJourneyCardFirst(
+  hits: ContentItemHit[],
+): ContentItemHit[] {
+  const i = hits.findIndex((h) =>
+    (h.title ?? '').toLowerCase().includes('journey'),
+  );
+  if (i < 1) {
+    return hits;
+  }
+  const copy = [...hits];
+  const [journey] = copy.splice(i, 1);
+  return [journey, ...copy];
+}

--- a/app/routes/navbar/__tests__/default-search-hits.test.ts
+++ b/app/routes/navbar/__tests__/default-search-hits.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const searchForHits = vi.fn();
+
+vi.mock('algoliasearch', () => ({
+  algoliasearch: vi.fn(() => ({ searchForHits })),
+}));
+
+import { fetchDefaultSearchHits } from '../default-search-hits.server';
+
+const INDEX = 'test_contentItems';
+
+function hit(title: string, contentType: string, url: string) {
+  return { objectID: `${contentType}-${title}`, title, contentType, url };
+}
+
+/** One Algolia response per request in the multi-query. */
+function respondWith(...hitGroups: unknown[][]) {
+  searchForHits.mockResolvedValue({
+    results: hitGroups.map((hits) => ({ hits })),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.ALGOLIA_APP_ID = 'test-app-id';
+  process.env.ALGOLIA_SEARCH_API_KEY = 'test-search-key';
+});
+
+describe('fetchDefaultSearchHits', () => {
+  // The order is the product requirement (CFDP-4197): a visitor opening search
+  // sees the newest thing to watch, then read, then listen, then what to attend.
+  it('orders latest message, article and podcast ahead of the featured events', async () => {
+    respondWith(
+      [hit('Latest Message', 'Sermon', 'latest-message')],
+      [hit('Latest Article', 'Article', 'latest-article')],
+      [hit('Latest Episode', 'Podcast', 'latest-episode')],
+      [
+        hit('Baptism', 'Event', 'baptism'),
+        hit('Night of Worship', 'Event', 'night-of-worship'),
+      ],
+    );
+
+    const hits = await fetchDefaultSearchHits(INDEX);
+
+    expect(hits.map((h) => h.title)).toEqual([
+      'Latest Message',
+      'Latest Article',
+      'Latest Episode',
+      'Baptism',
+      'Night of Worship',
+    ]);
+  });
+
+  // Journey is the church's entry-point class, so it leads the events regardless
+  // of where Algolia ranks it.
+  it('promotes the Journey event to the front of the featured events', async () => {
+    respondWith(
+      [hit('Latest Message', 'Sermon', 'latest-message')],
+      [],
+      [],
+      [
+        hit('Baptism', 'Event', 'baptism'),
+        hit('Journey Class', 'Event', 'journey'),
+        hit('Night of Worship', 'Event', 'night-of-worship'),
+      ],
+    );
+
+    const hits = await fetchDefaultSearchHits(INDEX);
+
+    expect(hits.map((h) => h.title)).toEqual([
+      'Latest Message',
+      'Journey Class',
+      'Baptism',
+      'Night of Worship',
+    ]);
+  });
+
+  // A hit with no usable path renders as a dead link in the popup.
+  it('drops hits that cannot resolve to a link', async () => {
+    respondWith(
+      [hit('Latest Message', 'Sermon', '  ')],
+      [hit('Latest Article', 'Article', 'latest-article')],
+      [],
+      [],
+    );
+
+    const hits = await fetchDefaultSearchHits(INDEX);
+
+    expect(hits.map((h) => h.title)).toEqual(['Latest Article']);
+  });
+
+  // The navbar renders on every page, so a search outage must not break it.
+  it('returns an empty list when Algolia fails', async () => {
+    searchForHits.mockRejectedValue(new Error('algolia down'));
+
+    await expect(fetchDefaultSearchHits(INDEX)).resolves.toEqual([]);
+  });
+
+  it('skips the request entirely without Algolia credentials', async () => {
+    delete process.env.ALGOLIA_APP_ID;
+
+    await expect(fetchDefaultSearchHits(INDEX)).resolves.toEqual([]);
+    expect(searchForHits).not.toHaveBeenCalled();
+  });
+});

--- a/app/routes/navbar/default-search-hits.server.ts
+++ b/app/routes/navbar/default-search-hits.server.ts
@@ -1,0 +1,72 @@
+/**
+ * Initial-open state for the desktop navbar site search (before a query is typed):
+ * latest message, latest article, latest podcast, then the featured events with
+ * "Journey" first.
+ *
+ * "Latest" comes from the contentItems index default ranking with a contentType
+ * filter — the same assumption the messages and events pages already make when
+ * they read the current series / featured cards.
+ */
+import { algoliasearch } from 'algoliasearch';
+
+import { resolveSearchHitLinkFromHit } from '~/components/navbar/search-hit-links';
+import {
+  FEATURED_EVENTS_FILTER,
+  FEATURED_EVENTS_HITS_PER_PAGE,
+  moveFeaturedJourneyCardFirst,
+} from '~/routes/events/featured-events';
+import type { ContentItemHit } from '~/routes/search/types';
+
+/** Content types listed above the featured events, in display order. */
+const LATEST_CONTENT_TYPES = ['Sermon', 'Article', 'Podcast'] as const;
+
+function hasResolvableLink(hit: ContentItemHit): boolean {
+  return resolveSearchHitLinkFromHit(hit).to.trim().length > 0;
+}
+
+export async function fetchDefaultSearchHits(
+  contentItemsIndexName: string,
+): Promise<ContentItemHit[]> {
+  const appId = process.env.ALGOLIA_APP_ID;
+  const searchApiKey = process.env.ALGOLIA_SEARCH_API_KEY;
+
+  if (!appId || !searchApiKey || !contentItemsIndexName) {
+    return [];
+  }
+
+  try {
+    const client = algoliasearch(appId, searchApiKey, {});
+
+    const { results } = await client.searchForHits<Record<string, unknown>>([
+      ...LATEST_CONTENT_TYPES.map((contentType) => ({
+        indexName: contentItemsIndexName,
+        params: {
+          filters: `contentType:"${contentType}"`,
+          hitsPerPage: 1,
+        },
+      })),
+      {
+        indexName: contentItemsIndexName,
+        params: {
+          filters: FEATURED_EVENTS_FILTER,
+          hitsPerPage: FEATURED_EVENTS_HITS_PER_PAGE,
+        },
+      },
+    ]);
+
+    const hitsAt = (index: number) =>
+      (results[index]?.hits ?? []).map((h) => h as unknown as ContentItemHit);
+
+    const latestHits = LATEST_CONTENT_TYPES.flatMap((_, index) =>
+      hitsAt(index),
+    );
+    const featuredEventHits = moveFeaturedJourneyCardFirst(
+      hitsAt(LATEST_CONTENT_TYPES.length),
+    );
+
+    return [...latestHits, ...featuredEventHits].filter(hasResolvableLink);
+  } catch (error) {
+    console.error('[navbar] default search hits fetch failed', error);
+    return [];
+  }
+}

--- a/app/routes/navbar/loader.tsx
+++ b/app/routes/navbar/loader.tsx
@@ -12,6 +12,8 @@ import type { AlgoliaIndexMap } from '~/lib/algolia-indexes';
 import { ContentChannelIds } from '~/lib/rock-config';
 import type { RockContentChannelItem } from '~/lib/types/rock-types';
 import { buildPodcastRoutingIndex } from '~/routes/podcasts/podcast-routing.server';
+import type { ContentItemHit } from '~/routes/search/types';
+import { fetchDefaultSearchHits } from './default-search-hits.server';
 
 // Define the return type for the loader
 export interface RootLoaderData {
@@ -29,6 +31,8 @@ export interface RootLoaderData {
   };
   /** Popular results (content users click most). From Algolia getTopHits when available; else empty and UI uses hardcoded fallback. */
   popularResults: { title: string; pathname: string }[];
+  /** Desktop site search's initial-open list, before a query is typed. */
+  defaultSearchHits: ContentItemHit[];
   siteBanner: {
     content: string;
     link?: string;
@@ -276,10 +280,12 @@ export async function loader({
       parsedUserData = userData as User;
     }
 
-    const [rawFeatureCards, rawSiteBanner] = await Promise.all([
-      fetchFeatureCards(),
-      fetchSiteBanner(),
-    ]);
+    const [rawFeatureCards, rawSiteBanner, defaultSearchHits] =
+      await Promise.all([
+        fetchFeatureCards(),
+        fetchSiteBanner(),
+        fetchDefaultSearchHits(algoliaIndexes.contentItems),
+      ]);
     const siteBanner = mapSiteBannerFromRockItem(rawSiteBanner);
 
     // If the API call failed, return empty arrays
@@ -305,6 +311,7 @@ export async function loader({
           indexes: algoliaIndexes,
         },
         popularResults: [],
+        defaultSearchHits,
         siteBanner,
       };
     }
@@ -381,6 +388,7 @@ export async function loader({
         indexes: algoliaIndexes,
       },
       popularResults: [],
+      defaultSearchHits,
       // Site Banner Data
       siteBanner: siteBanner,
     };
@@ -398,6 +406,7 @@ export async function loader({
         indexes: algoliaIndexes,
       },
       popularResults: [],
+      defaultSearchHits: [],
       siteBanner: EMPTY_SITE_BANNER,
     };
   }


### PR DESCRIPTION
## Summary
**CFDP-4197 — Desktop navbar search default state.** The desktop site search used to open onto whatever the `contentItems` index ranked highest for an empty query, which is effectively arbitrary. It now opens onto a curated list:

1. Latest message
2. Latest article
3. Latest podcast
4. Top 4 featured events, with **Journey** pinned first

The list is fetched server-side in the root navbar loader as a single Algolia multi-query (4 requests, one round trip),
so it's ready the moment the popup opens — no client fetch, no loading state, no flash. Typing a query or selecting a content-type filter swaps back to live results exactly as before; that gate mirrors Mobile's existing `isSearching` check.

**CFDP-4194 — Class interest card copy.** The "Can't Find a Class?" card on Class single pages now reads:

> **Looking for this class?**
> If this class isn't currently offered at your campus, let us know you're
> interested. We'll reach out when it's scheduled at your location.

The old copy ("Tell Us What You're Looking For" / "If enough people are
interested, we may offer this class in a future season...") framed the class as
hypothetical. The new copy reflects the actual case raised for *Before You Say I
Do* and *Freedom* — the class exists, it just isn't scheduled at the visitor's
campus yet. Text only; no logic, props, or types changed.

## Screenshots

N/A — see "Testing" below.

## Testing

**Navbar search (CFDP-4197)**

- [x] On desktop, click the navbar search icon without typing. The list should read: latest message, latest article, latest podcast, then up to 4 featured events with Journey first.
- [x] Each row links to the right place (`/messages/…`, `/articles/…`, `/podcasts/<show>/<episode>`, `/events/…`) and closes the popup on click.
- [x] Type a query — live Algolia results replace the list, with location results appearing as before. Clear it — the curated list comes back.
- [x] Select a content-type filter with an empty query — live refined results should show, not the curated list.
- [x] Confirm the Events page featured row is unchanged (Journey still first) — ts featured constants moved to a shared module in this PR.

**Class interest card (CFDP-4194)**

- [x] Open a Class single page whose Rock "I'm Interested" toggle is on and that has at least one scheduled session (e.g. Before You Say I Do, Freedom).
- [x] Scroll to "Join a Class" — the interest card at the end of the session carousel shows the new headline and body.
- [x] Apply a campus/format filter that returns no sessions — the same card renders full-width with the same new copy.
- [x] Click "Let Us Know" and confirm the interest modal still opens.
- [x] No new linter/type/test errors. `pnpm test` passes: **898 tests across 105 files**, including 5 new ones. `tsc --noEmit`, ESLint and Prettier all clean.

## Tickets

- https://christfellowshipchurch.atlassian.net/browse/CFDP-4197
- https://christfellowshipchurch.atlassian.net/browse/CFDP-4194

## Changes Made

### New Components Added

None — the existing `ContentHit` renders the curated search hits.

### New Utilities

- `app/routes/navbar/default-search-hits.server.ts` — `fetchDefaultSearchHits()`
  runs one Algolia multi-query (`contentType:"Sermon"`, `"Article"`, `"Podcast"`
  at `hitsPerPage: 1`, plus the featured-events query at 4), applies the Journey
  ordering, drops hits with no resolvable link, and returns `[]` on any failure.
- `app/routes/events/featured-events.ts` — extracted `FEATURED_EVENTS_FILTER`,
  `FEATURED_EVENTS_HITS_PER_PAGE` and `moveFeaturedJourneyCardFirst()` out of the
  all-events loader so both consumers share one definition of the rule.
- `app/routes/navbar/__tests__/default-search-hits.test.ts` — 5 tests covering
  display order, Journey promotion, dead-link filtering, the Algolia-failure
  path, and the no-credentials short circuit.

### New Assets

None.

### Dependencies

None.

### Route Implementation

- `app/routes/navbar/loader.tsx` — added `defaultSearchHits: ContentItemHit[]`
  to `RootLoaderData`, fetched inside the existing `Promise.all` and populated on
  all three return paths (the catch path returns `[]`).
- `app/routes/events/all-events/loader.tsx` — now imports the featured-events
  constants and helper from the shared module instead of defining them locally.
  No behavior change.
- `app/components/navbar/desktop/search/search-popup.component.tsx` — renders
  `defaultSearchHits` when there's no query and no content-type refinement;
  otherwise the live results, unchanged.
- `app/routes/class-finder/finder/components/cant-find-class-card.component.tsx`
  — replaced the card's headline and body copy.

### Key Features

- Desktop site search opens onto deliberate, current content instead of
  arbitrary index ranking.
- One extra Algolia round trip on the root loader, issued in parallel with the
  existing Rock fetches.
- Fails soft: the navbar renders on every page, so a search outage returns an
  empty list rather than breaking the nav.
- The "Journey first" rule now lives in one place, shared by the Events page and
  the navbar, instead of being duplicated.
- Class interest copy now speaks to campus availability rather than hypothetical
  future demand.