### PR TITLE
Image gallery component updated

### DIFF
--- a/.infisical.json
+++ b/.infisical.json
@@ -1,5 +1,5 @@
 {
   "workspaceId": "104f27e7-c992-44e9-bbff-7bab7acd26b2",
-  "defaultEnvironment": "",
+  "defaultEnvironment": "prod",
   "gitBranchToEnvironmentMapping": null
 }

--- a/app/lib/.server/fetch-rock-data.ts
+++ b/app/lib/.server/fetch-rock-data.ts
@@ -268,8 +268,7 @@ export const fetchRockData = async ({
   const previewMode = isPreviewMode();
   // Local/dev: always bypass Redis so CMS edits (e.g. new child items) show up
   // without waiting on TTL or manual cache invalidation.
-  const skipCache =
-    previewMode || process.env.NODE_ENV === 'development';
+  const skipCache = previewMode || process.env.NODE_ENV === 'development';
   // Preview mode only bypasses the Status filter — date-range filtering still
   // applies, so a not-yet-scheduled or already-expired item stays hidden.
   const effectiveFilterByDateRange = filterByDateRange;

--- a/app/lib/.server/fetch-rock-data.ts
+++ b/app/lib/.server/fetch-rock-data.ts
@@ -266,6 +266,10 @@ export const fetchRockData = async ({
   assertByIdEndpointHasNoIgnoredParams(endpoint, queryParams);
 
   const previewMode = isPreviewMode();
+  // Local/dev: always bypass Redis so CMS edits (e.g. new child items) show up
+  // without waiting on TTL or manual cache invalidation.
+  const skipCache =
+    previewMode || process.env.NODE_ENV === 'development';
   // Preview mode only bypasses the Status filter — date-range filtering still
   // applies, so a not-yet-scheduled or already-expired item stays hidden.
   const effectiveFilterByDateRange = filterByDateRange;
@@ -298,7 +302,8 @@ export const fetchRockData = async ({
   );
   // Preview never reads or writes the shared Redis cache — this deployment's
   // results (unapproved content) must never be served to or poison prod's cache.
-  const effectiveTtl: number = previewMode
+  // Local development also skips cache so Rock CMS changes are immediately visible.
+  const effectiveTtl: number = skipCache
     ? TTL.NONE
     : ttl !== undefined
       ? ttl

--- a/app/routes/page-builder/components/image-gallery/index.tsx
+++ b/app/routes/page-builder/components/image-gallery/index.tsx
@@ -5,32 +5,46 @@ import {
   CarouselDots,
   CarouselItem,
 } from '~/primitives/shadcn-primitives/carousel';
-import { PageBuilderSection } from '../../types';
-import { cn } from '~/lib/utils';
+import { ImageGalleryItem, PageBuilderSection } from '../../types';
 import { HTMLRenderer } from '~/primitives/html-renderer/html-renderer.component';
 
 export const ImageGallerySection = ({ data }: { data: PageBuilderSection }) => {
-  return (
-    <div className='w-full py-12 md:py-28 bg-white pl-5 md:pl-12 lg:px-18'>
-      <div className='max-w-screen-content mx-auto flex flex-col gap-12 xl:gap-20'>
-        <div className='flex flex-col gap-5 md:gap-6'>
-          <h2 className='text-2xl md:text-[52px] font-extrabold text-text-primary'>
-            {data.name}
-          </h2>
-          {data?.content?.length > 0 && (
-            <HTMLRenderer className='md:text-lg' html={data.content} />
-          )}
-        </div>
+  const sectionTitle =
+    data.titleOverride && data.titleOverride !== ''
+      ? data.titleOverride
+      : data.name;
+  const shouldShowTitle = !data.hideTitle && Boolean(sectionTitle?.trim());
+  const shouldShowContent = Boolean(data.content?.trim());
+  const shouldShowHeader = shouldShowTitle || shouldShowContent;
 
-        {/* Gallery Component */}
+  return (
+    <div className='w-full bg-white py-16 md:py-28 pl-5 md:pl-12 lg:px-18'>
+      <div className='mx-auto flex max-w-screen-content flex-col gap-12 md:gap-20'>
+        {shouldShowHeader && (
+          <div className='flex max-w-[768px] flex-col gap-5 md:gap-6'>
+            {shouldShowTitle && (
+              <h2 className='text-[48px] font-extrabold leading-[1.2] text-text-primary md:text-[52px]'>
+                {sectionTitle}
+              </h2>
+            )}
+            {shouldShowContent && (
+              <HTMLRenderer className='text-base md:text-lg' html={data.content} />
+            )}
+          </div>
+        )}
+
         <ImageGalleryComponent data={data.imageGallery} />
       </div>
     </div>
   );
 };
 
-const ImageGalleryComponent = ({ data }: { data: string[] | undefined }) => {
-  if (!data) {
+const ImageGalleryComponent = ({
+  data,
+}: {
+  data: ImageGalleryItem[] | undefined;
+}) => {
+  if (!data?.length) {
     return null;
   }
 
@@ -40,57 +54,53 @@ const ImageGalleryComponent = ({ data }: { data: string[] | undefined }) => {
         align: 'start',
       }}
     >
-      <CarouselContent
-        className={cn(
-          'gap-6 pt-4 aspect-video max-h-[176px]',
-          'md:mt-12 md:max-h-[400px]',
-          'lg:max-h-[650px]',
-          'xl:gap-8',
-          '2xl:max-h-[720px]',
-        )}
-      >
-        {data.map((image, index) => (
+      <CarouselContent className='gap-6'>
+        {data.map((item) => (
           <CarouselItem
-            key={index}
-            className={cn(
-              cn(
-                'w-full',
-                'md:basis-[95%]',
-                index !== data.length - 1
-                  ? 'md:basis-[95%] max-w-[1100px] 2xl:max-w-[1280px]'
-                  : 'md:basis-[96%] ',
-              ),
-            )}
+            key={item.id}
+            className='basis-[85%] sm:basis-[45%] lg:basis-[calc((100%-3rem)/3)]'
           >
-            <img
-              src={image}
-              alt={image}
-              className='w-full h-full object-cover'
-            />
+            <ImageGalleryCard item={item} />
           </CarouselItem>
         ))}
       </CarouselContent>
 
-      <div
-        className={cn('w-full relative mt-8 xl:mt-12 pb-8', {
-          'lg:mt-6 lg:pb-0': data.length < 4,
-        })}
-      >
-        <div className='absolute h-12 top-7 left-0'>
-          <CarouselDots
-            activeClassName='bg-ocean'
-            inactiveClassName='bg-neutral-lighter'
-          />
-        </div>
-
-        <div
-          className={cn(
-            'absolute h-12 right-44 lg:right-44 2xl:right-36 3xl:right-28',
-          )}
-        >
-          <CarouselArrows />
-        </div>
+      <div className='mt-8 flex w-full items-center justify-between md:mt-12'>
+        <CarouselDots
+          className='justify-start'
+          activeClassName='bg-ocean'
+          inactiveClassName='bg-neutral-lighter'
+        />
+        <CarouselArrows />
       </div>
     </Carousel>
+  );
+};
+
+const ImageGalleryCard = ({ item }: { item: ImageGalleryItem }) => {
+  const title = item.title?.trim();
+  const summary = item.summary?.trim();
+  const shouldShowOverlay = Boolean(title || summary);
+
+  return (
+    <div className='relative h-[194px] w-full overflow-hidden rounded-2xl md:h-[261px]'>
+      <img
+        src={item.image}
+        alt={title || 'Gallery image'}
+        className='size-full object-cover'
+      />
+      {shouldShowOverlay && (
+        <div className='absolute inset-x-0 bottom-0 flex flex-col gap-1 overflow-hidden bg-black/65 px-4 py-3'>
+          {title && (
+            <p className='text-sm font-semibold text-white md:text-base'>
+              {title}
+            </p>
+          )}
+          {summary && (
+            <p className='text-xs text-white/80 md:text-[13px]'>{summary}</p>
+          )}
+        </div>
+      )}
+    </div>
   );
 };

--- a/app/routes/page-builder/components/image-gallery/index.tsx
+++ b/app/routes/page-builder/components/image-gallery/index.tsx
@@ -18,7 +18,7 @@ export const ImageGallerySection = ({ data }: { data: PageBuilderSection }) => {
   const shouldShowHeader = shouldShowTitle || shouldShowContent;
 
   return (
-    <div className='w-full bg-white py-16 md:py-28 pl-5 md:pl-12 lg:px-18'>
+    <div className='w-full bg-white py-16 pb-10 md:py-28 pl-5 md:pl-12 lg:px-18'>
       <div className='mx-auto flex max-w-screen-content flex-col gap-12 md:gap-20'>
         {shouldShowHeader && (
           <div className='flex max-w-[768px] flex-col gap-5 md:gap-6'>
@@ -58,14 +58,14 @@ const ImageGalleryComponent = ({
         {data.map((item) => (
           <CarouselItem
             key={item.id}
-            className='basis-[85%] sm:basis-[45%] lg:basis-[calc((100%-3rem)/3)]'
+            className='basis-[68%] sm:basis-[45%] lg:basis-[calc((100%-3rem)/3)]'
           >
             <ImageGalleryCard item={item} />
           </CarouselItem>
         ))}
       </CarouselContent>
 
-      <div className='mt-8 flex w-full items-center justify-between md:mt-12'>
+      <div className='mt-5 flex w-full items-center justify-between pr-5 md:mt-8 md:pr-0'>
         <CarouselDots
           className='justify-start'
           activeClassName='bg-ocean'
@@ -83,7 +83,7 @@ const ImageGalleryCard = ({ item }: { item: ImageGalleryItem }) => {
   const shouldShowOverlay = Boolean(title || summary);
 
   return (
-    <div className='relative h-[194px] w-full overflow-hidden rounded-2xl md:h-[261px]'>
+    <div className='relative aspect-square w-full overflow-hidden rounded-2xl md:aspect-auto md:h-[261px]'>
       <img
         src={item.image}
         alt={title || 'Gallery image'}

--- a/app/routes/page-builder/components/image-gallery/index.tsx
+++ b/app/routes/page-builder/components/image-gallery/index.tsx
@@ -28,7 +28,10 @@ export const ImageGallerySection = ({ data }: { data: PageBuilderSection }) => {
               </h2>
             )}
             {shouldShowContent && (
-              <HTMLRenderer className='text-base md:text-lg' html={data.content} />
+              <HTMLRenderer
+                className='text-base md:text-lg'
+                html={data.content}
+              />
             )}
           </div>
         )}

--- a/app/routes/page-builder/components/image-gallery/mock-data.tsx
+++ b/app/routes/page-builder/components/image-gallery/mock-data.tsx
@@ -2,12 +2,36 @@ import { ImageGallery } from '../../types';
 
 export const imageGalleryData: ImageGallery = {
   id: '1',
+  hideTitle: false,
   images: [
-    '/assets/images/page-builder/temp.jpg',
-    '/assets/images/page-builder/temp.jpg',
-    '/assets/images/page-builder/temp.jpg',
-    '/assets/images/page-builder/temp.jpg',
-    '/assets/images/page-builder/temp.jpg',
+    {
+      id: '1',
+      image: '/assets/images/page-builder/temp.jpg',
+      title: 'Image Title',
+      summary: 'A brief description of this image',
+    },
+    {
+      id: '2',
+      image: '/assets/images/page-builder/temp.jpg',
+      title: 'Image Title',
+      summary: 'A brief description of this image',
+    },
+    {
+      id: '3',
+      image: '/assets/images/page-builder/temp.jpg',
+      title: 'Image Title',
+      summary: 'A brief description of this image',
+    },
+    {
+      id: '4',
+      image: '/assets/images/page-builder/temp.jpg',
+    },
+    {
+      id: '5',
+      image: '/assets/images/page-builder/temp.jpg',
+      title: 'Image Title',
+      summary: 'A brief description of this image',
+    },
   ],
   description:
     'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse varius enim in eros elementum tristique.',

--- a/app/routes/page-builder/loader.tsx
+++ b/app/routes/page-builder/loader.tsx
@@ -23,6 +23,7 @@ import {
 } from './types';
 import { format, parseISO } from 'date-fns';
 import { fetchWistiaDataFromRock } from '~/lib/.server/fetch-wistia-data';
+import { getAttributeMatrixItems } from '~/lib/.server/rock-utils';
 import {
   buildPodcastRoutingIndex,
   PODCAST_SHOW_CHANNEL_ID,
@@ -80,9 +81,13 @@ interface RockContentItem {
 interface RockAttributeMatrixItem {
   id: string;
   attributeValues: {
-    header: RockAttributeValue;
-    content: RockAttributeValue;
-    image: RockAttributeValue;
+    header?: RockAttributeValue;
+    content?: RockAttributeValue;
+    image?: RockAttributeValue;
+    title?: RockAttributeValue;
+    summary?: RockAttributeValue;
+    cardTitle?: RockAttributeValue;
+    cardSummary?: RockAttributeValue;
   };
 }
 
@@ -199,6 +204,10 @@ export const mapPageBuilderChildItems = async (
         name: child.title,
         titleOverride: getStringValue(
           child.attributeValues?.titleOverride?.value ?? '',
+        ),
+        hideTitle: getBooleanValue(
+          child.attributeValues?.hideTitle?.value ??
+            attributeValues?.hideTitle,
         ),
         content: child.content,
         linkTreeLayout: await getLinkTreeLayout(child.attributeValues || {}),
@@ -496,39 +505,56 @@ export const mapPageBuilderChildItems = async (
           ),
           faqs: faqs.map((faq: RockAttributeMatrixItem) => ({
             id: faq.id,
-            question: faq.attributeValues.header.value,
-            answer: faq.attributeValues.content.value,
+            question: getStringValue(faq.attributeValues.header?.value ?? ''),
+            answer: getStringValue(faq.attributeValues.content?.value ?? ''),
           })),
         };
       }
 
       if (sectionType === 'IMAGE_GALLERY') {
-        const { id: matrixId } = await fetchRockData({
-          endpoint: `AttributeMatrices`,
-          queryParams: {
-            $filter: `Guid eq guid'${getStringValue(
-              attributeValues?.images || '',
-            )}'`,
-            $select: 'Id',
-          },
-        });
+        const imagesGuid = getStringValue(attributeValues?.images || '');
 
-        const imageGallery = await fetchRockData({
-          endpoint: `AttributeMatrixItems`,
-          queryParams: {
-            $filter: `AttributeMatrix/${getIdentifierType(matrixId).query}`,
-            loadAttributes: 'simple',
-          },
-        });
+        if (!imagesGuid) {
+          console.error(
+            'IMAGE_GALLERY section is missing the images attribute:',
+            child.id,
+          );
+          return { ...baseChild, imageGallery: [] };
+        }
 
-        return {
-          ...baseChild,
-          imageGallery: imageGallery.map((image: RockAttributeMatrixItem) =>
-            createImageUrlFromGuid(
-              getStringValue(image.attributeValues.image.value),
-            ),
-          ),
-        };
+        try {
+          const imageGallery = await getAttributeMatrixItems({
+            attributeMatrixGuid: imagesGuid,
+          });
+
+          return {
+            ...baseChild,
+            imageGallery: imageGallery.map((image) => {
+              const title = getStringValue(
+                image.attributeValues?.cardTitle?.value ??
+                  image.attributeValues?.title?.value ??
+                  '',
+              ).trim();
+              const summary = getStringValue(
+                image.attributeValues?.cardSummary?.value ??
+                  image.attributeValues?.summary?.value ??
+                  '',
+              ).trim();
+
+              return {
+                id: String(image.id),
+                image: createImageUrlFromGuid(
+                  getStringValue(image.attributeValues?.image?.value ?? ''),
+                ),
+                ...(title ? { title } : {}),
+                ...(summary ? { summary } : {}),
+              };
+            }),
+          };
+        } catch (error) {
+          console.error('Failed to load IMAGE_GALLERY section:', child.id, error);
+          return { ...baseChild, imageGallery: [] };
+        }
       }
 
       return baseChild;

--- a/app/routes/page-builder/loader.tsx
+++ b/app/routes/page-builder/loader.tsx
@@ -206,8 +206,7 @@ export const mapPageBuilderChildItems = async (
           child.attributeValues?.titleOverride?.value ?? '',
         ),
         hideTitle: getBooleanValue(
-          child.attributeValues?.hideTitle?.value ??
-            attributeValues?.hideTitle,
+          child.attributeValues?.hideTitle?.value ?? attributeValues?.hideTitle,
         ),
         content: child.content,
         linkTreeLayout: await getLinkTreeLayout(child.attributeValues || {}),
@@ -552,7 +551,11 @@ export const mapPageBuilderChildItems = async (
             }),
           };
         } catch (error) {
-          console.error('Failed to load IMAGE_GALLERY section:', child.id, error);
+          console.error(
+            'Failed to load IMAGE_GALLERY section:',
+            child.id,
+            error,
+          );
           return { ...baseChild, imageGallery: [] };
         }
       }

--- a/app/routes/page-builder/page-builder-page.tsx
+++ b/app/routes/page-builder/page-builder-page.tsx
@@ -97,7 +97,7 @@ export function renderSection(
       );
       return null;
     case 'IMAGE_GALLERY':
-      if (section.imageGallery) {
+      if (section.imageGallery?.length) {
         return (
           <div key={section.id} id={anchorId} className='scroll-mt-18'>
             <ImageGallerySection data={section} />

--- a/app/routes/page-builder/types.ts
+++ b/app/routes/page-builder/types.ts
@@ -58,12 +58,23 @@ export type FAQ = {
 };
 
 /**
+ * Represents a single image in an Image Gallery section
+ */
+export type ImageGalleryItem = {
+  id: string;
+  image: string;
+  title?: string;
+  summary?: string;
+};
+
+/**
  * Represents Image Gallery data structure for mock data
  */
 export type ImageGallery = {
   id: string;
-  images: string[];
+  images: ImageGalleryItem[];
   description?: string;
+  hideTitle?: boolean;
 };
 
 /**
@@ -96,6 +107,7 @@ export type PageBuilderSection = {
   id: string;
   name: string;
   titleOverride?: string;
+  hideTitle?: boolean;
   content: string;
   type: SectionType;
   linkTreeLayout?: 'GRID' | 'LIST'; // only used for resource collections
@@ -103,7 +115,7 @@ export type PageBuilderSection = {
   faqs?: FAQItem[];
   stillHaveQuestionsLink?: string; // only in FAQs component
   cta?: CallToAction; // Used in FAQs component
-  imageGallery?: string[];
+  imageGallery?: ImageGalleryItem[];
   viewMoreLink?: string | undefined;
   className?: string; // Location Single pages uses page builder components that want custom padding around
 };


### PR DESCRIPTION
## Summary

Updates the Page Builder / Ministry Builder **Image Gallery** section to match the Web 3.0 Figma design: multi-card carousel with rounded images, optional dark overlays, and section header controls.

Supports Rock’s **Hide Title** toggle and per-image **Card Title** / **Card Summary**. Overlays render only when at least one of those fields is present; empty content is omitted.

## Screenshots
<img width="1262" height="787" alt="Screenshot 2026-08-12 at 11 14 57 AM" src="https://github.com/user-attachments/assets/6dcaa3b2-617e-4d2e-bfeb-e5010e1dcbfd" />

## Testing

- [x] Open a page with an Image Gallery section (e.g. `/ministries/young-adults`)
- [x] Confirm ~3 cards on desktop, peek/carousel on mobile, dots left + arrows right
- [x] Cards with Card Title and/or Card Summary show the bottom overlay; cards with neither show image only
- [x] With **Hide Title** on, section title is hidden; with it off, title shows (title override when set)
- [x] Empty section content does not render a blank description block
- [x] Carousel dots/arrows work with multiple images
- [x] Ensure mobile layout matches Figma.
- [x] `pnpm check` shows no errors or warnings.

## Tickets

[CFDP-4213](https://christfellowshipchurch.atlassian.net/browse/CFDP-4213)

## Changes Made

### New Components Added

- None (updated existing gallery)

### New Utilities

- None

### New Assets

- None

### Dependencies

- None

### Route Implementation

- `app/routes/page-builder/components/image-gallery/index.tsx` — Figma layout; conditional section title/content; card overlays
- `app/routes/page-builder/components/image-gallery/mock-data.tsx` — mock `ImageGalleryItem` shape
- `app/routes/page-builder/loader.tsx` — maps gallery via `getAttributeMatrixItems`; reads `cardTitle` / `cardSummary` (and `hideTitle`); returns `ImageGalleryItem[]`
- `app/routes/page-builder/page-builder-page.tsx` — renders gallery only when items exist
- `app/routes/page-builder/types.ts` — `ImageGalleryItem`, `hideTitle` on section

### Key Features

- Multi-card carousel aligned to Figma (rounded cards, overlay typography, nav)
- **Hide Title** from Rock hides the section heading
- Section body HTML only when content exists
- Card overlay only when Card Title and/or Card Summary is set
- Works for Page Builder and Ministry Builder (shared mapper + `renderSection`)

[CFDP-4213]: https://christfellowshipchurch.atlassian.net/browse/CFDP-4213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ