### PR TITLE
Lead a group -> Host a group

### DIFF
--- a/app/routes/group-finder/group-finder.tsx
+++ b/app/routes/group-finder/group-finder.tsx
@@ -3,7 +3,7 @@ import { Button } from '~/primitives/button/button.primitive';
 import { GroupSearch } from './partials/group-search.partial';
 import { FinderHero } from '../../components/finders/hero';
 
-const leadGroupUrl = '/volunteer/church/cdae1da5-cd92-4d77-bb19-55cdb6ebad27';
+const leadGroupUrl = 'https://rock.gocf.org/page/5984';
 
 export function GroupFinderPage() {
   return (
@@ -34,7 +34,7 @@ export function GroupFinderPage() {
               },
               {
                 href: leadGroupUrl,
-                title: 'Lead a group',
+                title: 'Host a group',
                 intent: 'primary',
                 className:
                   'text-base font-normal hover:bg-white! hover:text-ocean!',
@@ -64,7 +64,7 @@ export function GroupFinderPage() {
               },
               {
                 href: leadGroupUrl,
-                title: 'Lead a group',
+                title: 'Host a group',
                 intent: 'primary',
                 className:
                   'text-base font-normal hover:bg-white! hover:text-ocean!',


### PR DESCRIPTION
## Summary
We need to change the Lead a Group button on the Group Finder page to go to https://rock.gocf.org/page/5984, and to say "Host" instead of a "Lead"
