### PR TITLE
feat(group-finder): gate notify trigger on Rock ContentItem 21402 active dates

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -10,7 +10,7 @@
 name: 'Dependency review'
 on:
   pull_request:
-    branches: [ "main" ]
+    branches: ['main']
 
 # If using a dependency submission action in this workflow this permission will need to be set to:
 #

--- a/app/lib/rock-config.ts
+++ b/app/lib/rock-config.ts
@@ -4,6 +4,10 @@
  */
 export const ROCK_PUBLIC_SITE_ORIGIN = 'https://rock.christfellowship.church';
 
+export const ContentItemIds = {
+  groupsLaunchNotify: 21402,
+};
+
 export const ContentChannelIds = {
   articles: 43,
   default: 85,

--- a/app/routes/class-finder/finder/components/group-class-type-hits.ts
+++ b/app/routes/class-finder/finder/components/group-class-type-hits.ts
@@ -53,9 +53,9 @@ export function isCompleteClassFinderHit(
 
   return Boolean(
     pathName &&
-      (hit.classType || '').trim() &&
-      (hit.title || '').trim() &&
-      hasCover,
+    (hit.classType || '').trim() &&
+    (hit.title || '').trim() &&
+    hasCover,
   );
 }
 

--- a/app/routes/group-finder/loader.tsx
+++ b/app/routes/group-finder/loader.tsx
@@ -4,7 +4,9 @@ import { algoliasearch } from 'algoliasearch';
 
 import { AuthenticationError } from '~/lib/.server/error-types';
 import { getServerAlgoliaIndexes } from '~/lib/.server/algolia-indexes.server';
+import { fetchRockData } from '~/lib/.server/fetch-rock-data';
 import type { AlgoliaIndexMap } from '~/lib/algolia-indexes';
+import { ContentItemIds } from '~/lib/rock-config';
 
 import { buildGroupFinderAlgoliaSearchParams } from './components/build-group-finder-algolia-search';
 import { parseGroupFinderUrlState } from './group-finder-url-state';
@@ -21,6 +23,8 @@ export type LoaderReturnType = {
   minMaxAgeValues: string[];
   /** Campus name -> campus city, for group cards whose groups have no meeting location. */
   campusCityByName: Record<string, string>;
+  /** True when Rock ContentChannelItem 21402 is within its active date window and approved. */
+  showGroupsLaunchNotify: boolean;
 };
 
 type CampusCityHit = {
@@ -47,6 +51,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   let groupNbPages = 0;
   let minMaxAgeValues: string[] = [];
   const campusCityByName: Record<string, string> = {};
+  let showGroupsLaunchNotify = false;
   const url = new URL(request.url);
 
   // The loader owns first paint and deep links. Once hydrated, same-page filter
@@ -111,6 +116,20 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
     console.error('[group-finder] Algolia loader fetch failed', error);
   }
 
+  try {
+    const notifyItem = await fetchRockData({
+      endpoint: 'ContentChannelItems',
+      queryParams: {
+        $filter: `Id eq ${ContentItemIds.groupsLaunchNotify}`,
+      },
+      filterByDateRange: true,
+      filterByStatusApproved: true,
+    });
+    showGroupsLaunchNotify = Boolean(notifyItem && !Array.isArray(notifyItem));
+  } catch (error) {
+    console.error('[group-finder] groups launch notify fetch failed', error);
+  }
+
   return Response.json({
     // Expose only the search key needed by Algolia's browser client; interactive
     // filtering then continues client-side without re-running this loader.
@@ -123,5 +142,6 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
     groupPage,
     minMaxAgeValues,
     campusCityByName,
+    showGroupsLaunchNotify,
   } satisfies LoaderReturnType);
 };

--- a/app/routes/group-finder/partials/group-search.partial.tsx
+++ b/app/routes/group-finder/partials/group-search.partial.tsx
@@ -126,6 +126,7 @@ export const GroupSearch = () => {
     minMaxAgeValues,
     algoliaIndexes,
     campusCityByName,
+    showGroupsLaunchNotify,
   } = loaderData;
   const groupIndexName = algoliaIndexes.groups;
   const [searchParams, setSearchParams] = useSearchParams();
@@ -469,6 +470,7 @@ export const GroupSearch = () => {
               isGeoSearch={coordinates?.lat != null && coordinates?.lng != null}
               isVirtualFilterActive={isVirtualFilterActive}
               campusCityByName={campusCityByName}
+              showGroupsLaunchNotify={showGroupsLaunchNotify}
             />
           </InstantSearch>
         ) : (
@@ -502,6 +504,7 @@ export const GroupSearch = () => {
               isGeoSearch={coordinates?.lat != null && coordinates?.lng != null}
               isVirtualFilterActive={isVirtualFilterActive}
               campusCityByName={campusCityByName}
+              showGroupsLaunchNotify={showGroupsLaunchNotify}
             />
           </>
         )}
@@ -517,6 +520,7 @@ function GroupFinderInstantSearchResults({
   isGeoSearch,
   isVirtualFilterActive,
   campusCityByName,
+  showGroupsLaunchNotify,
 }: {
   initialHits: LoaderReturnType['groupHits'];
   initialNbHits: number;
@@ -524,6 +528,7 @@ function GroupFinderInstantSearchResults({
   isGeoSearch: boolean;
   isVirtualFilterActive: boolean;
   campusCityByName: LoaderReturnType['campusCityByName'];
+  showGroupsLaunchNotify: boolean;
 }) {
   const { items } = useHits<LoaderReturnType['groupHits'][number]>();
   const { nbHits } = useStats();
@@ -573,6 +578,7 @@ function GroupFinderInstantSearchResults({
       isGeoSearch={isGeoSearch}
       isVirtualFilterActive={isVirtualFilterActive}
       campusCityByName={campusCityByName}
+      showGroupsLaunchNotify={showGroupsLaunchNotify}
     />
   );
 }
@@ -589,6 +595,7 @@ function GroupFinderInitialResults({
   isGeoSearch,
   isVirtualFilterActive,
   campusCityByName,
+  showGroupsLaunchNotify,
 }: {
   groupHits: LoaderReturnType['groupHits'];
   groupNbHits: number;
@@ -601,6 +608,7 @@ function GroupFinderInitialResults({
   isGeoSearch: boolean;
   isVirtualFilterActive: boolean;
   campusCityByName: LoaderReturnType['campusCityByName'];
+  showGroupsLaunchNotify: boolean;
 }) {
   return (
     <GroupFinderResultsLayout
@@ -616,6 +624,7 @@ function GroupFinderInitialResults({
       isGeoSearch={isGeoSearch}
       isVirtualFilterActive={isVirtualFilterActive}
       campusCityByName={campusCityByName}
+      showGroupsLaunchNotify={showGroupsLaunchNotify}
     />
   );
 }
@@ -633,6 +642,7 @@ function GroupFinderResultsLayout({
   isGeoSearch,
   isVirtualFilterActive,
   campusCityByName,
+  showGroupsLaunchNotify,
 }: {
   groupHits: LoaderReturnType['groupHits'];
   groupNbHits: number;
@@ -646,11 +656,15 @@ function GroupFinderResultsLayout({
   isGeoSearch: boolean;
   isVirtualFilterActive: boolean;
   campusCityByName: LoaderReturnType['campusCityByName'];
+  showGroupsLaunchNotify: boolean;
 }) {
   return (
     <div className='flex flex-col bg-gray pt-4 pb-8 md:pt-12 md:pb-20 w-full content-padding'>
       <div className='max-w-screen-content mx-auto md:w-full'>
-        <GroupFinderResultsHeader hitCount={groupNbHits} />
+        <GroupFinderResultsHeader
+          hitCount={groupNbHits}
+          showGroupsLaunchNotify={showGroupsLaunchNotify}
+        />
         <div className='min-h-[320px]'>
           {groupHits.length === 0 && !isLoading ? (
             <p className='text-text-secondary text-center py-8'>
@@ -708,25 +722,40 @@ function GroupFinderResultsLayout({
   );
 }
 
-function GroupFinderResultsHeader({ hitCount }: { hitCount: number }) {
+function GroupFinderResultsHeader({
+  hitCount,
+  showGroupsLaunchNotify,
+}: {
+  hitCount: number;
+  showGroupsLaunchNotify: boolean;
+}) {
   const formattedHitCount = hitCount.toLocaleString();
 
   return (
-    <div className='mb-4 md:mb-6'>
+    <div className='mb-4 md:mb-6 max-w-[1296px] lg:mr-auto'>
       <div className='hidden md:flex md:items-center md:justify-between md:gap-6'>
         <FinderResultsStats hitCount={hitCount} />
-        <div className='flex items-center gap-6 text-base text-text-primary'>
-          <p>More groups available at our next launch.</p>
-          <GroupFinderNotifyTrigger variant='desktop' />
-        </div>
+        {showGroupsLaunchNotify && (
+          <div className='flex items-center gap-6 text-base text-text-primary'>
+            <p>More groups available at our next launch.</p>
+            <GroupFinderNotifyTrigger variant='desktop' />
+          </div>
+        )}
       </div>
-
       <div className='flex flex-col items-start gap-1 md:hidden'>
-        <p className='text-sm leading-5 text-text-primary'>
-          {formattedHitCount} Results - More available at our next groups
-          launch.
-        </p>
-        <GroupFinderNotifyTrigger variant='mobile' />
+        {showGroupsLaunchNotify ? (
+          <>
+            <p className='text-sm leading-5 text-text-primary'>
+              {formattedHitCount} Results - More available at our next groups
+              launch.
+            </p>
+            <GroupFinderNotifyTrigger variant='mobile' />
+          </>
+        ) : (
+          <p className='text-sm leading-5 text-text-primary'>
+            {formattedHitCount} Results
+          </p>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Gate the \"Get Notified\" CTA and associated next-launch copy in the Group Finder behind Rock ContentChannelItem 21402 being within its active date window (\`StartDateTime\` / \`ExpireDateTime\`) and approved. The content team can control the campaign window directly in Rock without a code deploy — the trigger and promo text only appear when item 21402 is scheduled active.

## Screenshots

[Paste your screenshots here]

## Testing

- [ ] Set ContentChannelItem 21402 in Rock to an active date range (StartDateTime in the past, ExpireDateTime in the future, Status = Approved) → visit \`/group-finder\` and confirm the \"More groups available at our next launch.\" copy and \"Get Notified\" button are visible on both desktop and mobile
- [ ] Set the item outside its date range (e.g. ExpireDateTime in the past, or StartDateTime in the future) → confirm the promo copy and trigger are hidden; desktop shows only the results stats, mobile shows \`{N} Results\` with no launch suffix or button
- [ ] Set the item to Unapproved or delete it entirely → same hidden result as above; group results still load normally
- [x] Was any new linter/type/test errors/warnings (run \`pnpm check\` for linter/type/prettier check and \`pnpm test\` for running tests)? ✅ \`pnpm check\` passes clean

## Tickets

[insert Jira ticket reference here]

## Changes Made

### New Components Added

- None

### New Utilities

- None

### New Assets

- None

### Dependencies

- None

### Route Implementation

- \`app/lib/rock-config.ts\` — Added \`ContentItemIds\` export with \`groupsLaunchNotify: 21402\`
- \`app/routes/group-finder/loader.tsx\` — Added \`showGroupsLaunchNotify: boolean\` to \`LoaderReturnType\`; fetches ContentChannelItem 21402 with \`filterByDateRange: true\` and \`filterByStatusApproved: true\` after the Algolia block; fails closed (\`false\`) if Rock is unavailable
- \`app/routes/group-finder/partials/group-search.partial.tsx\` — Threads \`showGroupsLaunchNotify\` from \`useLoaderData\` through \`GroupFinderInstantSearchResults\` → \`GroupFinderInitialResults\` → \`GroupFinderResultsLayout\` → \`GroupFinderResultsHeader\`; gates both the desktop launch sentence + trigger and the mobile launch suffix + trigger behind the flag

### Key Features

- Content-team-controlled campaign window: the notify CTA activates and deactivates purely via Rock's Start/Expire dates on item 21402 — no code changes needed to turn it on or off
- Fail-safe: Rock errors or a missing/inactive item always result in the CTA being hidden, so group results are never broken by a Rock outage
- No client-side Rock call; the flag is resolved at SSR time in the loader and is stable for the page session

Made with [Cursor](https://cursor.com)