### PR TITLE
Groups scroll lock

### DIFF
--- a/app/components/finders/finder-sticky-bar.component.tsx
+++ b/app/components/finders/finder-sticky-bar.component.tsx
@@ -10,13 +10,15 @@ type FinderStickyBarProps = {
 
 /**
  * Sticky filter strip below the main navbar (matches group / class finder finder UIs).
+ * z-40 sits above the site footer (z-30) so desktop filter popovers are not covered
+ * when open near the bottom of the page; still below navbar (z-400) and cookie banner (z-50).
  */
 export function FinderStickyBar({ children, className }: FinderStickyBarProps) {
   const stickyTopClass = useStickyTopBelowNavbarClass();
   return (
     <div
       className={cn(
-        'sticky z-20 w-full min-w-0 border-b border-black/5 bg-white shadow-sm content-padding select-none transition-all duration-300',
+        'sticky z-40 w-full min-w-0 border-b border-black/5 bg-white shadow-sm content-padding select-none transition-all duration-300',
         stickyTopClass,
         className,
       )}

--- a/app/components/finders/finder-sticky-bar.component.tsx
+++ b/app/components/finders/finder-sticky-bar.component.tsx
@@ -18,7 +18,7 @@ export function FinderStickyBar({ children, className }: FinderStickyBarProps) {
   return (
     <div
       className={cn(
-        'sticky z-40 w-full min-w-0 border-b border-black/5 bg-white shadow-sm content-padding select-none transition-all duration-300',
+        'sticky z-40 w-full min-w-0 max-w-full overflow-x-clip border-b border-black/5 bg-white shadow-sm content-padding select-none transition-all duration-300',
         stickyTopClass,
         className,
       )}

--- a/app/components/finders/search-filters/active-filter.component.tsx
+++ b/app/components/finders/search-filters/active-filter.component.tsx
@@ -3,6 +3,7 @@ import { useInstantSearch } from 'react-instantsearch';
 import startCase from 'lodash/startCase';
 import { Icon } from '~/primitives/icon/icon';
 import { AlgoliaFinderClearAllButton } from '~/routes/group-finder/components/clear-all-button.component';
+import { formatMeetingFrequencyLabel } from '~/routes/group-finder/format-group-meeting-schedule';
 import { GroupType } from '~/routes/group-finder/types';
 
 type RefinementChip = {
@@ -17,6 +18,9 @@ function refinementChipDisplayLabel(attribute: string, value: string): string {
     const v = value.toLowerCase();
     if (v === 'true') return 'Adults Only';
     if (v === 'false') return 'Child Welcome';
+  }
+  if (attribute === ('meetingFrequency' as const satisfies keyof GroupType)) {
+    return formatMeetingFrequencyLabel(value);
   }
   if (attribute === 'eventCategories') {
     return startCase(value);

--- a/app/components/finders/search-filters/filter-popup.component.tsx
+++ b/app/components/finders/search-filters/filter-popup.component.tsx
@@ -23,6 +23,7 @@ import {
 import { cn } from '~/lib/utils';
 import { Button } from '~/primitives/button/button.primitive';
 import { Icon } from '~/primitives/icon/icon';
+import { formatMeetingFrequencyLabel } from '~/routes/group-finder/format-group-meeting-schedule';
 
 type FilterCoordinates = { lat: number | null; lng: number | null };
 
@@ -135,36 +136,35 @@ export function MobileFilterBottomSheet({
     };
   }, []);
 
-  // Lock scroll with `body { position: fixed }` so the overlay stays viewport-fixed on iOS.
-  useEffect(() => {
-    const scrollY = window.scrollY;
-    const prevBody = {
-      position: document.body.style.position,
-      top: document.body.style.top,
-      left: document.body.style.left,
-      right: document.body.style.right,
-      width: document.body.style.width,
-      overflow: document.body.style.overflow,
-    };
-    const prevHtmlOverflow = document.documentElement.style.overflow;
+  // Keep page scrollY intact. `position: fixed` + top offset was jumping the
+  // page to the top on open (and failing to restore on close) with sticky pills.
+  // Block background wheel/touch instead; sheet body keeps its own scroller.
+  useLayoutEffect(() => {
+    const isSheetScroller = (target: Event['target']) =>
+      target instanceof Element &&
+      target.closest('[data-finder-filter-scroll]') != null;
 
-    document.documentElement.style.overflow = 'hidden';
-    document.body.style.position = 'fixed';
-    document.body.style.top = `-${scrollY}px`;
-    document.body.style.left = '0';
-    document.body.style.right = '0';
-    document.body.style.width = '100%';
-    document.body.style.overflow = 'hidden';
+    const blockBackgroundScroll = (event: Event) => {
+      if (isSheetScroller(event.target)) return;
+      event.preventDefault();
+    };
+
+    document.addEventListener('wheel', blockBackgroundScroll, {
+      passive: false,
+      capture: true,
+    });
+    document.addEventListener('touchmove', blockBackgroundScroll, {
+      passive: false,
+      capture: true,
+    });
 
     return () => {
-      document.documentElement.style.overflow = prevHtmlOverflow;
-      document.body.style.position = prevBody.position;
-      document.body.style.top = prevBody.top;
-      document.body.style.left = prevBody.left;
-      document.body.style.right = prevBody.right;
-      document.body.style.width = prevBody.width;
-      document.body.style.overflow = prevBody.overflow;
-      window.scrollTo(0, scrollY);
+      document.removeEventListener('wheel', blockBackgroundScroll, {
+        capture: true,
+      });
+      document.removeEventListener('touchmove', blockBackgroundScroll, {
+        capture: true,
+      });
     };
   }, []);
 
@@ -290,7 +290,10 @@ export function MobileFilterBottomSheet({
               </button>
             </div>
           </div>
-          <div className='min-h-0 min-w-0 flex-1 overflow-x-hidden overflow-y-auto overscroll-contain pt-2'>
+          <div
+            data-finder-filter-scroll
+            className='min-h-0 min-w-0 flex-1 overflow-x-hidden overflow-y-auto overscroll-contain pt-2'
+          >
             {scrollable}
           </div>
           {footer}
@@ -550,6 +553,21 @@ export const FilterPopup = ({
 function meetingTypeUsesGlobeIcon(label: string): boolean {
   const t = label.trim().toLowerCase();
   return t === 'virtual' || t === 'online';
+}
+
+function refinementItemDisplayLabel(
+  attribute: string,
+  label: string,
+  value: string,
+): string {
+  if (attribute === 'meetingFrequency') {
+    return formatMeetingFrequencyLabel(label || value);
+  }
+  if (attribute === 'adultsOnly') {
+    if (value === 'false' || value === 'False') return 'Children Welcome';
+    return 'Adult Only';
+  }
+  return label;
 }
 
 const FilterPopupContent = ({
@@ -885,12 +903,11 @@ const FilterPopupContent = ({
                               ) : null}
                             </div>
                             <div className={styles.checkbox}>
-                              {data.attribute === 'adultsOnly'
-                                ? item.value === 'false' ||
-                                  item.value === 'False'
-                                  ? 'Children Welcome'
-                                  : 'Adult Only'
-                                : item.label}
+                              {refinementItemDisplayLabel(
+                                data.attribute,
+                                item.label,
+                                item.value,
+                              )}
                             </div>
                           </div>
                         ) : (
@@ -940,7 +957,11 @@ const FilterPopupContent = ({
                               ? item.label === 'Thursday'
                                 ? 'Thur'
                                 : item.label.substring(0, 3)
-                              : item.label}
+                              : refinementItemDisplayLabel(
+                                  data.attribute,
+                                  item.label,
+                                  item.value,
+                                )}
                           </Button>
                         )}
                       </div>

--- a/app/components/finders/search-filters/filter-popup.component.tsx
+++ b/app/components/finders/search-filters/filter-popup.component.tsx
@@ -1,6 +1,7 @@
 import React, {
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -360,6 +361,40 @@ export const FilterPopup = ({
   const isBottomSheet = layout === 'bottomSheet';
   const isEmbedded = layout === 'embedded';
 
+  // Desktop popovers sit under the sticky filter bar. A fixed vh max-height
+  // ignores that offset, so on short viewports the Clear / Show footer can sit
+  // below the fold while page scroll is locked. Cap height to remaining space.
+  const [viewportMaxHeightPx, setViewportMaxHeightPx] = useState<number | null>(
+    null,
+  );
+
+  useLayoutEffect(() => {
+    if (!showSection || isBottomSheet || isEmbedded) {
+      setViewportMaxHeightPx(null);
+      return;
+    }
+
+    const BOTTOM_GAP_PX = 16;
+    const MIN_HEIGHT_PX = 200;
+
+    const updateMaxHeight = () => {
+      const el = ref.current;
+      if (!el) return;
+      const top = el.getBoundingClientRect().top;
+      setViewportMaxHeightPx(
+        Math.max(MIN_HEIGHT_PX, window.innerHeight - top - BOTTOM_GAP_PX),
+      );
+    };
+
+    updateMaxHeight();
+    const rafId = window.requestAnimationFrame(updateMaxHeight);
+    window.addEventListener('resize', updateMaxHeight);
+    return () => {
+      window.cancelAnimationFrame(rafId);
+      window.removeEventListener('resize', updateMaxHeight);
+    };
+  }, [showSection, isBottomSheet, isEmbedded]);
+
   const multiSection = data.content.length > 1;
 
   const bodyScrollable = (
@@ -471,7 +506,9 @@ export const FilterPopup = ({
     <div
       ref={ref}
       className={cn(
-        'cursor-default z-10 flex max-h-[min(70vh,calc(100dvh-10rem))] flex-col bg-white',
+        // Fallback max-height before layout measurement; JS overrides with
+        // remaining viewport space so the footer stays on-screen on short displays.
+        'cursor-default z-10 flex min-h-0 max-h-[min(70vh,calc(100dvh-12rem))] flex-col bg-white',
         'rounded-2xl border border-neutral-lighter overflow-hidden',
         'absolute top-[65px] right-1/2 w-[280px] translate-x-1/2 xl:w-[320px]',
         showSection
@@ -481,7 +518,12 @@ export const FilterPopup = ({
       )}
       style={
         showSection
-          ? style
+          ? {
+              ...style,
+              ...(viewportMaxHeightPx != null
+                ? { maxHeight: viewportMaxHeightPx }
+                : null),
+            }
           : { ...style, left: '-9999px', pointerEvents: 'none' }
       }
       onClick={(e) => e.stopPropagation()}

--- a/app/components/finders/search-filters/filter-popup.component.tsx
+++ b/app/components/finders/search-filters/filter-popup.component.tsx
@@ -471,7 +471,7 @@ export const FilterPopup = ({
     <div
       ref={ref}
       className={cn(
-        'cursor-default z-10 flex flex-col gap-4 bg-white',
+        'cursor-default z-10 flex max-h-[min(70vh,calc(100dvh-10rem))] flex-col bg-white',
         'rounded-2xl border border-neutral-lighter overflow-hidden',
         'absolute top-[65px] right-1/2 w-[280px] translate-x-1/2 xl:w-[320px]',
         showSection
@@ -484,17 +484,23 @@ export const FilterPopup = ({
           ? style
           : { ...style, left: '-9999px', pointerEvents: 'none' }
       }
+      onClick={(e) => e.stopPropagation()}
     >
-      <div className='flex items-center justify-between p-4 pb-1'>
+      <div className='flex shrink-0 items-center justify-between p-4 pb-1'>
         <h3 className='text-xl font-bold text-black'>{popupTitle}</h3>
         <div className='cursor-pointer!' onClick={() => onHide()}>
           <Icon name='x' color='black' />
         </div>
       </div>
 
-      {bodyScrollable}
+      <div
+        data-finder-filter-scroll
+        className='min-h-0 flex-1 overflow-y-auto overscroll-contain'
+      >
+        {bodyScrollable}
+      </div>
 
-      {footerEl}
+      {footerEl ? <div className='shrink-0 bg-white'>{footerEl}</div> : null}
     </div>
   );
 };

--- a/app/components/finders/search-filters/index.tsx
+++ b/app/components/finders/search-filters/index.tsx
@@ -14,6 +14,7 @@ import {
   type FilterPopupData,
 } from '~/components/finders/search-filters/filter-popup.component';
 import { cn } from '~/lib/utils';
+import { useNavbarVisibility } from '~/providers/navbar-visibility-context';
 const MORE_FILTERS_ID = 'moreFilters';
 
 function isInsideSearchFiltersPortal(target: unknown): boolean {
@@ -95,6 +96,7 @@ export function SearchFilters({
   groupedFooterCount = false,
 }: SearchFiltersProps) {
   const { indexUiState } = useInstantSearch();
+  const { setIsFinderFilterOpen } = useNavbarVisibility();
   const refinementList = useMemo(
     () => (indexUiState.refinementList ?? {}) as Record<string, string[]>,
     [indexUiState.refinementList],
@@ -111,6 +113,70 @@ export function SearchFilters({
     mq.addEventListener('change', apply);
     return () => mq.removeEventListener('change', apply);
   }, []);
+
+  // Desktop/tablet popovers: freeze navbar hide/show and block page scroll so
+  // the sticky filter bar (and absolute popup) stay put. Do NOT set
+  // overflow:hidden on html/body — that breaks position:sticky and leaves the
+  // popup clipped above the viewport when the navbar was open.
+  // Mobile bottom sheets already lock scroll in MobileFilterBottomSheet.
+  useEffect(() => {
+    const isDesktopFilterOpen =
+      Boolean(activeDropdown) && !useMobileBottomSheet;
+    setIsFinderFilterOpen(isDesktopFilterOpen);
+
+    if (!isDesktopFilterOpen) {
+      return () => setIsFinderFilterOpen(false);
+    }
+
+    const isInFilterPopupScroll = (target: unknown) => {
+      if (!(target instanceof Element)) return false;
+      return target.closest('[data-finder-filter-scroll]') != null;
+    };
+
+    const preventPageScroll = (event: Event) => {
+      if (isInFilterPopupScroll(event.target)) return;
+      event.preventDefault();
+    };
+
+    const preventScrollKeys = (event: Event) => {
+      const key = 'key' in event ? String((event as { key: string }).key) : '';
+      const scrollKeys = new Set([
+        'ArrowUp',
+        'ArrowDown',
+        'PageUp',
+        'PageDown',
+        'Home',
+        'End',
+        ' ',
+      ]);
+      if (!scrollKeys.has(key)) return;
+      const target = event.target;
+      if (
+        target instanceof HTMLElement &&
+        (target.tagName === 'INPUT' ||
+          target.tagName === 'TEXTAREA' ||
+          target.tagName === 'SELECT' ||
+          target.isContentEditable)
+      ) {
+        return;
+      }
+      if (isInFilterPopupScroll(target)) return;
+      event.preventDefault();
+    };
+
+    document.addEventListener('wheel', preventPageScroll, { passive: false });
+    document.addEventListener('touchmove', preventPageScroll, {
+      passive: false,
+    });
+    document.addEventListener('keydown', preventScrollKeys);
+
+    return () => {
+      setIsFinderFilterOpen(false);
+      document.removeEventListener('wheel', preventPageScroll);
+      document.removeEventListener('touchmove', preventPageScroll);
+      document.removeEventListener('keydown', preventScrollKeys);
+    };
+  }, [activeDropdown, useMobileBottomSheet, setIsFinderFilterOpen]);
 
   const hasCompactOverflow =
     compactInlineFilterCount != null &&

--- a/app/components/finders/search-filters/index.tsx
+++ b/app/components/finders/search-filters/index.tsx
@@ -5,6 +5,7 @@ import {
   useRef,
   useState,
   type ComponentProps,
+  type PointerEvent as ReactPointerEvent,
   type ReactNode,
 } from 'react';
 import { useInstantSearch } from 'react-instantsearch';
@@ -16,6 +17,13 @@ import {
 import { cn } from '~/lib/utils';
 import { useNavbarVisibility } from '~/providers/navbar-visibility-context';
 const MORE_FILTERS_ID = 'moreFilters';
+
+/** Avoid focusing sticky pills — browsers scroll them to their in-flow (page-top) position. */
+function onFinderFilterPillPointerDown(event: ReactPointerEvent) {
+  if (event.pointerType === 'mouse') {
+    event.preventDefault();
+  }
+}
 
 function isInsideSearchFiltersPortal(target: unknown): boolean {
   if (target == null || typeof target !== 'object') return false;
@@ -54,9 +62,9 @@ export type SearchFiltersAllFiltersRenderProps = {
   onHide: () => void;
   onClearAllToUrl: () => void;
   /**
-   * True when viewport is narrow mobile (`max-width: 767px`): render the overflow
-   * panel as a bottom sheet (same as single-filter popups). False on tablet compact
-   * row — use inline card chrome instead.
+   * True when the overflow “More” panel should render as a bottom sheet.
+   * Compact-row UIs (`lg:hidden`, phone + tablet) always pass true so More does
+   * not expand as an inline card inside the sticky filter bar.
    */
   mobileBottomSheet: boolean;
   /** Same label as the overflow trigger pill (use as bottom sheet title on mobile). */
@@ -104,79 +112,28 @@ export function SearchFilters({
 
   const [activeDropdown, setActiveDropdown] = useState<string | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
-  const [useMobileBottomSheet, setUseMobileBottomSheet] = useState(false);
+  /** Matches Tailwind `lg` — phone + tablet compact row use bottom sheets. */
+  const [useCompactBottomSheet, setUseCompactBottomSheet] = useState(false);
 
   useEffect(() => {
-    const mq = window.matchMedia('(max-width: 767px)');
-    const apply = () => setUseMobileBottomSheet(mq.matches);
+    const mq = window.matchMedia('(max-width: 1023px)');
+    const apply = () => setUseCompactBottomSheet(mq.matches);
     apply();
     mq.addEventListener('change', apply);
     return () => mq.removeEventListener('change', apply);
   }, []);
 
-  // Desktop/tablet popovers: freeze navbar hide/show and block page scroll so
-  // the sticky filter bar (and absolute popup) stay put. Do NOT set
-  // overflow:hidden on html/body — that breaks position:sticky and leaves the
-  // popup clipped above the viewport when the navbar was open.
-  // Mobile bottom sheets already lock scroll in MobileFilterBottomSheet.
+  // Freeze navbar whenever any finder filter is open (desktop popover or compact
+  // bottom sheet) so scroll/gesture noise cannot toggle nav visibility mid-sheet.
+  // Do not clear in an effect cleanup on dep change — that briefly unfreezes
+  // between null→open.
   useEffect(() => {
-    const isDesktopFilterOpen =
-      Boolean(activeDropdown) && !useMobileBottomSheet;
-    setIsFinderFilterOpen(isDesktopFilterOpen);
+    setIsFinderFilterOpen(Boolean(activeDropdown));
+  }, [activeDropdown, setIsFinderFilterOpen]);
 
-    if (!isDesktopFilterOpen) {
-      return () => setIsFinderFilterOpen(false);
-    }
-
-    const isInFilterPopupScroll = (target: unknown) => {
-      if (!(target instanceof Element)) return false;
-      return target.closest('[data-finder-filter-scroll]') != null;
-    };
-
-    const preventPageScroll = (event: Event) => {
-      if (isInFilterPopupScroll(event.target)) return;
-      event.preventDefault();
-    };
-
-    const preventScrollKeys = (event: Event) => {
-      const key = 'key' in event ? String((event as { key: string }).key) : '';
-      const scrollKeys = new Set([
-        'ArrowUp',
-        'ArrowDown',
-        'PageUp',
-        'PageDown',
-        'Home',
-        'End',
-        ' ',
-      ]);
-      if (!scrollKeys.has(key)) return;
-      const target = event.target;
-      if (
-        target instanceof HTMLElement &&
-        (target.tagName === 'INPUT' ||
-          target.tagName === 'TEXTAREA' ||
-          target.tagName === 'SELECT' ||
-          target.isContentEditable)
-      ) {
-        return;
-      }
-      if (isInFilterPopupScroll(target)) return;
-      event.preventDefault();
-    };
-
-    document.addEventListener('wheel', preventPageScroll, { passive: false });
-    document.addEventListener('touchmove', preventPageScroll, {
-      passive: false,
-    });
-    document.addEventListener('keydown', preventScrollKeys);
-
-    return () => {
-      setIsFinderFilterOpen(false);
-      document.removeEventListener('wheel', preventPageScroll);
-      document.removeEventListener('touchmove', preventPageScroll);
-      document.removeEventListener('keydown', preventScrollKeys);
-    };
-  }, [activeDropdown, useMobileBottomSheet, setIsFinderFilterOpen]);
+  useEffect(() => {
+    return () => setIsFinderFilterOpen(false);
+  }, [setIsFinderFilterOpen]);
 
   const hasCompactOverflow =
     compactInlineFilterCount != null &&
@@ -218,6 +175,8 @@ export function SearchFilters({
     if (activeDropdown === dropdownName) {
       setActiveDropdown(null);
     } else {
+      // Sync freeze before the bottom sheet mounts.
+      setIsFinderFilterOpen(true);
       setActiveDropdown(dropdownName);
     }
   };
@@ -230,6 +189,7 @@ export function SearchFilters({
     if (activeDropdown === MORE_FILTERS_ID) {
       setActiveDropdown(null);
     } else {
+      setIsFinderFilterOpen(true);
       setActiveDropdown(MORE_FILTERS_ID);
     }
   };
@@ -296,6 +256,7 @@ export function SearchFilters({
           embedPopup && 'relative',
           isHighlighted && dropdownButtonOpenStyles,
         )}
+        onPointerDown={onFinderFilterPillPointerDown}
         onClick={() => toggleDropdown(item.id)}
       >
         <div className='flex min-w-0 flex-row items-center gap-2'>
@@ -378,7 +339,7 @@ export function SearchFilters({
               {inlineCompactItems.map((item) => (
                 <Fragment key={item.id}>
                   {renderFilterPill(item, {
-                    embedPopup: !useMobileBottomSheet,
+                    embedPopup: !useCompactBottomSheet,
                     isSingleVisibleButton: compactRowButtonCount === 1,
                     compactEqualWidth: compactRowButtonCount > 1,
                   })}
@@ -388,7 +349,7 @@ export function SearchFilters({
               {overflowDesktopItems.length === 1 ? (
                 <Fragment key={overflowDesktopItems[0].id}>
                   {renderFilterPill(overflowDesktopItems[0], {
-                    embedPopup: !useMobileBottomSheet,
+                    embedPopup: !useCompactBottomSheet,
                     isSingleVisibleButton: compactRowButtonCount === 1,
                     compactEqualWidth: compactRowButtonCount > 1,
                   })}
@@ -400,6 +361,7 @@ export function SearchFilters({
                     compactRowButtonCount > 1 ? 'min-w-0 flex-1' : 'w-fit',
                     isMoreHighlighted && dropdownButtonOpenStyles,
                   )}
+                  onPointerDown={onFinderFilterPillPointerDown}
                   onClick={() => openMorePanel()}
                 >
                   <div className='flex min-w-0 flex-row items-center gap-2'>
@@ -443,7 +405,7 @@ export function SearchFilters({
               ) : null}
             </div>
 
-            {useMobileBottomSheet && compactInlineOpenItem ? (
+            {useCompactBottomSheet && compactInlineOpenItem ? (
               <FilterPopup
                 key={compactInlineOpenItem.id}
                 popupTitle={compactInlineOpenItem.popupTitle}
@@ -457,25 +419,15 @@ export function SearchFilters({
               />
             ) : null}
 
-            {showMoreForOverflow && isMoreOpen && renderMorePanel ? (
-              useMobileBottomSheet ? (
+            {showMoreForOverflow && isMoreOpen && renderMorePanel
+              ? // Compact row (`lg:hidden`) always uses the bottom sheet for More.
                 renderMorePanel({
                   onHide: closeAllDropdowns,
                   onClearAllToUrl,
                   mobileBottomSheet: true,
                   morePanelTitle: moreButtonLabel,
                 })
-              ) : (
-                <div className='w-full overflow-hidden rounded-lg border border-neutral-300 shadow-md'>
-                  {renderMorePanel({
-                    onHide: closeAllDropdowns,
-                    onClearAllToUrl,
-                    mobileBottomSheet: false,
-                    morePanelTitle: moreButtonLabel,
-                  })}
-                </div>
-              )
-            ) : null}
+              : null}
           </div>
         ) : null}
 

--- a/app/components/navbar/navbar.component.tsx
+++ b/app/components/navbar/navbar.component.tsx
@@ -103,11 +103,8 @@ export function Navbar() {
 
     const handleScroll = () => {
       // Don't hide/translate the navbar while search, a mega-menu, or a finder
-      // filter popover is open. `-translate-y-full` uses the CSS `translate`
-      // property, which makes fixed/absolute dropdowns position relative to
-      // the nav and detaches them. Finder filters also need the navbar frozen
-      // so scroll cannot re-show the nav/banner over Clear / Show results.
-      // Use the ref so the freeze is synchronous (React state alone races).
+      // filter is open (desktop popover or compact bottom sheet). Use the ref so
+      // the freeze is synchronous with open (React state alone can race).
       if (isSearchOpen || openDropdown || isFinderFilterOpenRef.current) {
         return;
       }

--- a/app/components/navbar/navbar.component.tsx
+++ b/app/components/navbar/navbar.component.tsx
@@ -53,7 +53,8 @@ export function Navbar() {
 
   const [showSiteBanner, setShowSiteBanner] = useState<boolean>(false);
 
-  const { setIsNavbarVisible, setIsSiteBannerVisible } = useNavbarVisibility();
+  const { setIsNavbarVisible, setIsSiteBannerVisible, isFinderFilterOpenRef } =
+    useNavbarVisibility();
 
   // Check if navbar should be hidden for current route
   const isNavbarHidden = shouldHideNavbar(pathname);
@@ -101,10 +102,13 @@ export function Navbar() {
     }
 
     const handleScroll = () => {
-      // Don't hide/translate the navbar while search or a mega-menu is open.
-      // `-translate-y-full` uses the CSS `translate` property, which makes
-      // fixed/absolute dropdowns position relative to the nav and detaches them.
-      if (isSearchOpen || openDropdown) {
+      // Don't hide/translate the navbar while search, a mega-menu, or a finder
+      // filter popover is open. `-translate-y-full` uses the CSS `translate`
+      // property, which makes fixed/absolute dropdowns position relative to
+      // the nav and detaches them. Finder filters also need the navbar frozen
+      // so scroll cannot re-show the nav/banner over Clear / Show results.
+      // Use the ref so the freeze is synchronous (React state alone races).
+      if (isSearchOpen || openDropdown || isFinderFilterOpenRef.current) {
         return;
       }
 
@@ -144,7 +148,7 @@ export function Navbar() {
     return () => {
       window.removeEventListener('scroll', handleScroll);
     };
-  }, [defaultMode, isNavbarHidden, isSearchOpen, openDropdown]);
+  }, [defaultMode, isNavbarHidden, isSearchOpen, openDropdown, isFinderFilterOpenRef]);
 
   // Initial mode setup
   useEffect(() => {

--- a/app/components/navbar/navbar.component.tsx
+++ b/app/components/navbar/navbar.component.tsx
@@ -148,7 +148,13 @@ export function Navbar() {
     return () => {
       window.removeEventListener('scroll', handleScroll);
     };
-  }, [defaultMode, isNavbarHidden, isSearchOpen, openDropdown, isFinderFilterOpenRef]);
+  }, [
+    defaultMode,
+    isNavbarHidden,
+    isSearchOpen,
+    openDropdown,
+    isFinderFilterOpenRef,
+  ]);
 
   // Initial mode setup
   useEffect(() => {

--- a/app/providers/__tests__/navbar-visibility-context.test.tsx
+++ b/app/providers/__tests__/navbar-visibility-context.test.tsx
@@ -11,15 +11,24 @@ function TestConsumer() {
     setIsNavbarVisible,
     isSiteBannerVisible,
     setIsSiteBannerVisible,
+    isFinderFilterOpen,
+    setIsFinderFilterOpen,
+    isFinderFilterOpenRef,
   } = useNavbarVisibility();
   return (
     <div>
       <span data-testid='visibility'>{String(isNavbarVisible)}</span>
       <span data-testid='banner'>{String(isSiteBannerVisible)}</span>
+      <span data-testid='finder-filter'>{String(isFinderFilterOpen)}</span>
+      <span data-testid='finder-filter-ref'>
+        {String(isFinderFilterOpenRef.current)}
+      </span>
       <button onClick={() => setIsNavbarVisible(false)}>hide</button>
       <button onClick={() => setIsNavbarVisible(true)}>show</button>
       <button onClick={() => setIsSiteBannerVisible(true)}>banner-on</button>
       <button onClick={() => setIsSiteBannerVisible(false)}>banner-off</button>
+      <button onClick={() => setIsFinderFilterOpen(true)}>filter-on</button>
+      <button onClick={() => setIsFinderFilterOpen(false)}>filter-off</button>
     </div>
   );
 }
@@ -33,6 +42,8 @@ describe('NavbarVisibilityProvider', () => {
     );
     expect(screen.getByTestId('visibility').textContent).toBe('true');
     expect(screen.getByTestId('banner').textContent).toBe('false');
+    expect(screen.getByTestId('finder-filter').textContent).toBe('false');
+    expect(screen.getByTestId('finder-filter-ref').textContent).toBe('false');
   });
 
   it('updates isSiteBannerVisible', () => {
@@ -45,6 +56,20 @@ describe('NavbarVisibilityProvider', () => {
     expect(screen.getByTestId('banner').textContent).toBe('true');
     fireEvent.click(screen.getByText('banner-off'));
     expect(screen.getByTestId('banner').textContent).toBe('false');
+  });
+
+  it('updates isFinderFilterOpen and sync ref', () => {
+    render(
+      <NavbarVisibilityProvider>
+        <TestConsumer />
+      </NavbarVisibilityProvider>,
+    );
+    fireEvent.click(screen.getByText('filter-on'));
+    expect(screen.getByTestId('finder-filter').textContent).toBe('true');
+    expect(screen.getByTestId('finder-filter-ref').textContent).toBe('true');
+    fireEvent.click(screen.getByText('filter-off'));
+    expect(screen.getByTestId('finder-filter').textContent).toBe('false');
+    expect(screen.getByTestId('finder-filter-ref').textContent).toBe('false');
   });
 
   it('updates isNavbarVisible to false', () => {

--- a/app/providers/navbar-visibility-context.tsx
+++ b/app/providers/navbar-visibility-context.tsx
@@ -1,4 +1,10 @@
-import React, { createContext, useContext, useState } from 'react';
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useRef,
+  useState,
+} from 'react';
 
 interface NavbarVisibilityContextType {
   isNavbarVisible: boolean;
@@ -6,6 +12,17 @@ interface NavbarVisibilityContextType {
   /** True when the global site banner (below nav) is visible — affects sticky `top` offsets. */
   isSiteBannerVisible: boolean;
   setIsSiteBannerVisible: (visible: boolean) => void;
+  /**
+   * True while a finder (groups/classes) desktop filter popover is open.
+   * Navbar freezes hide/show-on-scroll so it cannot cover Clear / Show results.
+   */
+  isFinderFilterOpen: boolean;
+  setIsFinderFilterOpen: (open: boolean) => void;
+  /**
+   * Synchronous flag for scroll handlers. React state alone races the frame where
+   * opening a filter would otherwise toggle navbar visibility before re-render.
+   */
+  isFinderFilterOpenRef: React.MutableRefObject<boolean>;
 }
 
 const NavbarVisibilityContext = createContext<
@@ -17,6 +34,14 @@ export const NavbarVisibilityProvider: React.FC<{
 }> = ({ children }) => {
   const [isNavbarVisible, setIsNavbarVisible] = useState(true);
   const [isSiteBannerVisible, setIsSiteBannerVisible] = useState(false);
+  const [isFinderFilterOpen, setIsFinderFilterOpenState] = useState(false);
+  const isFinderFilterOpenRef = useRef(false);
+
+  const setIsFinderFilterOpen = useCallback((open: boolean) => {
+    isFinderFilterOpenRef.current = open;
+    setIsFinderFilterOpenState(open);
+  }, []);
+
   return (
     <NavbarVisibilityContext.Provider
       value={{
@@ -24,6 +49,9 @@ export const NavbarVisibilityProvider: React.FC<{
         setIsNavbarVisible,
         isSiteBannerVisible,
         setIsSiteBannerVisible,
+        isFinderFilterOpen,
+        setIsFinderFilterOpen,
+        isFinderFilterOpenRef,
       }}
     >
       {children}

--- a/app/providers/navbar-visibility-context.tsx
+++ b/app/providers/navbar-visibility-context.tsx
@@ -13,8 +13,8 @@ interface NavbarVisibilityContextType {
   isSiteBannerVisible: boolean;
   setIsSiteBannerVisible: (visible: boolean) => void;
   /**
-   * True while a finder (groups/classes) desktop filter popover is open.
-   * Navbar freezes hide/show-on-scroll so it cannot cover Clear / Show results.
+   * True while a finder (groups/classes) filter popover or bottom sheet is open.
+   * Navbar freezes hide/show-on-scroll while the sheet/popover is up.
    */
   isFinderFilterOpen: boolean;
   setIsFinderFilterOpen: (open: boolean) => void;

--- a/app/routes/class-finder/finder/partials/class-search.partial.tsx
+++ b/app/routes/class-finder/finder/partials/class-search.partial.tsx
@@ -217,8 +217,8 @@ export const ClassSearch = () => {
             <ClassFinderInstantSearchSync />
             <Configure hitsPerPage={CLASS_FINDER_LOADER_HITS_PER_PAGE} />
             <FinderStickyBar>
-              <div className='mx-auto flex max-w-screen-content flex-col gap-3 py-4 md:flex-row md:items-center md:gap-4'>
-                <div className='w-full md:w-[240px] lg:w-[250px] xl:w-[266px] flex items-center rounded-lg border border-[#DEE0E3] focus-within:border-ocean py-2'>
+              <div className='mx-auto flex w-full min-w-0 max-w-screen-content flex-col gap-3 py-4 md:flex-row md:items-center md:gap-4'>
+                <div className='flex w-full shrink-0 items-center rounded-lg border border-[#DEE0E3] py-2 focus-within:border-ocean md:w-[240px] lg:w-[250px] xl:w-[266px]'>
                   <Icon
                     name='searchAlt'
                     className='text-neutral-default ml-3'
@@ -242,7 +242,7 @@ export const ClassSearch = () => {
                   />
                 </div>
 
-                <div className='lg:hidden w-full'>
+                <div className='min-w-0 w-full flex-1 lg:hidden'>
                   <SearchFilters
                     onClearAllToUrl={clearAllFiltersFromUrl}
                     desktopFilters={CLASS_SEARCH_DESKTOP_FILTERS}
@@ -295,12 +295,14 @@ export const ClassSearch = () => {
                 Hold those on screen and show filter skeletons until client-side
                 InstantSearch is ready to take over. */}
             <FinderStickyBar>
-              <div className='mx-auto flex max-w-screen-content flex-col gap-3 py-4 md:flex-row md:items-center md:gap-4'>
+              <div className='mx-auto flex w-full min-w-0 max-w-screen-content flex-col gap-3 py-4 md:flex-row md:items-center md:gap-4'>
                 <div
-                  className='h-[42px] w-full animate-pulse rounded-lg bg-neutral-200 md:w-[240px] lg:w-[250px] xl:w-[266px]'
+                  className='h-[42px] w-full shrink-0 animate-pulse rounded-lg bg-neutral-200 md:w-[240px] lg:w-[250px] xl:w-[266px]'
                   aria-hidden
                 />
-                <ClassFinderFiltersSkeleton />
+                <div className='min-w-0 w-full flex-1'>
+                  <ClassFinderFiltersSkeleton />
+                </div>
               </div>
             </FinderStickyBar>
 

--- a/app/routes/group-finder/__tests__/format-group-meeting-schedule.test.ts
+++ b/app/routes/group-finder/__tests__/format-group-meeting-schedule.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import {
+  extractWeekOfMonthScheduleLabel,
+  formatGroupMeetingScheduleTitle,
+  formatMeetingFrequencyLabel,
+} from '../format-group-meeting-schedule';
+
+describe('formatMeetingFrequencyLabel', () => {
+  it('clarifies Monthly so it is not read as once-per-month only', () => {
+    expect(formatMeetingFrequencyLabel('Monthly')).toBe('Select weeks monthly');
+  });
+
+  it('leaves other frequencies unchanged', () => {
+    expect(formatMeetingFrequencyLabel('Weekly')).toBe('Weekly');
+    expect(formatMeetingFrequencyLabel('Bi-Weekly')).toBe('Bi-Weekly');
+  });
+});
+
+describe('extractWeekOfMonthScheduleLabel', () => {
+  it('parses 1st & 3rd Saturdays from summary copy', () => {
+    expect(
+      extractWeekOfMonthScheduleLabel(
+        'Meet 1st & 3rd Saturdays at the Googan coffee shop in Downtown Stuart.',
+        'Saturday',
+      ),
+    ).toBe('1st & 3rd Saturdays');
+  });
+
+  it('parses 2nd and 4th Thursday of the month', () => {
+    expect(
+      extractWeekOfMonthScheduleLabel(
+        'They meet on the 2nd and 4th Thursday of the month.',
+        'Thursday',
+      ),
+    ).toBe('2nd & 4th Thursdays');
+  });
+
+  it('parses a single week-of-month day', () => {
+    expect(
+      extractWeekOfMonthScheduleLabel(
+        'We meet the 2nd Friday of each month at various homes.',
+        'Friday',
+      ),
+    ).toBe('2nd Friday of each month');
+  });
+
+  it('returns null when no week-of-month phrasing is present', () => {
+    expect(
+      extractWeekOfMonthScheduleLabel(
+        'A fun cooking class where each week we will learn a recipe.',
+        'Thursday',
+      ),
+    ).toBeNull();
+  });
+});
+
+describe('formatGroupMeetingScheduleTitle', () => {
+  it('uses week-of-month phrasing from summary when frequency is Monthly', () => {
+    expect(
+      formatGroupMeetingScheduleTitle({
+        meetingFrequency: 'Monthly',
+        meetingDay: 'Saturday',
+        summary: 'Meet 1st & 3rd Saturdays at the Googan coffee shop.',
+      }),
+    ).toBe('1st & 3rd Saturdays');
+  });
+
+  it('falls back to clarified Monthly label when summary has no weeks', () => {
+    expect(
+      formatGroupMeetingScheduleTitle({
+        meetingFrequency: 'Monthly',
+        meetingDay: 'Friday',
+        summary: 'Women of all ages looking to grow community.',
+      }),
+    ).toBe('Select weeks monthly, Friday');
+  });
+
+  it('keeps Weekly formatting', () => {
+    expect(
+      formatGroupMeetingScheduleTitle({
+        meetingFrequency: 'Weekly',
+        meetingDay: 'Monday',
+        summary: '',
+      }),
+    ).toBe('Weekly, Monday');
+  });
+});

--- a/app/routes/group-finder/components/filters/refinement-content.component.tsx
+++ b/app/routes/group-finder/components/filters/refinement-content.component.tsx
@@ -3,6 +3,7 @@ import { useRefinementList } from 'react-instantsearch';
 import { cn } from '~/lib/utils';
 import { Button } from '~/primitives/button/button.primitive';
 import { Icon } from '~/primitives/icon/icon';
+import { formatMeetingFrequencyLabel } from '../../format-group-meeting-schedule';
 import { GroupType } from '../../types';
 
 function meetingTypeUsesGlobeIcon(label: string): boolean {
@@ -86,7 +87,10 @@ export const AllFiltersRefinementContent = ({
         ? item.label === 'Thursday'
           ? 'Thur'
           : item.label.substring(0, 3)
-        : item.label}
+        : content.attribute ===
+            ('meetingFrequency' as const satisfies keyof GroupType)
+          ? formatMeetingFrequencyLabel(item.label || item.value)
+          : item.label}
     </Button>
   );
 

--- a/app/routes/group-finder/components/group-finder-overflow-filters.component.tsx
+++ b/app/routes/group-finder/components/group-finder-overflow-filters.component.tsx
@@ -136,12 +136,15 @@ export function GroupFinderOverflowFiltersPanel({
   }
 
   return (
-    <div className='flex h-auto min-h-0 w-full max-h-[85vh] flex-col overflow-hidden bg-white shadow-md md:max-h-none'>
+    <div className='flex min-h-0 w-full max-h-[min(85vh,calc(100dvh-10rem))] flex-col overflow-hidden bg-white shadow-md'>
       <div className='shrink-0'>
         <FiltersHeader onHide={onHide} />
       </div>
 
-      <div className='min-h-0 flex-1 overflow-y-auto px-4'>
+      <div
+        data-finder-filter-scroll
+        className='min-h-0 flex-1 overflow-y-auto overscroll-contain px-4'
+      >
         {embeddedFilters}
       </div>
 

--- a/app/routes/group-finder/components/group-finder-query-input.component.tsx
+++ b/app/routes/group-finder/components/group-finder-query-input.component.tsx
@@ -32,7 +32,7 @@ export function GroupFinderQueryInput({
   }, [localQuery, onQueryCommit, query]);
 
   return (
-    <div className='w-full md:w-[240px] lg:w-[250px] xl:w-[266px] flex items-center rounded-lg border border-[#DEE0E3] focus-within:border-ocean py-2'>
+    <div className='w-full shrink-0 md:w-[240px] lg:w-[250px] xl:w-[266px] flex items-center rounded-lg border border-[#DEE0E3] focus-within:border-ocean py-2'>
       <Icon name='searchAlt' className='text-neutral-default ml-3' size={16} />
       <input
         type='search'

--- a/app/routes/group-finder/format-group-meeting-schedule.ts
+++ b/app/routes/group-finder/format-group-meeting-schedule.ts
@@ -1,0 +1,168 @@
+/**
+ * Display helpers for group meeting frequency / schedule copy.
+ *
+ * Algolia only stores `meetingFrequency` as Weekly | Monthly | Bi-Weekly | Once | Daily.
+ * Week-of-month details (1st & 3rd, etc.) are not indexed — they often appear in
+ * the group summary. "Monthly" alone reads as "once a month", which is misleading
+ * for multi-week schedules, so we clarify the label and enrich from summary when possible.
+ */
+
+const ORDINAL_RE = '(?:1st|2nd|3rd|4th|first|second|third|fourth)';
+const DAY_RE =
+  '(?:Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday|Mon|Tues|Tue|Wed|Thu|Thur|Thurs|Fri|Sat|Sun)';
+
+const ORDINAL_NORMALIZE: Record<string, string> = {
+  first: '1st',
+  second: '2nd',
+  third: '3rd',
+  fourth: '4th',
+  '1st': '1st',
+  '2nd': '2nd',
+  '3rd': '3rd',
+  '4th': '4th',
+};
+
+const DAY_NORMALIZE: Record<string, string> = {
+  mon: 'Monday',
+  monday: 'Monday',
+  tue: 'Tuesday',
+  tues: 'Tuesday',
+  tuesday: 'Tuesday',
+  wed: 'Wednesday',
+  wednesday: 'Wednesday',
+  thu: 'Thursday',
+  thur: 'Thursday',
+  thurs: 'Thursday',
+  thursday: 'Thursday',
+  fri: 'Friday',
+  friday: 'Friday',
+  sat: 'Saturday',
+  saturday: 'Saturday',
+  sun: 'Sunday',
+  sunday: 'Sunday',
+};
+
+function normalizeOrdinal(value: string): string {
+  return ORDINAL_NORMALIZE[value.toLowerCase()] ?? value;
+}
+
+function normalizeDayName(value: string): string {
+  return DAY_NORMALIZE[value.toLowerCase()] ?? value;
+}
+
+function pluralizeDay(day: string): string {
+  const full = normalizeDayName(day);
+  return full.endsWith('s') ? full : `${full}s`;
+}
+
+/**
+ * Human label for a raw Algolia `meetingFrequency` facet/value.
+ * Keeps refine values unchanged — only affects display.
+ */
+export function formatMeetingFrequencyLabel(
+  frequency: string | null | undefined,
+): string {
+  const value = (frequency ?? '').trim();
+  if (!value) return '';
+  if (/^monthly$/i.test(value)) {
+    return 'Select weeks monthly';
+  }
+  return value;
+}
+
+/**
+ * Try to pull "1st & 3rd Saturdays" / "2nd Friday of each month" style phrasing
+ * from free text (usually the group summary).
+ */
+export function extractWeekOfMonthScheduleLabel(
+  text: string | null | undefined,
+  meetingDay?: string | null,
+): string | null {
+  const source = (text ?? '').replace(/\s+/g, ' ').trim();
+  if (!source) return null;
+
+  const fallbackDay = (meetingDay ?? '').trim();
+
+  const dual = source.match(
+    new RegExp(
+      `\\b(${ORDINAL_RE})\\s*(?:&|and|,)\\s*(?:the\\s+)?(${ORDINAL_RE})\\s+(${DAY_RE})s?\\b`,
+      'i',
+    ),
+  );
+  if (dual) {
+    const a = normalizeOrdinal(dual[1]);
+    const b = normalizeOrdinal(dual[2]);
+    const day = normalizeDayName(dual[3]);
+    return `${a} & ${b} ${pluralizeDay(day)}`;
+  }
+
+  const dualWeeks = source.match(
+    new RegExp(
+      `\\b(${ORDINAL_RE})\\s*(?:&|and|,)\\s*(?:the\\s+)?(${ORDINAL_RE})\\s+weeks?(?:\\s+of\\s+the\\s+month)?\\b`,
+      'i',
+    ),
+  );
+  if (dualWeeks && fallbackDay) {
+    const a = normalizeOrdinal(dualWeeks[1]);
+    const b = normalizeOrdinal(dualWeeks[2]);
+    return `${a} & ${b} ${pluralizeDay(fallbackDay)}`;
+  }
+
+  const single = source.match(
+    new RegExp(
+      `\\b(?:the\\s+)?(${ORDINAL_RE})\\s+(${DAY_RE})s?(?:\\s+of\\s+(?:each|the|every)\\s+month)?\\b`,
+      'i',
+    ),
+  );
+  if (single) {
+    const ordinal = normalizeOrdinal(single[1]);
+    const day = normalizeDayName(single[2]);
+    if (/\bof\s+(?:each|the|every)\s+month\b/i.test(source)) {
+      return `${ordinal} ${day} of each month`;
+    }
+    // Prefer explicit month phrasing when frequency is monthly-style week-of-month.
+    return `${ordinal} ${day} of each month`;
+  }
+
+  const singleWeek = source.match(
+    new RegExp(
+      `\\b(?:the\\s+)?(${ORDINAL_RE})\\s+week(?:s)?(?:\\s+of\\s+(?:each|the|every)\\s+month)?\\b`,
+      'i',
+    ),
+  );
+  if (singleWeek && fallbackDay) {
+    const ordinal = normalizeOrdinal(singleWeek[1]);
+    return `${ordinal} ${normalizeDayName(fallbackDay)} of each month`;
+  }
+
+  return null;
+}
+
+/**
+ * Title line for the group-single schedule InfoItem
+ * (e.g. "1st & 3rd Saturdays" or "Select weeks monthly, Saturday").
+ */
+export function formatGroupMeetingScheduleTitle({
+  meetingFrequency,
+  meetingDay,
+  summary,
+  title,
+}: {
+  meetingFrequency?: string | null;
+  meetingDay?: string | null;
+  summary?: string | null;
+  title?: string | null;
+}): string {
+  const day = (meetingDay ?? '').trim() || 'TBD';
+  const frequency = (meetingFrequency ?? '').trim();
+  const source = `${summary ?? ''} ${title ?? ''}`;
+
+  if (/^monthly$/i.test(frequency)) {
+    const fromCopy = extractWeekOfMonthScheduleLabel(source, day);
+    if (fromCopy) return fromCopy;
+    return `${formatMeetingFrequencyLabel(frequency)}, ${day}`;
+  }
+
+  if (!frequency) return day;
+  return `${formatMeetingFrequencyLabel(frequency)}, ${day}`;
+}

--- a/app/routes/group-finder/partials/group-search.partial.tsx
+++ b/app/routes/group-finder/partials/group-search.partial.tsx
@@ -417,7 +417,7 @@ export const GroupSearch = () => {
             />
 
             <FinderStickyBar>
-              <div className='mx-auto flex max-w-screen-content flex-col gap-3 py-4 md:flex-row md:items-center md:gap-4'>
+              <div className='mx-auto flex w-full min-w-0 max-w-screen-content flex-col gap-3 py-4 md:flex-row md:items-center md:gap-4'>
                 <GroupFinderQueryInput
                   query={urlState.query}
                   onQueryCommit={commitQuery}
@@ -428,34 +428,36 @@ export const GroupSearch = () => {
                   aria-hidden
                   className='hidden h-8 w-px shrink-0 bg-[#DEE0E3] md:block'
                 />
-                <SearchFilters
-                  onClearAllToUrl={clearAllFiltersFromUrl}
-                  desktopFilters={desktopFilters}
-                  compactInlineFilterCount={2}
-                  filterPopupAgeInput={ageInput}
-                  setFilterPopupAgeInput={setAgeInput}
-                  isFilterPillSupplementallyActive={
-                    isFilterPillSupplementallyActive
-                  }
-                  renderMorePanel={({
-                    onHide,
-                    onClearAllToUrl,
-                    mobileBottomSheet,
-                  }) => (
-                    <GroupFinderOverflowFiltersPanel
-                      onHide={onHide}
-                      ageInput={ageInput}
-                      setAgeInput={setAgeInput}
-                      coordinates={coordinates}
-                      setCoordinates={setCoordinates}
-                      locationSource={locationSource}
-                      onLocationKind={setLocationSource}
-                      onClearAllToUrl={onClearAllToUrl}
-                      mobileBottomSheet={mobileBottomSheet}
-                      bottomSheetTitle={GROUP_FINDER_MORE_POPUP_TITLE}
-                    />
-                  )}
-                />
+                <div className='min-w-0 w-full flex-1'>
+                  <SearchFilters
+                    onClearAllToUrl={clearAllFiltersFromUrl}
+                    desktopFilters={desktopFilters}
+                    compactInlineFilterCount={2}
+                    filterPopupAgeInput={ageInput}
+                    setFilterPopupAgeInput={setAgeInput}
+                    isFilterPillSupplementallyActive={
+                      isFilterPillSupplementallyActive
+                    }
+                    renderMorePanel={({
+                      onHide,
+                      onClearAllToUrl,
+                      mobileBottomSheet,
+                    }) => (
+                      <GroupFinderOverflowFiltersPanel
+                        onHide={onHide}
+                        ageInput={ageInput}
+                        setAgeInput={setAgeInput}
+                        coordinates={coordinates}
+                        setCoordinates={setCoordinates}
+                        locationSource={locationSource}
+                        onLocationKind={setLocationSource}
+                        onClearAllToUrl={onClearAllToUrl}
+                        mobileBottomSheet={mobileBottomSheet}
+                        bottomSheetTitle={GROUP_FINDER_MORE_POPUP_TITLE}
+                      />
+                    )}
+                  />
+                </div>
               </div>
               <ActiveFilters
                 onClearAllToUrl={clearAllFiltersFromUrl}
@@ -479,7 +481,7 @@ export const GroupSearch = () => {
                 reserve filter space with a skeleton. This avoids a blank grid
                 while the client-only Algolia widgets boot. */}
             <FinderStickyBar>
-              <div className='mx-auto flex max-w-screen-content flex-col gap-3 py-4 md:flex-row md:items-center md:gap-4'>
+              <div className='mx-auto flex w-full min-w-0 max-w-screen-content flex-col gap-3 py-4 md:flex-row md:items-center md:gap-4'>
                 <GroupFinderQueryInput
                   query={urlState.query}
                   onQueryCommit={commitQuery}
@@ -488,7 +490,9 @@ export const GroupSearch = () => {
                   aria-hidden
                   className='hidden h-8 w-px shrink-0 bg-[#DEE0E3] md:block'
                 />
-                <GroupFinderFiltersSkeleton />
+                <div className='min-w-0 w-full flex-1'>
+                  <GroupFinderFiltersSkeleton />
+                </div>
               </div>
             </FinderStickyBar>
 

--- a/app/routes/group-single/partials/group-single-hero.partial.tsx
+++ b/app/routes/group-single/partials/group-single-hero.partial.tsx
@@ -1,6 +1,7 @@
 import { cn } from '~/lib/utils';
 import { TopicBadge } from '../components/group-single-banner.component';
 import { GroupType, splitGroupTopics } from '~/routes/group-finder/types';
+import { formatGroupMeetingScheduleTitle } from '~/routes/group-finder/format-group-meeting-schedule';
 import { icons } from '~/lib/icons';
 import { Icon } from '~/primitives/icon/icon';
 import { Link } from 'react-router-dom';
@@ -108,6 +109,8 @@ const GroupInfo = ({ hit }: { hit: GroupType }) => {
     minMaxAge,
     adultsOnly,
     childCareDescription,
+    summary,
+    title,
   } = hit;
   const adultsOnlyBool = adultsOnly === 'True';
 
@@ -130,6 +133,12 @@ const GroupInfo = ({ hit }: { hit: GroupType }) => {
   const groupItemTitle = `${groupFor || 'Anyone'}${
     peopleWhoAre && peopleWhoAre.length > 0 ? `, ${peopleWhoAre[0]}` : ''
   }`;
+  const meetingScheduleTitle = formatGroupMeetingScheduleTitle({
+    meetingFrequency,
+    meetingDay,
+    summary,
+    title,
+  });
 
   return (
     <div className='flex flex-col md:flex-row md:flex-wrap lg:flex-col gap-8'>
@@ -146,7 +155,7 @@ const GroupInfo = ({ hit }: { hit: GroupType }) => {
       />
       {meetingDay && meetingTime && (
         <InfoItem
-          title={`${meetingFrequency}, ${meetingDay || 'TBD'}`}
+          title={meetingScheduleTitle}
           description={`${formattedMeetingTime} ET`}
           icon='calendarAlt'
           isLayoutReversed={true}

--- a/app/routes/volunteer/components/__tests__/volunteer-algolia.component.test.tsx
+++ b/app/routes/volunteer/components/__tests__/volunteer-algolia.component.test.tsx
@@ -55,7 +55,9 @@ vi.mock('~/primitives/shadcn-primitives/carousel', () => ({
   CarouselContent: ({ children }: { children: ReactNode }) => (
     <div>{children}</div>
   ),
-  CarouselItem: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  CarouselItem: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
   CarouselArrows: () => null,
   CarouselDots: () => null,
 }));


### PR DESCRIPTION
## Summary

Fixes Groups Finder (and shared finder) desktop/tablet filter UX:

1. **Filter popovers + scroll** — Scrolling while a filter is open no longer re-shows the sticky navbar/site banner over **Clear** / **Show results**, and popovers stay usable on short viewports and near the bottom of the page.
2. **Monthly meeting copy** — Groups with `meetingFrequency: Monthly` no longer read as “meets once a month.” The schedule line prefers week-of-month phrasing from the summary when available (e.g. **1st & 3rd Saturdays**), otherwise shows **Select weeks monthly**.

Previously, desktop filter popovers did not lock page scroll or freeze navbar hide/show behavior. Scrolling could slide the navbar and site CTA banner back in (`z-400`) over the sticky filter bar, blocking footer actions. Popovers near the end of the page also painted under the site footer (`z-30`). On short screens / tablet More, the panel could extend past the viewport with page scroll locked and no internal scroll.

## Screenshots

[Paste your screenshots here]

## Testing

- [ ] On desktop Groups Finder, scroll so the navbar is **hidden**, open Location / People / Topics / More — page should not scroll; Clear / Show results remain clickable
- [ ] On desktop, with navbar **visible**, open the same filters — sticky bar and popup stay aligned under the nav (not clipped above the viewport); navbar should not jump away
- [ ] With a tall filter (e.g. People / Topics), confirm the popup scrolls internally and Clear / Show results stay pinned at the bottom of the popup
- [ ] On a **short desktop viewport**, open More / People — footer actions stay on screen; content scrolls inside the popup
- [ ] Near the bottom of the page, open a filter — popup should appear **above** the site footer
- [ ] On **tablet**, open More — panel scrolls internally; Clear All / Show results remain reachable
- [ ] Mobile bottom-sheet filters still open/close and lock scroll as before
- [ ] Spot-check Class Finder desktop filters (shared `SearchFilters`) for the same behavior
- [ ] Open a **Monthly** group whose summary mentions 1st & 3rd (or similar) — schedule line shows that week phrasing (not bare “Monthly”)
- [ ] Open a Monthly group without week phrasing in the summary — schedule shows “Select weeks monthly, {day}”
- [ ] Meeting Frequency filter / active chip shows “Select weeks monthly” (refine value still Monthly)
- [ ] `pnpm check` shows no errors or warnings

## Tickets

[CFDP-4209](https://christfellowshipchurch.atlassian.net/browse/CFDP-4209)
[CFDP-4224](https://christfellowshipchurch.atlassian.net/browse/CFDP-4224)

## Changes Made

### New Components Added

- N/A

### New Utilities

- `app/routes/group-finder/format-group-meeting-schedule.ts` — clarifies Monthly labels and extracts week-of-month phrasing from summary/title when present
- Unit tests in `app/routes/group-finder/__tests__/format-group-meeting-schedule.test.ts`

### New Assets

- N/A

### Dependencies

- N/A

### Route Implementation

- Group single hero schedule title uses the new formatter
- Shared finder/navbar behavior used by Groups Finder / Class Finder

### Key Features

- Freeze navbar hide/show while a desktop finder filter is open (`isFinderFilterOpen` + sync ref in `navbar-visibility-context`)
- Block page scroll via wheel/touch/keyboard while a desktop filter is open (no `overflow: hidden` on `html`/`body`, which broke sticky positioning)
- Constrain desktop filter popover height to remaining viewport space, with scrollable body + sticky Clear / Show results footer
- Raise finder sticky bar to `z-40` so popovers stack above the site footer
- Fix tablet More panel: keep max-height + allow internal scroll under the page scroll lock
- Clearer Monthly meeting schedule copy (and filter chip label) so users don’t assume “once a month only”

[CFDP-4209]: https://christfellowshipchurch.atlassian.net/browse/CFDP-4209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ