### PR TITLE
Image gallery update - Lightbox

### DIFF
--- a/app/routes/page-builder/components/image-gallery/index.tsx
+++ b/app/routes/page-builder/components/image-gallery/index.tsx
@@ -154,7 +154,7 @@ const ImageGalleryLightbox = ({
       <Dialog.Portal>
         <Dialog.Overlay className='fixed inset-0 z-499 bg-black/70 data-[state=closed]:animate-dialogOverlayHide data-[state=open]:animate-dialogOverlayShow' />
         <Dialog.Content
-          className='fixed top-1/2 left-1/2 z-500 max-h-[90vh] w-[min(92vw,1100px)] -translate-x-1/2 -translate-y-1/2 outline-none data-[state=closed]:animate-dialogContentHide data-[state=open]:animate-dialogContentShow'
+          className='fixed inset-0 z-500 m-auto h-fit max-h-[90vh] w-[min(92vw,1100px)] origin-center outline-none data-[state=closed]:animate-lightboxHide data-[state=open]:animate-lightboxShow'
           aria-describedby={undefined}
         >
           <VisuallyHidden.Root>

--- a/app/routes/page-builder/components/image-gallery/index.tsx
+++ b/app/routes/page-builder/components/image-gallery/index.tsx
@@ -1,3 +1,6 @@
+import { useState } from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
+import * as VisuallyHidden from '@radix-ui/react-visually-hidden';
 import {
   Carousel,
   CarouselArrows,
@@ -5,6 +8,7 @@ import {
   CarouselDots,
   CarouselItem,
 } from '~/primitives/shadcn-primitives/carousel';
+import Icon from '~/primitives/icon';
 import { ImageGalleryItem, PageBuilderSection } from '../../types';
 import { HTMLRenderer } from '~/primitives/html-renderer/html-renderer.component';
 
@@ -47,53 +51,80 @@ const ImageGalleryComponent = ({
 }: {
   data: ImageGalleryItem[] | undefined;
 }) => {
+  const [lightboxItem, setLightboxItem] = useState<ImageGalleryItem | null>(
+    null,
+  );
+
   if (!data?.length) {
     return null;
   }
 
   return (
-    <Carousel
-      opts={{
-        align: 'start',
-      }}
-    >
-      <CarouselContent className='gap-6'>
-        {data.map((item) => (
-          <CarouselItem
-            key={item.id}
-            className='basis-[68%] sm:basis-[45%] lg:basis-[calc((100%-3rem)/3)]'
-          >
-            <ImageGalleryCard item={item} />
-          </CarouselItem>
-        ))}
-      </CarouselContent>
+    <>
+      <Carousel
+        opts={{
+          align: 'start',
+        }}
+      >
+        <CarouselContent className='gap-6'>
+          {data.map((item) => (
+            <CarouselItem
+              key={item.id}
+              className='basis-[68%] sm:basis-[45%] lg:basis-[calc((100%-3rem)/3)]'
+            >
+              <ImageGalleryCard
+                item={item}
+                onOpen={() => setLightboxItem(item)}
+              />
+            </CarouselItem>
+          ))}
+        </CarouselContent>
 
-      <div className='mt-5 flex w-full items-center justify-between pr-5 md:mt-8 md:pr-0'>
-        <CarouselDots
-          className='justify-start'
-          activeClassName='bg-ocean'
-          inactiveClassName='bg-neutral-lighter'
-        />
-        <CarouselArrows />
-      </div>
-    </Carousel>
+        <div className='mt-5 flex w-full items-center justify-between pr-5 md:mt-8 md:pr-0'>
+          <CarouselDots
+            className='justify-start'
+            activeClassName='bg-ocean'
+            inactiveClassName='bg-neutral-lighter'
+          />
+          <CarouselArrows />
+        </div>
+      </Carousel>
+
+      <ImageGalleryLightbox
+        item={lightboxItem}
+        onOpenChange={(open) => {
+          if (!open) setLightboxItem(null);
+        }}
+      />
+    </>
   );
 };
 
-const ImageGalleryCard = ({ item }: { item: ImageGalleryItem }) => {
+const ImageGalleryCard = ({
+  item,
+  onOpen,
+}: {
+  item: ImageGalleryItem;
+  onOpen: () => void;
+}) => {
   const title = item.title?.trim();
   const summary = item.summary?.trim();
   const shouldShowOverlay = Boolean(title || summary);
 
   return (
-    <div className='relative aspect-square w-full overflow-hidden rounded-2xl md:aspect-auto md:h-[261px]'>
+    <button
+      type='button'
+      onClick={onOpen}
+      aria-label={title ? `View ${title}` : 'View gallery image'}
+      className='relative aspect-square w-full cursor-pointer overflow-hidden rounded-2xl md:aspect-auto md:h-[261px]'
+    >
       <img
         src={item.image}
         alt={title || 'Gallery image'}
         className='size-full object-cover'
       />
       {shouldShowOverlay && (
-        <div className='absolute inset-x-0 bottom-0 flex flex-col gap-1 overflow-hidden bg-black/65 px-4 py-3'>
+        <div className='absolute inset-x-0 bottom-0 flex flex-col gap-1 overflow-hidden bg-black/65 px-4 py-3 text-left'>
           {title && (
             <p className='text-sm font-semibold text-white md:text-base'>
               {title}
@@ -104,6 +135,53 @@ const ImageGalleryCard = ({ item }: { item: ImageGalleryItem }) => {
           )}
         </div>
       )}
-    </div>
+    </button>
+  );
+};
+
+const ImageGalleryLightbox = ({
+  item,
+  onOpenChange,
+}: {
+  item: ImageGalleryItem | null;
+  onOpenChange: (open: boolean) => void;
+}) => {
+  const title = item?.title?.trim();
+  const alt = title || 'Gallery image';
+
+  return (
+    <Dialog.Root open={Boolean(item)} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className='fixed inset-0 z-499 bg-black/70 data-[state=closed]:animate-dialogOverlayHide data-[state=open]:animate-dialogOverlayShow' />
+        <Dialog.Content
+          className='fixed top-1/2 left-1/2 z-500 max-h-[90vh] w-[min(92vw,1100px)] -translate-x-1/2 -translate-y-1/2 outline-none data-[state=closed]:animate-dialogContentHide data-[state=open]:animate-dialogContentShow'
+          aria-describedby={undefined}
+        >
+          <VisuallyHidden.Root>
+            <Dialog.Title>{alt}</Dialog.Title>
+            <Dialog.Description>
+              Enlarged gallery image. Press Escape or click outside to close.
+            </Dialog.Description>
+          </VisuallyHidden.Root>
+
+          <div className='relative'>
+            <Dialog.Close
+              className='absolute top-3 right-3 z-10 flex size-10 cursor-pointer items-center justify-center rounded-full bg-black/50 text-white transition-colors hover:bg-black/70'
+              aria-label='Close image'
+            >
+              <Icon name='x' color='white' size={24} />
+            </Dialog.Close>
+
+            {item && (
+              <img
+                src={item.image}
+                alt={alt}
+                className='max-h-[90vh] w-full rounded-lg object-contain'
+              />
+            )}
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
   );
 };

--- a/app/styles/tailwind.css
+++ b/app/styles/tailwind.css
@@ -35,6 +35,9 @@
     cubic-bezier(0.16, 1, 0.3, 1);
   --animate-dialogContentHide: dialogContentHide 150ms
     cubic-bezier(0.16, 1, 0.3, 1);
+  /* Image gallery lightbox — scale only (no translate); pairs with inset/m-auto centering */
+  --animate-lightboxShow: lightboxShow 200ms cubic-bezier(0.16, 1, 0.3, 1);
+  --animate-lightboxHide: lightboxHide 150ms cubic-bezier(0.16, 1, 0.3, 1);
 
   /* Accordion */
   --animate-accordion-down: accordion-down 0.3s ease-out;
@@ -234,6 +237,26 @@
   to {
     opacity: 0;
     transform: translate(-50%, -48%) scale(0.96);
+  }
+}
+@keyframes lightboxShow {
+  from {
+    opacity: 0;
+    transform: scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+@keyframes lightboxHide {
+  from {
+    opacity: 1;
+    transform: scale(1);
+  }
+  to {
+    opacity: 0;
+    transform: scale(0.98);
   }
 }
 @keyframes accordion-down {


### PR DESCRIPTION
## Summary

Adds a click-to-enlarge lightbox for Image Gallery cards so users can view the full image more clearly. Clicking a card opens a large centered image with a close control and a dimmed page overlay.

## Screenshots
<img width="1512" height="833" alt="Screenshot 2026-08-13 at 3 22 03 PM" src="https://github.com/user-attachments/assets/f01b21da-07fd-45a0-ba29-3cf55e349053" />


## Testing

- [ ] Open a page with an Image Gallery section (e.g. `/ministries/young-adults`)
- [ ] Click a gallery card — lightbox opens with the enlarged image
- [ ] Confirm the **X** appears in the top-right of the image and closes the lightbox
- [ ] Click the dimmed overlay outside the image — lightbox closes
- [ ] Press Escape — lightbox closes
- [ ] Confirm cards with title/summary overlays still open the lightbox correctly
- [ ] Ran `pnpm check` shows no warnings or errors.

## Tickets

[CFDP-4223](https://christfellowshipchurch.atlassian.net/browse/CFDP-4223)

## Changes Made

### New Components Added

- `ImageGalleryLightbox` in `app/routes/page-builder/components/image-gallery/index.tsx` — Radix Dialog-based image lightbox

### New Utilities

- None

### New Assets

- None

### Dependencies

- None (uses existing `@radix-ui/react-dialog`, `@radix-ui/react-visually-hidden`, and `Icon`)

### Route Implementation

- `app/routes/page-builder/components/image-gallery/index.tsx` — gallery cards are buttons that open the lightbox; lightbox renders enlarged image with overlay dismiss and close button

### Key Features

- Click any gallery card to open a large image lightbox
- Dimmed full-page overlay; click outside the image to close
- Close button (X) overlaid on the top-right of the image
- Escape key closes the lightbox
- Accessible dialog title/description via visually hidden Radix content

[CFDP-4223]: https://christfellowshipchurch.atlassian.net/browse/CFDP-4223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ