### PR TITLE
Add all opportunities finder

### DIFF
--- a/app/routes/volunteer/community-opportunities/community-opportunities-page.tsx
+++ b/app/routes/volunteer/community-opportunities/community-opportunities-page.tsx
@@ -1,0 +1,64 @@
+import { useState } from 'react';
+import { Link, useLoaderData } from 'react-router-dom';
+
+import { SectionTitle } from '~/components/section-title';
+import { cn } from '~/lib/utils';
+import Icon from '~/primitives/icon';
+
+import { VolunteerAlgolia } from '../components/volunteer-algolia.component';
+import { VolunteerAlgoliaSkeleton } from '../components/volunteer-algolia-skeleton.component';
+import type { CommunityOpportunitiesLoaderData } from './loader';
+
+export function CommunityOpportunitiesPage() {
+  const { ALGOLIA_APP_ID, ALGOLIA_SEARCH_API_KEY, algoliaIndexes } =
+    useLoaderData<CommunityOpportunitiesLoaderData>();
+  const [volunteerUiReady, setVolunteerUiReady] = useState(false);
+
+  return (
+    <main className='bg-white'>
+      <header className='border-b border-neutral-lighter content-padding'>
+        <div className='mx-auto flex w-full max-w-screen-content items-center py-4'>
+          <Link
+            to='/volunteer#community'
+            prefetch='intent'
+            className='inline-flex items-center gap-2 text-sm font-bold text-neutral-darker transition-colors hover:text-ocean'
+          >
+            <Icon name='chevronLeft' size={16} className='shrink-0' />
+            Back to Volunteer
+          </Link>
+        </div>
+      </header>
+
+      <div className='pb-10 pt-12 content-padding md:pb-10 md:pt-16'>
+        <div className='mx-auto flex w-full max-w-screen-content flex-col gap-4'>
+          <SectionTitle sectionTitle='Needs in our region' />
+          <h1 className='text-[40px] font-extrabold capitalize leading-tight text-text-primary md:text-[52px]'>
+            Volunteer in our Community
+          </h1>
+        </div>
+      </div>
+
+      <div
+        className='relative bg-white'
+        aria-busy={volunteerUiReady ? undefined : true}
+      >
+        <div
+          className={cn(
+            !volunteerUiReady && 'pointer-events-none select-none opacity-0',
+          )}
+        >
+          <VolunteerAlgolia
+            appId={ALGOLIA_APP_ID}
+            apiKey={ALGOLIA_SEARCH_API_KEY}
+            indexName={algoliaIndexes.missions}
+            resultsLayout='grid'
+            onVolunteerUiReady={() => setVolunteerUiReady(true)}
+          />
+        </div>
+        {!volunteerUiReady ? (
+          <VolunteerAlgoliaSkeleton resultsLayout='grid' />
+        ) : null}
+      </div>
+    </main>
+  );
+}

--- a/app/routes/volunteer/community-opportunities/loader.ts
+++ b/app/routes/volunteer/community-opportunities/loader.ts
@@ -1,0 +1,16 @@
+import { getServerAlgoliaIndexes } from '~/lib/.server/algolia-indexes.server';
+import type { AlgoliaIndexMap } from '~/lib/algolia-indexes';
+
+export type CommunityOpportunitiesLoaderData = {
+  ALGOLIA_APP_ID: string;
+  ALGOLIA_SEARCH_API_KEY: string;
+  algoliaIndexes: AlgoliaIndexMap;
+};
+
+export async function loader() {
+  return Response.json({
+    ALGOLIA_APP_ID: process.env.ALGOLIA_APP_ID ?? '',
+    ALGOLIA_SEARCH_API_KEY: process.env.ALGOLIA_SEARCH_API_KEY ?? '',
+    algoliaIndexes: getServerAlgoliaIndexes(),
+  } satisfies CommunityOpportunitiesLoaderData);
+}

--- a/app/routes/volunteer/community-opportunities/meta.ts
+++ b/app/routes/volunteer/community-opportunities/meta.ts
@@ -1,0 +1,11 @@
+import type { MetaFunction } from 'react-router-dom';
+
+import { createMeta } from '~/lib/meta-utils';
+
+export const meta: MetaFunction = () =>
+  createMeta({
+    title: 'Volunteer In Our Community | Christ Fellowship Church',
+    description:
+      'Browse all community volunteer opportunities at Christ Fellowship Church.',
+    path: '/volunteer/community-opportunities',
+  });

--- a/app/routes/volunteer/components/__tests__/volunteer-algolia.component.test.tsx
+++ b/app/routes/volunteer/components/__tests__/volunteer-algolia.component.test.tsx
@@ -8,14 +8,22 @@ import type { Volunteer } from '../../types';
 
 const mocks = vi.hoisted(() => ({
   hits: [] as Volunteer[],
+  indexUiState: {} as {
+    query?: string;
+    refinementList?: Record<string, string[]>;
+  },
 }));
 
 vi.mock('react-instantsearch', () => ({
   Configure: () => null,
   InstantSearch: ({ children }: { children: ReactNode }) => <>{children}</>,
   useHits: () => ({ items: mocks.hits }),
-  useInstantSearch: () => ({ status: 'idle' }),
+  useInstantSearch: () => ({
+    status: 'idle',
+    indexUiState: mocks.indexUiState,
+  }),
   useRefinementList: () => ({ items: [], refine: vi.fn() }),
+  useStats: () => ({ nbHits: mocks.hits.length }),
 }));
 
 vi.mock('~/lib/create-search-client', () => ({
@@ -40,6 +48,16 @@ vi.mock('~/components/hubs-tags-refinement', () => ({
 
 vi.mock('~/routes/group-finder/components/clear-all-button.component', () => ({
   AlgoliaFinderClearAllButton: () => null,
+}));
+
+vi.mock('~/primitives/shadcn-primitives/carousel', () => ({
+  Carousel: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  CarouselContent: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  CarouselItem: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  CarouselArrows: () => null,
+  CarouselDots: () => null,
 }));
 
 const volunteer: Volunteer = {
@@ -67,6 +85,7 @@ const volunteer: Volunteer = {
 describe('VolunteerAlgolia', () => {
   it('renders private mission results as list rows when requested', () => {
     mocks.hits = [volunteer];
+    mocks.indexUiState = {};
 
     render(
       <MemoryRouter
@@ -84,5 +103,33 @@ describe('VolunteerAlgolia', () => {
     const link = screen.getByRole('link', { name: /Serve Our Neighbors/ });
     expect(link).toHaveAttribute('href', '/volunteer/outreach/mission-guid-1');
     expect(link.closest('li')).toBeInTheDocument();
+  });
+
+  it('preserves active InstantSearch filters on the View All opportunities CTA', () => {
+    mocks.hits = [volunteer];
+    mocks.indexUiState = {
+      refinementList: {
+        category: ['Support Teams'],
+        campusList: ['Boynton Beach'],
+      },
+    };
+
+    render(
+      <MemoryRouter initialEntries={['/volunteer']}>
+        <VolunteerAlgolia
+          appId='test-app-id'
+          apiKey='test-api-key'
+          indexName='dev_webv3_missions'
+        />
+      </MemoryRouter>,
+    );
+
+    const viewAllLink = screen.getByRole('link', {
+      name: /View all opportunities/i,
+    });
+    expect(viewAllLink).toHaveAttribute(
+      'href',
+      '/volunteer/community-opportunities?category=Support+Teams&campusList=Boynton+Beach',
+    );
   });
 });

--- a/app/routes/volunteer/components/finder/__tests__/volunteer-algolia-instantsearch-router.test.ts
+++ b/app/routes/volunteer/components/finder/__tests__/volunteer-algolia-instantsearch-router.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createVolunteerAlgoliaInstantSearchRouter } from '../volunteer-algolia-instantsearch-router';
+
+function createRefs(pathname: string, search: string) {
+  const searchParamsRef = {
+    current: new URLSearchParams(search),
+  };
+  const setSearchParams = vi.fn((params: URLSearchParams) => {
+    searchParamsRef.current = params;
+  });
+  const setSearchParamsRef = { current: setSearchParams };
+  const pathnameRef = { current: pathname };
+  const onUpdateCallbackRef = { current: null };
+
+  return {
+    searchParamsRef,
+    setSearchParamsRef,
+    pathnameRef,
+    onUpdateCallbackRef,
+    setSearchParams,
+  };
+}
+
+describe('createVolunteerAlgoliaInstantSearchRouter', () => {
+  it('skips the first write that would clear landing filter params', () => {
+    const refs = createRefs(
+      '/volunteer/community-opportunities',
+      'category=Support+Teams&campusList=Boynton+Beach',
+    );
+    window.history.pushState(
+      {},
+      '',
+      '/volunteer/community-opportunities?category=Support+Teams&campusList=Boynton+Beach',
+    );
+
+    const router = createVolunteerAlgoliaInstantSearchRouter(refs);
+
+    router.write({});
+    expect(refs.setSearchParams).not.toHaveBeenCalled();
+    expect(refs.searchParamsRef.current.toString()).toBe(
+      'category=Support+Teams&campusList=Boynton+Beach',
+    );
+
+    router.write({
+      refinementList: { category: ['Outreach'] },
+    });
+    expect(refs.setSearchParams).toHaveBeenCalledTimes(1);
+    expect(refs.setSearchParams.mock.calls[0]?.[0].toString()).toBe(
+      'category=Outreach',
+    );
+  });
+
+  it('ignores writes after navigating away from the router pathname', () => {
+    const refs = createRefs('/volunteer', 'category=Outreach');
+    window.history.pushState(
+      {},
+      '',
+      '/volunteer/community-opportunities?category=Outreach',
+    );
+
+    const router = createVolunteerAlgoliaInstantSearchRouter(refs);
+    // Consume the initial-write skip with a no-op equal write first.
+    router.write({
+      refinementList: { category: ['Outreach'] },
+    });
+    expect(refs.setSearchParams).not.toHaveBeenCalled();
+
+    router.write({});
+    expect(refs.setSearchParams).not.toHaveBeenCalled();
+  });
+
+  it('ignores writes after dispose', () => {
+    const refs = createRefs('/volunteer', '');
+    window.history.pushState({}, '', '/volunteer');
+
+    const router = createVolunteerAlgoliaInstantSearchRouter(refs);
+    router.write({});
+    router.dispose();
+    router.write({
+      refinementList: { category: ['Outreach'] },
+    });
+
+    expect(refs.setSearchParams).not.toHaveBeenCalled();
+  });
+});

--- a/app/routes/volunteer/components/finder/volunteer-algolia-instantsearch-router.ts
+++ b/app/routes/volunteer/components/finder/volunteer-algolia-instantsearch-router.ts
@@ -31,6 +31,17 @@ export function createVolunteerAlgoliaInstantSearchRouter(
     onUpdateCallbackRef,
   } = refs;
 
+  /**
+   * InstantSearch often emits an empty uiState once before widgets hydrate from
+   * `router.read()`. Writing that clears landing URL params; our searchParams →
+   * onUpdate effect then wipes InstantSearch. Skip that first divergent write.
+   *
+   * Also ignore writes after dispose / after navigating away — the previous
+   * page's InstantSearch can call `setSearchParams({})` against the new route.
+   */
+  let hasCompletedInitialWrite = false;
+  let isDisposed = false;
+
   return {
     createURL(routeState: VolunteerAlgoliaUrlState): string {
       const params = volunteerAlgoliaUrlStateToParams(routeState);
@@ -42,7 +53,28 @@ export function createVolunteerAlgoliaInstantSearchRouter(
       return parseVolunteerAlgoliaUrlState(searchParamsRef.current);
     },
     write(routeState: VolunteerAlgoliaUrlState): void {
-      setSearchParamsRef.current(volunteerAlgoliaUrlStateToParams(routeState), {
+      if (isDisposed) return;
+
+      if (
+        typeof window !== 'undefined' &&
+        window.location.pathname !== pathnameRef.current
+      ) {
+        return;
+      }
+
+      const params = volunteerAlgoliaUrlStateToParams(routeState);
+      const current = searchParamsRef.current?.toString() ?? '';
+      if (params.toString() === current) {
+        hasCompletedInitialWrite = true;
+        return;
+      }
+
+      if (!hasCompletedInitialWrite) {
+        hasCompletedInitialWrite = true;
+        return;
+      }
+
+      setSearchParamsRef.current(params, {
         replace: true,
         preventScrollReset: true,
       });
@@ -51,6 +83,7 @@ export function createVolunteerAlgoliaInstantSearchRouter(
       onUpdateCallbackRef.current = callback;
     },
     dispose(): void {
+      isDisposed = true;
       onUpdateCallbackRef.current = null;
     },
   };

--- a/app/routes/volunteer/components/volunteer-algolia-skeleton.component.tsx
+++ b/app/routes/volunteer/components/volunteer-algolia-skeleton.component.tsx
@@ -9,24 +9,39 @@ export function VolunteerAlgoliaSkeleton({
   resultsLayout = 'carousel',
 }: {
   className?: string;
-  resultsLayout?: 'carousel' | 'list';
+  resultsLayout?: 'carousel' | 'list' | 'grid';
 }) {
   return (
     <div className={cn('animate-pulse', className)} aria-hidden>
       <div className='content-padding'>
-        <div className='max-w-[1280px] mx-auto flex flex-col gap-4 md:flex-row md:flex-wrap md:items-center md:justify-between'>
-          <div className='flex min-w-0 flex-1 flex-wrap items-center gap-2'>
-            <div className='h-11 w-36 rounded-full bg-neutral-light' />
-            <div className='h-11 w-28 rounded-full bg-neutral-light' />
-            <div className='h-11 w-28 rounded-full bg-neutral-light' />
-            <div className='h-11 w-32 rounded-full bg-neutral-light' />
+        {resultsLayout === 'grid' ? (
+          <div className='mx-auto hidden max-w-screen-content items-center gap-4 pb-6 md:flex md:pb-8'>
+            <div className='h-11 w-48 shrink-0 rounded-xl bg-neutral-light' />
+            <div className='flex min-w-0 flex-1 flex-wrap items-center gap-2'>
+              <div className='h-10 w-28 rounded-full bg-neutral-light' />
+              <div className='h-10 w-32 rounded-full bg-neutral-light' />
+              <div className='h-10 w-36 rounded-full bg-neutral-light' />
+              <div className='h-10 w-40 rounded-full bg-neutral-light' />
+            </div>
+            <div className='h-5 w-16 shrink-0 rounded bg-neutral-light' />
           </div>
-          <div className='h-12 w-full rounded-lg bg-neutral-light md:w-80' />
-        </div>
+        ) : (
+          <div className='max-w-screen-content mx-auto hidden flex-col gap-4 md:flex md:flex-row md:flex-wrap md:items-center md:justify-between'>
+            <div className='flex min-w-0 flex-1 flex-wrap items-center gap-2'>
+              <div className='h-11 w-36 rounded-full bg-neutral-light' />
+              <div className='h-11 w-28 rounded-full bg-neutral-light' />
+              <div className='h-11 w-28 rounded-full bg-neutral-light' />
+              <div className='h-11 w-32 rounded-full bg-neutral-light' />
+            </div>
+            <div className='h-12 w-full rounded-lg bg-neutral-light md:w-80' />
+          </div>
+        )}
       </div>
 
       {resultsLayout === 'list' ? (
         <VolunteerListSkeleton />
+      ) : resultsLayout === 'grid' ? (
+        <VolunteerGridSkeleton />
       ) : (
         <VolunteerCarouselSkeleton />
       )}
@@ -38,7 +53,7 @@ function VolunteerCarouselSkeleton() {
   return (
     <>
       <div className='pl-5 md:pl-12 lg:pl-18 2xl:pl-0!'>
-        <div className='mt-8 flex py-2 items-stretch gap-6 overflow-hidden max-w-[1280px] mx-auto'>
+        <div className='mt-8 flex py-2 items-stretch gap-6 overflow-hidden max-w-screen-content mx-auto'>
           {[0, 1, 2].map((i) => (
             <div
               key={i}
@@ -66,25 +81,48 @@ function VolunteerCarouselSkeleton() {
         </div>
       </div>
       <div className='pl-5 md:pl-12 lg:pl-18 2xl:pl-0!'>
-        <div className='max-w-[1280px] mx-auto relative mt-8 min-h-[4.5rem] pb-14 sm:pb-16 md:pb-8'>
-          <div className='absolute left-4 top-1 flex gap-2 md:left-0 md:top-7'>
-            {[0, 1, 2, 3, 4].map((i) => (
-              <div
-                key={i}
-                className='size-2.5 rounded-full bg-neutral-light md:size-3'
-              />
-            ))}
+        <div className='mx-auto mt-4 flex max-w-screen-content items-center justify-between gap-4 pr-5 md:mt-8 md:pr-0'>
+          <div className='flex gap-2'>
+            <div className='size-12 rounded-full border border-neutral-light' />
+            <div className='size-12 rounded-full border border-neutral-light' />
           </div>
+          <div className='h-11 w-28 rounded-full border border-neutral-light md:w-52' />
         </div>
       </div>
     </>
   );
 }
 
+function VolunteerGridSkeleton() {
+  return (
+    <div className='border-t border-neutral-lighter bg-gray content-padding py-6'>
+      <div className='mx-auto grid max-w-screen-content grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 lg:gap-8'>
+        {[0, 1, 2, 3, 4, 5].map((i) => (
+          <div
+            key={i}
+            className='flex min-h-0 flex-col overflow-hidden rounded-[36px] bg-white shadow-sm'
+          >
+            <div className='aspect-16/10 w-full max-h-[156px] shrink-0 bg-neutral-light' />
+            <div className='flex flex-1 flex-col gap-3 p-5'>
+              <div className='h-6 w-4/5 rounded-md bg-neutral-light' />
+              <div className='flex gap-2'>
+                <div className='h-7 w-24 rounded-full bg-neutral-light' />
+                <div className='h-7 w-28 rounded-md bg-neutral-light' />
+              </div>
+              <div className='h-4 w-3/5 rounded bg-neutral-light' />
+              <div className='h-4 w-2/5 rounded bg-neutral-light' />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 function VolunteerListSkeleton() {
   return (
     <div className='content-padding py-6'>
-      <div className='mx-auto flex max-w-[1280px] flex-col gap-4'>
+      <div className='mx-auto flex max-w-screen-content flex-col gap-4'>
         {[0, 1, 2].map((i) => (
           <div
             key={i}

--- a/app/routes/volunteer/components/volunteer-algolia.component.tsx
+++ b/app/routes/volunteer/components/volunteer-algolia.component.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useLocation, useSearchParams } from 'react-router-dom';
 import {
   Configure,
@@ -6,6 +6,7 @@ import {
   useHits,
   useInstantSearch,
   useRefinementList,
+  useStats,
 } from 'react-instantsearch';
 
 import { FinderStickyBar } from '~/components/finders/finder-sticky-bar.component';
@@ -15,12 +16,12 @@ import { HubsTagsRefinementList } from '~/components/hubs-tags-refinement';
 import { cn } from '~/lib/utils';
 import { createSearchClient } from '~/lib/create-search-client';
 import { AlgoliaFinderClearAllButton } from '~/routes/group-finder/components/clear-all-button.component';
+import { Button } from '~/primitives/button/button.primitive';
 import { Icon } from '~/primitives/icon/icon';
 import {
   Carousel,
   CarouselArrows,
   CarouselContent,
-  CarouselDots,
   CarouselItem,
 } from '~/primitives/shadcn-primitives/carousel';
 
@@ -56,6 +57,15 @@ const volunteerCategorySelected = cn(
 
 const volunteerCategoryRemove = cn(
   'shrink-0 cursor-pointer rounded-full p-0.5 text-ocean transition-colors hover:bg-ocean/25 focus:outline-none focus-visible:ring-2 focus-visible:ring-ocean focus-visible:ring-offset-1',
+);
+
+/** Community opportunities page — matches Figma search-row pills. */
+const volunteerGridCategoryUnselected = cn(
+  'inline-flex max-w-full shrink-0 cursor-pointer items-center justify-center rounded-full bg-gray px-3 py-2.5 text-sm font-semibold text-text-primary transition-colors hover:bg-neutral-200',
+);
+
+const volunteerGridCategorySelected = cn(
+  'inline-flex max-w-full shrink-0 cursor-default items-center gap-1.5 rounded-full bg-ocean/10 px-3 py-2.5 text-sm font-semibold text-ocean transition-colors hover:bg-ocean/10',
 );
 
 const VOLUNTEER_SLIDE_CLASS =
@@ -98,7 +108,7 @@ function VolunteerHitsCarousel() {
           slidesToScroll: 1,
           containScroll: 'trimSnaps',
         }}
-        className='mx-auto mt-3 w-full max-w-[1280px]'
+        className='mx-auto mt-3 w-full max-w-screen-content'
       >
         <CarouselContent className='items-stretch gap-8 py-6'>
           {hits.map((hit, index) => (
@@ -116,17 +126,76 @@ function VolunteerHitsCarousel() {
           ))}
         </CarouselContent>
 
-        <div className='relative mt-4 flex min-h-[4.5rem] items-center justify-between pb-14 pr-5 sm:pb-16 md:mt-8 md:min-h-0 md:pb-8 md:pr-0'>
-          <div className='hidden md:block'>
-            <CarouselDots
-              activeClassName='bg-ocean'
-              inactiveClassName='bg-neutral-lighter'
-            />
+        <div className='mt-4 flex items-center justify-between gap-4 pr-5 md:mt-8 md:pr-0'>
+          <div className='flex min-w-0 items-center'>
+            <CarouselArrows arrowStyles='text-ocean border-ocean hover:text-navy hover:border-navy' />
           </div>
 
-          <CarouselArrows arrowStyles='text-ocean border-ocean hover:text-navy hover:border-navy' />
+          <Button
+            intent='secondary'
+            href={`/volunteer/community-opportunities${location.search}`}
+            size='md'
+            className='shrink-0 rounded-full px-6 text-base md:px-8'
+          >
+            <span className='md:hidden'>View All</span>
+            <span className='hidden md:inline'>View all opportunities</span>
+          </Button>
         </div>
       </Carousel>
+    </div>
+  );
+}
+
+const VOLUNTEER_GRID_PAGE_SIZE = 9;
+
+function VolunteerHitsGrid({ onShowMore }: { onShowMore: () => void }) {
+  const { items: hits } = useHits<Volunteer>();
+  const { nbHits } = useStats();
+  const location = useLocation();
+
+  if (hits.length === 0) {
+    return (
+      <div className='border-t border-neutral-lighter bg-gray content-padding py-8'>
+        <p className='text-neutral-default text-center text-lg 2xl:px-0'>
+          No volunteer opportunities match your filters right now. Try clearing
+          a filter or check back soon.
+        </p>
+      </div>
+    );
+  }
+
+  const canShowMore = hits.length < nbHits;
+
+  return (
+    <div className='border-t border-neutral-lighter bg-gray content-padding py-6'>
+      <ul className='mx-auto grid w-full max-w-screen-content grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 lg:gap-8'>
+        {hits.map((hit) => (
+          <li key={hit.objectID} className='min-w-0'>
+            <VolunteerCard
+              volunteer={hit}
+              listingSearch={location.search}
+              finderOrigin='community-opportunities'
+              className='h-full w-full min-w-0'
+            />
+          </li>
+        ))}
+      </ul>
+
+      <div className='mx-auto mt-10 flex max-w-screen-content flex-col items-center gap-3'>
+        {canShowMore ? (
+          <Button
+            intent='secondary'
+            size='md'
+            className='rounded-full px-8 text-base'
+            onClick={onShowMore}
+          >
+            Show more opportunities
+          </Button>
+        ) : null}
+        <p className='text-sm text-neutral-default'>
+          {`Showing ${hits.length} of ${nbHits} opportunities`}
+        </p>
+      </div>
     </div>
   );
 }
@@ -146,7 +215,7 @@ function VolunteerHitsList() {
 
   return (
     <div className='content-padding py-6'>
-      <ul className='mx-auto flex w-full max-w-[1280px] flex-col gap-4'>
+      <ul className='mx-auto flex w-full max-w-screen-content flex-col gap-4'>
         {hits.map((hit) => (
           <VolunteerListCard
             key={hit.objectID}
@@ -159,7 +228,11 @@ function VolunteerHitsList() {
   );
 }
 
-function CampusFilterSelect() {
+function CampusFilterSelect({
+  variant = 'default',
+}: {
+  variant?: 'default' | 'grid';
+}) {
   const { items, refine } = useRefinementList({
     attribute: FACET_CAMPUS,
     limit: 50,
@@ -167,24 +240,40 @@ function CampusFilterSelect() {
 
   const value = items.find((i) => i.isRefined)?.value ?? '';
   const hasCampusSelected = Boolean(value);
+  const isGrid = variant === 'grid';
 
   return (
     <div className='relative w-fit shrink-0'>
       <Icon
         name='map'
         className={cn(
-          'pointer-events-none absolute left-3 top-1/2 z-1 -translate-y-1/2 bottom-[8px] transition-colors',
-          hasCampusSelected ? 'text-ocean' : 'text-neutral-default',
+          'pointer-events-none absolute top-1/2 z-1 -translate-y-1/2 transition-colors',
+          isGrid ? 'left-4' : 'left-3 bottom-2',
+          hasCampusSelected
+            ? 'text-ocean'
+            : isGrid
+              ? 'text-text-primary'
+              : 'text-neutral-default',
         )}
-        size={16}
+        size={isGrid ? 24 : 16}
       />
       <select
         aria-label='Filter by location'
         className={cn(
-          'w-fit appearance-none rounded-[8px] border py-2.5 pl-9 pr-10 text-sm font-semibold focus:outline-none focus:ring-0 cursor-pointer transition-all duration-300',
-          hasCampusSelected
-            ? 'border-ocean bg-ocean/5 text-ocean hover:border-ocean'
-            : 'border-[#DEE0E3] bg-white text-neutral-default hover:border-neutral-default',
+          'w-fit appearance-none border focus:outline-none focus:ring-0 cursor-pointer transition-all duration-300',
+          isGrid
+            ? cn(
+                'rounded-xl border-neutral-lighter py-2.5 pl-12 pr-12 text-sm font-bold',
+                hasCampusSelected
+                  ? 'border-ocean bg-ocean/5 text-ocean hover:border-ocean'
+                  : 'bg-white text-text-primary hover:border-neutral-default',
+              )
+            : cn(
+                'rounded-[8px] py-2.5 pl-9 pr-10 text-sm font-semibold',
+                hasCampusSelected
+                  ? 'border-ocean bg-ocean/5 text-ocean hover:border-ocean'
+                  : 'border-[#DEE0E3] bg-white text-neutral-default hover:border-neutral-default',
+              ),
         )}
         value={value}
         onChange={(e) => {
@@ -204,9 +293,13 @@ function CampusFilterSelect() {
         name='chevronDown'
         className={cn(
           'pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 transition-colors',
-          hasCampusSelected ? 'text-ocean' : 'text-neutral-default',
+          hasCampusSelected
+            ? 'text-ocean'
+            : isGrid
+              ? 'text-text-primary'
+              : 'text-neutral-default',
         )}
-        size={20}
+        size={isGrid ? 24 : 20}
       />
     </div>
   );
@@ -218,16 +311,23 @@ export function VolunteerAlgolia({
   indexName,
   onVolunteerUiReady,
   resultsLayout = 'carousel',
+  hitsPerPage: hitsPerPageProp,
 }: {
   appId: string;
   apiKey: string;
   indexName: string;
   /** Called once when credentials are missing, or when the first Algolia search reaches `idle`. */
   onVolunteerUiReady?: () => void;
-  resultsLayout?: 'carousel' | 'list';
+  resultsLayout?: 'carousel' | 'list' | 'grid';
+  /** Override Algolia page size. Grid layout grows this via “Show more”. */
+  hitsPerPage?: number;
 }) {
   const [searchParams, setSearchParams] = useSearchParams();
   const location = useLocation();
+  const defaultHitsPerPage =
+    hitsPerPageProp ??
+    (resultsLayout === 'grid' ? VOLUNTEER_GRID_PAGE_SIZE : 24);
+  const [gridHitsPerPage, setGridHitsPerPage] = useState(defaultHitsPerPage);
 
   const searchParamsRef = useRef(searchParams);
   const setSearchParamsRef = useRef(setSearchParams);
@@ -239,6 +339,11 @@ export function VolunteerAlgolia({
   searchParamsRef.current = searchParams;
   setSearchParamsRef.current = setSearchParams;
   pathnameRef.current = location.pathname;
+
+  useEffect(() => {
+    if (resultsLayout !== 'grid') return;
+    setGridHitsPerPage(defaultHitsPerPage);
+  }, [defaultHitsPerPage, resultsLayout, searchParams]);
 
   const router = useMemo(
     () =>
@@ -301,13 +406,17 @@ export function VolunteerAlgolia({
       future={{ preserveSharedStateOnUnmount: true }}
     >
       <VolunteerSearchReadyReporter onReady={onVolunteerUiReady} />
-      <Configure hitsPerPage={12} />
+      <Configure
+        hitsPerPage={
+          resultsLayout === 'grid' ? gridHitsPerPage : defaultHitsPerPage
+        }
+      />
 
       {/* Mobile: sticky strip + bottom-sheet filter popups (parent must be `md:hidden` only here) */}
       <div className='flex flex-col gap-4 md:hidden'>
         <div className='flex w-full min-w-0 max-w-[100vw] flex-col'>
           <FinderStickyBar>
-            <div className='mx-auto flex w-full max-w-[1280px] flex-col gap-3 py-4'>
+            <div className='mx-auto flex w-full max-w-screen-content flex-col gap-3 py-4'>
               <SearchFilters
                 onClearAllToUrl={() => {}}
                 desktopFilters={desktopFilters}
@@ -320,26 +429,53 @@ export function VolunteerAlgolia({
       </div>
 
       {/* Desktop: inline category pills + clear + campus */}
-      <div className='content-padding'>
-        <div className='mx-auto hidden max-w-[1280px] flex-col gap-3 md:flex md:flex-row md:flex-wrap md:items-center md:justify-between'>
-          <div className='flex min-w-0 flex-1 flex-col gap-3 sm:flex-row sm:items-center'>
-            <HubsTagsRefinementList
-              attribute={FACET_CATEGORY}
-              wrapperClass='flex min-w-0 flex-1 flex-wrap gap-2 md:gap-4 px-1 pb-4 md:pb-0 overflow-x-auto scrollbar-hide'
-              unselectedClassName={volunteerCategoryUnselected}
-              selectedClassName={volunteerCategorySelected}
-              removeButtonClassName={volunteerCategoryRemove}
-            />
+      <div
+        className={cn(
+          'hidden content-padding md:block',
+          resultsLayout === 'grid' && 'md:pb-6 lg:pb-8',
+        )}
+      >
+        {resultsLayout === 'grid' ? (
+          <div className='mx-auto flex max-w-screen-content items-center gap-4'>
+            <CampusFilterSelect variant='grid' />
+            <div className='flex min-w-0 flex-1 items-center gap-5'>
+              <HubsTagsRefinementList
+                attribute={FACET_CATEGORY}
+                wrapperClass='flex min-w-0 flex-1 flex-wrap gap-2'
+                unselectedClassName={volunteerGridCategoryUnselected}
+                selectedClassName={volunteerGridCategorySelected}
+                removeButtonClassName={volunteerCategoryRemove}
+              />
+              <AlgoliaFinderClearAllButton className='text-sm' />
+            </div>
           </div>
-          <div className='flex shrink-0 flex-wrap items-center justify-end gap-3 md:ml-auto'>
-            <AlgoliaFinderClearAllButton />
-            <CampusFilterSelect />
+        ) : (
+          <div className='mx-auto flex max-w-screen-content flex-col gap-3 md:flex-row md:flex-wrap md:items-center md:justify-between'>
+            <div className='flex min-w-0 flex-1 flex-col gap-3 sm:flex-row sm:items-center'>
+              <HubsTagsRefinementList
+                attribute={FACET_CATEGORY}
+                wrapperClass='flex min-w-0 flex-1 flex-wrap gap-2 md:gap-4 px-1 pb-4 md:pb-0 overflow-x-auto scrollbar-hide'
+                unselectedClassName={volunteerCategoryUnselected}
+                selectedClassName={volunteerCategorySelected}
+                removeButtonClassName={volunteerCategoryRemove}
+              />
+            </div>
+            <div className='flex shrink-0 flex-wrap items-center justify-end gap-3 md:ml-auto'>
+              <AlgoliaFinderClearAllButton />
+              <CampusFilterSelect />
+            </div>
           </div>
-        </div>
+        )}
       </div>
 
       {resultsLayout === 'list' ? (
         <VolunteerHitsList />
+      ) : resultsLayout === 'grid' ? (
+        <VolunteerHitsGrid
+          onShowMore={() =>
+            setGridHitsPerPage((current) => current + VOLUNTEER_GRID_PAGE_SIZE)
+          }
+        />
       ) : (
         <VolunteerHitsCarousel />
       )}

--- a/app/routes/volunteer/components/volunteer-algolia.component.tsx
+++ b/app/routes/volunteer/components/volunteer-algolia.component.tsx
@@ -439,21 +439,21 @@ export function VolunteerAlgolia({
         }
       />
 
-      {/* Mobile: sticky strip + bottom-sheet filter popups (parent must be `md:hidden` only here) */}
-      <div className='flex flex-col gap-4 md:hidden'>
-        <div className='flex w-full min-w-0 max-w-[100vw] flex-col'>
-          <FinderStickyBar>
-            <div className='mx-auto flex w-full max-w-screen-content flex-col gap-3 py-4'>
-              <SearchFilters
-                onClearAllToUrl={() => {}}
-                desktopFilters={desktopFilters}
-                compactInlineFilterCount={2}
-              />
-            </div>
-            <ActiveFilters />
-          </FinderStickyBar>
+      {/*
+        Mobile sticky filters must be a direct InstantSearch sibling of the
+        results (same as group/class finder). A short `md:hidden` wrapper around
+        only the bar makes `position: sticky` leave with that short box.
+      */}
+      <FinderStickyBar className='md:hidden max-w-[100vw]'>
+        <div className='mx-auto flex w-full max-w-screen-content flex-col gap-3 py-4'>
+          <SearchFilters
+            onClearAllToUrl={() => {}}
+            desktopFilters={desktopFilters}
+            compactInlineFilterCount={2}
+          />
         </div>
-      </div>
+        <ActiveFilters />
+      </FinderStickyBar>
 
       {/* Desktop: inline category pills + clear + campus */}
       <div

--- a/app/routes/volunteer/components/volunteer-algolia.component.tsx
+++ b/app/routes/volunteer/components/volunteer-algolia.component.tsx
@@ -194,7 +194,7 @@ function VolunteerHitsGrid({ onShowMore }: { onShowMore: () => void }) {
   const canShowMore = hits.length < nbHits;
 
   return (
-    <div className='border-t border-neutral-lighter bg-gray content-padding py-6'>
+    <div className='border-t border-neutral-lighter bg-gray content-padding py-8 md:pb-16'>
       <ul className='mx-auto grid w-full max-w-screen-content grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 lg:gap-8'>
         {hits.map((hit) => (
           <li key={hit.objectID} className='min-w-0'>

--- a/app/routes/volunteer/components/volunteer-algolia.component.tsx
+++ b/app/routes/volunteer/components/volunteer-algolia.component.tsx
@@ -30,6 +30,7 @@ import { VolunteerListCard } from './volunteer-list-card.component';
 import type { Volunteer } from '../types';
 import {
   parseVolunteerAlgoliaUrlState,
+  volunteerAlgoliaUrlStateToParams,
   type VolunteerAlgoliaUrlState,
 } from './finder/volunteer-algolia-url-state';
 import {
@@ -71,6 +72,32 @@ const volunteerGridCategorySelected = cn(
 const VOLUNTEER_SLIDE_CLASS =
   'flex min-h-0 w-full min-w-0 flex-col pl-0 basis-[82%] sm:basis-[calc((100%-36px)/2)] lg:basis-[calc((100%-64px)/3)] max-w-[405px]';
 
+/**
+ * Active InstantSearch filters as a query string (`?category=…&campusList=…`).
+ * Prefer this over `location.search` so the View All CTA still works when UI
+ * filters are applied but the URL has not caught up yet.
+ */
+function useVolunteerFilterSearch(): string {
+  const { indexUiState } = useInstantSearch();
+
+  return useMemo(() => {
+    const query =
+      typeof indexUiState.query === 'string' && indexUiState.query.trim()
+        ? indexUiState.query
+        : undefined;
+    const refinementList = indexUiState.refinementList as
+      | Record<string, string[]>
+      | undefined;
+
+    const params = volunteerAlgoliaUrlStateToParams({
+      query,
+      refinementList,
+    });
+    const qs = params.toString();
+    return qs ? `?${qs}` : '';
+  }, [indexUiState.query, indexUiState.refinementList]);
+}
+
 /** Notifies parent once when InstantSearch reports `idle` (first response settled). */
 function VolunteerSearchReadyReporter({ onReady }: { onReady?: () => void }) {
   const { status } = useInstantSearch();
@@ -89,7 +116,7 @@ function VolunteerSearchReadyReporter({ onReady }: { onReady?: () => void }) {
 
 function VolunteerHitsCarousel() {
   const { items: hits } = useHits<Volunteer>();
-  const location = useLocation();
+  const filterSearch = useVolunteerFilterSearch();
 
   if (hits.length === 0) {
     return (
@@ -119,7 +146,7 @@ function VolunteerHitsCarousel() {
             >
               <VolunteerCard
                 volunteer={hit}
-                listingSearch={location.search}
+                listingSearch={filterSearch}
                 className='h-full w-full min-w-0'
               />
             </CarouselItem>
@@ -133,7 +160,7 @@ function VolunteerHitsCarousel() {
 
           <Button
             intent='secondary'
-            href={`/volunteer/community-opportunities${location.search}`}
+            href={`/volunteer/community-opportunities${filterSearch}`}
             size='md'
             className='shrink-0 rounded-full px-6 text-base md:px-8'
           >
@@ -151,7 +178,7 @@ const VOLUNTEER_GRID_PAGE_SIZE = 9;
 function VolunteerHitsGrid({ onShowMore }: { onShowMore: () => void }) {
   const { items: hits } = useHits<Volunteer>();
   const { nbHits } = useStats();
-  const location = useLocation();
+  const filterSearch = useVolunteerFilterSearch();
 
   if (hits.length === 0) {
     return (
@@ -173,7 +200,7 @@ function VolunteerHitsGrid({ onShowMore }: { onShowMore: () => void }) {
           <li key={hit.objectID} className='min-w-0'>
             <VolunteerCard
               volunteer={hit}
-              listingSearch={location.search}
+              listingSearch={filterSearch}
               finderOrigin='community-opportunities'
               className='h-full w-full min-w-0'
             />

--- a/app/routes/volunteer/components/volunteer-card.component.tsx
+++ b/app/routes/volunteer/components/volunteer-card.component.tsx
@@ -30,15 +30,18 @@ function volunteerCardPropsEqual(
     volunteer: Volunteer;
     listingSearch: string;
     className?: string;
+    finderOrigin?: VolunteerFinderBackPayload['origin'];
   },
   next: {
     volunteer: Volunteer;
     listingSearch: string;
     className?: string;
+    finderOrigin?: VolunteerFinderBackPayload['origin'];
   },
 ): boolean {
   if (prev.listingSearch !== next.listingSearch) return false;
   if (prev.className !== next.className) return false;
+  if (prev.finderOrigin !== next.finderOrigin) return false;
   const p = prev.volunteer;
   const n = next.volunteer;
   if (p.objectID !== n.objectID) return false;
@@ -76,14 +79,17 @@ function VolunteerCardInner({
   volunteer,
   listingSearch,
   className,
+  finderOrigin,
 }: {
   volunteer: Volunteer;
   listingSearch: string;
   className?: string;
+  finderOrigin?: VolunteerFinderBackPayload['origin'];
 }) {
   const finderBackPayload: VolunteerFinderBackPayload = {
     missionGroupGuid: volunteer.groupGuid,
     volunteerListSearch: listingSearch,
+    origin: finderOrigin,
   };
 
   // Cover image: group photo first, Event Type Defined Value image as fallback.

--- a/app/routes/volunteer/outreach-opportunity/components/outreach-finder-return-href.ts
+++ b/app/routes/volunteer/outreach-opportunity/components/outreach-finder-return-href.ts
@@ -6,7 +6,7 @@ export type VolunteerFinderBackPayload = {
   /** `location.search` on the originating finder (`""` or `?category=…`). */
   volunteerListSearch: string;
   /** Omitted by existing volunteer cards; they continue to use the volunteer finder. */
-  origin?: 'missions-private-events';
+  origin?: 'missions-private-events' | 'community-opportunities';
 };
 
 export const VOLUNTEER_FINDER_BACK_STORAGE_KEY =
@@ -23,7 +23,11 @@ function parseFinderBackPayload(
     return null;
   }
   if (typeof o.volunteerListSearch !== 'string') return null;
-  if (o.origin !== undefined && o.origin !== 'missions-private-events') {
+  if (
+    o.origin !== undefined &&
+    o.origin !== 'missions-private-events' &&
+    o.origin !== 'community-opportunities'
+  ) {
     return null;
   }
   return {

--- a/app/routes/volunteer/outreach-opportunity/outreach-opportunity-page.tsx
+++ b/app/routes/volunteer/outreach-opportunity/outreach-opportunity-page.tsx
@@ -67,6 +67,12 @@ export function OutreachOpportunityPage() {
         navigate(`/missions-private-events${payload.volunteerListSearch}`);
         return;
       }
+      if (payload.origin === 'community-opportunities') {
+        navigate(
+          `/volunteer/community-opportunities${payload.volunteerListSearch}`,
+        );
+        return;
+      }
       if (payload.volunteerListSearch.trim().length > 1) {
         navigate(-1);
         return;

--- a/app/routes/volunteer/partials/volunteer-church.partial.tsx
+++ b/app/routes/volunteer/partials/volunteer-church.partial.tsx
@@ -12,7 +12,7 @@ export function VolunteerAtChurch() {
       id='church'
       className='w-full bg-dark-navy text-white pl-5 md:pl-12 lg:px-18'
     >
-      <div className='mx-auto max-w-[1280px] w-full flex flex-col items-center gap-10 py-16 md:gap-14 md:py-24 lg:py-28'>
+      <div className='mx-auto max-w-screen-content w-full flex flex-col items-center gap-10 py-16 md:gap-14 md:py-24 lg:py-28'>
         <div className='flex w-full flex-col gap-6 pr-5 md:pr-12 lg:pr-0 text-white md:flex-row md:items-end md:justify-between '>
           <div className='flex min-w-0 flex-1 flex-col gap-4'>
             <div className='flex items-center gap-4'>

--- a/app/routes/volunteer/partials/volunteer-community.partial.tsx
+++ b/app/routes/volunteer/partials/volunteer-community.partial.tsx
@@ -19,7 +19,7 @@ export function VolunteerCommunity() {
     <section id='community' className='w-full bg-white md:bg-gray py-28'>
       <div className='flex flex-col gap-4'>
         <div className='content-padding'>
-          <div className='max-w-[1280px] mx-auto flex flex-col gap-6'>
+          <div className='max-w-screen-content mx-auto flex flex-col gap-6'>
             <SectionTitle sectionTitle='Needs in our region' />
             <div className='flex flex-col gap-4 md:flex-row md:items-end md:justify-between'></div>
             <h2 className='text-[40px] font-extrabold leading-tight text-text-primary md:text-[52px]'>
@@ -48,7 +48,7 @@ export function VolunteerCommunity() {
         </div>
 
         <div className='content-padding'>
-          <div className='max-w-[1280px] mx-auto mt-16 flex flex-col md:flex-row items-center justify-center gap-6 text-center'>
+          <div className='max-w-screen-content mx-auto mt-16 flex flex-col md:flex-row items-center justify-center gap-6 text-center'>
             <p className='md:text-lg font-semibold text-neutral-dark'>
               Have a skill set we should know about?
             </p>

--- a/app/routes/volunteer/partials/volunteer-stats.partial.tsx
+++ b/app/routes/volunteer/partials/volunteer-stats.partial.tsx
@@ -97,7 +97,7 @@ export function VolunteerStats() {
       id='stats'
       className='w-full bg-dark-navy text-white content-padding'
     >
-      <div className='mx-auto flex w-full max-w-[1280px] flex-col py-16 md:py-24 lg:py-28'>
+      <div className='mx-auto flex w-full max-w-screen-content flex-col py-16 md:py-24 lg:py-28'>
         <header className='flex flex-col gap-4'>
           <div className='flex items-center gap-4'>
             <div className='h-1 w-8 shrink-0 bg-ocean-web' aria-hidden />

--- a/app/routes/volunteer_.community-opportunities.tsx
+++ b/app/routes/volunteer_.community-opportunities.tsx
@@ -1,0 +1,6 @@
+import { CommunityOpportunitiesPage } from './volunteer/community-opportunities/community-opportunities-page';
+
+export { loader } from './volunteer/community-opportunities/loader';
+export { meta } from './volunteer/community-opportunities/meta';
+
+export default CommunityOpportunitiesPage;


### PR DESCRIPTION
## Summary

Adds a dedicated community opportunities listing page and updates the Volunteer In Our Community carousel so users can browse all opportunities beyond the homepage preview.

These changes are necessary to match the Web 3.0 design: carousel controls now link to a full filtered grid at `/volunteer/community-opportunities`, with proper back-navigation from opportunity detail and mobile/desktop filter layouts that don’t conflict with the legacy `/volunteer/:path` redirect.

## Screenshots
<img width="2313" height="1311" alt="Screenshot 2026-08-11 at 1 32 22 PM" src="https://github.com/user-attachments/assets/53990873-e00a-408f-9608-feca020f6e7f" />


## Testing

- [x] On `/volunteer` community section: carousel has no dots; arrows on the left; CTA on the right (“View All” on mobile, “View all opportunities” on desktop)
- [x] CTA navigates to `/volunteer/community-opportunities` and preserves active filter query params
- [x] Confirm the URL does **not** redirect to `/volunteer/outreach/community-opportunities`
- [x] Desktop filters: location dropdown → category pills → Clear All; grey results area starts below the divider under filters
- [ ] Mobile: desktop filter bar is hidden; sticky mobile filters still work
- [x] “Show more opportunities” loads more cards and updates “Showing X of Y”
- [x] Open an opportunity from the grid, then Back returns to `/volunteer/community-opportunities` with filters intact
- [x] Short result sets do not leave a large empty white gap above the footer
- [x] “Back to Volunteer” returns to `/volunteer#community`
- [x] `pnpm check` — shows no warnings or errors.

## Tickets

[CFDP-4211](https://christfellowshipchurch.atlassian.net/browse/CFDP-4211)

## Changes Made

### New Components Added

- `app/routes/volunteer/community-opportunities/community-opportunities-page.tsx` — full-page community opportunities UI (back nav, hero, Algolia grid)
- Grid results UI inside `app/routes/volunteer/components/volunteer-algolia.component.tsx` (`VolunteerHitsGrid`) — responsive card grid, show-more, result count
- Grid skeleton in `app/routes/volunteer/components/volunteer-algolia-skeleton.component.tsx` (`VolunteerGridSkeleton`)

### New Utilities

- Extended `VolunteerFinderBackPayload.origin` in `app/routes/volunteer/outreach-opportunity/components/outreach-finder-return-href.ts` to support `'community-opportunities'`
- Back-nav handling in `app/routes/volunteer/outreach-opportunity/outreach-opportunity-page.tsx` for returning to the new listing page

### New Assets

- None

### Dependencies

- None

### Route Implementation

- `app/routes/volunteer_.community-opportunities.tsx` — route entry for `/volunteer/community-opportunities` (uses `volunteer_` escape so it is not caught by legacy `/volunteer/:path` → outreach redirect)
- `app/routes/volunteer/community-opportunities/loader.ts` — Algolia credentials/indexes loader
- `app/routes/volunteer/community-opportunities/meta.ts` — page metadata

### Key Features

- Homepage community carousel: dots removed; arrows left; View All / View all opportunities CTA linking to the full listing
- New `/volunteer/community-opportunities` page with filterable Algolia grid, show-more pagination, and Figma-aligned desktop filter bar
- Mobile uses sticky filters only; desktop filter bar hidden below `md`
- Opportunity detail back navigation returns to the community opportunities page when opened from that grid
- Aligns several volunteer section max-widths to `max-w-screen-content` for consistency

[CFDP-4211]: https://christfellowshipchurch.atlassian.net/browse/CFDP-4211?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ